### PR TITLE
In Base64 encoding, if result ends in \n, remove it. (Fixes #79, #105)

### DIFF
--- a/src/encoding/base64.js
+++ b/src/encoding/base64.js
@@ -54,7 +54,8 @@ function s2r(t) {
 			r += "\n";
 		r += '=';
 	}
-
+  	if (r.charAt(r.length-1)==="\n")
+    		r=r.slice(0,-1);
 	return r;
 }
 


### PR DESCRIPTION
When the last line of the output of the Base64 "s2r" function has exactly 60 characters, a line break is mistakenly added to the end. This causes issue #79. #105 solves this issue on the decoding side, but the problem is actually here on the encoding side. Now, if the output ends in a line break, we remove it before returning.
