### PR TITLE
Webworker

### DIFF
--- a/src/ciphers/openpgp.crypto.worker.js
+++ b/src/ciphers/openpgp.crypto.worker.js
@@ -47,7 +47,7 @@ var CRYPTOWORKER = (function (symEncrypt, symDecrypt) {
 			args.data &&
 			args.openpgp_cfb) {
 			// start encryption
-			output = symEncrypt(prefixrandom, 9, key, data, 0);
+			output = symEncrypt(args.prefixrandom, args.algo, args.key, args.data, args.openpgp_cfb);
 			
 		} else if (args.type === 'decrypt' &&
 			args.algo &&
@@ -55,7 +55,7 @@ var CRYPTOWORKER = (function (symEncrypt, symDecrypt) {
 			args.data &&
 			args.openpgp_cfb) {
 			// start decryption
-			output = symDecrypt(9, key, ciphertext, 0);
+			output = symDecrypt(args.algo, args.key, args.data, args.openpgp_cfb);
 			
 		} else {
 			throw 'Not all arguments for web worker crypto are defined!';


### PR DESCRIPTION
Hey,

I have modularized the symmetric encryption logic by moving it into the file src/ciphers/openpgp.crypto.sym.js and removed the reference the 'window' object from sha.js. With these minor changes, it is now possible to do symmetric encryption and sha operations in a web worker thread.

The openpgp.js unit tests pass and I have tested the newly created minified version in safewith.me. But as usual a second set of eyes on the patch wouldn't hurt.

The external apis remain the same and I have not added the Web Worker code itself into the library, since that Api is not yet supported on every browsers and I figured this code should be contained in the application logic, not a crypto library. If we do want it in the library, we may want to discuss (on the mailing list?) how the new api should look like. Theoretically, it should be possible to add the function with the same signature externally, but just with an optional asynchronous callback.

Tankred
