### PR TITLE
Add auto release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.8"
+- '0.10'
+- '0.8'
+branches:
+  except:
+  - LatestDev
 before_install:
-  - npm install -g grunt-cli
+- npm install -g grunt-cli
+after_success:
+- travis/success.sh

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha-phantomjs": "~3.1.6",
     "phantomjs": "~1.9.2-5",
     "chai": "~1.8.1",
+    "github2": "git://github.com/open-sw/node-github2.git",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-browserify": "~1.2.11",
     "grunt-contrib-uglify": "*",

--- a/travis/make-release.js
+++ b/travis/make-release.js
@@ -1,0 +1,166 @@
+var fs = require('fs');
+
+var Client = require('github2');
+
+var repoPath = process.env['TRAVIS_REPO_SLUG'].split('/');
+var commitSHA = process.env["TRAVIS_COMMIT"];
+
+var user = repoPath[0];
+var repo = repoPath[1];
+var token = process.env['GITHUB_TOKEN'];
+
+var pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+
+var release = {
+  "user": user,
+  "repo": repo,
+  "tag_name": "LatestDev",
+  "name": "v" + pkg.version + " (Unstable)",
+  "body": "The latest tested version of the master branch.\n\nTravis-CI build #" + process.env['TRAVIS_BUILD_NUMBER'] + ".",
+  "prerelease": true
+};
+
+var client = new Client(
+  {
+    version: "3.0.0"
+  }
+);
+
+client.authenticate(
+  {
+    "type": "oauth",
+    "token": token
+  }
+);
+
+client.gitdata.updateReference(
+  {
+    "user": release.user,
+    "repo": release.repo,
+    "ref": "tags/" + release.tag_name,
+    "sha": commitSHA
+  },
+  function (err, res) {
+    if (err) {
+      client.gitdata.createReference(
+        {
+          "user": release.user,
+          "repo": release.repo,
+          "ref": "refs/tags/" + release.tag_name,
+          "sha": commitSHA
+        },
+        function (err, res) {
+          if (!err) {
+            createRelease();
+          } else {
+            console.log("repos.createReference:\n", err);
+          }
+        }
+      );
+    } else {
+      createRelease();
+    }
+  }
+);
+
+function createRelease() {
+  client.repos.getAllReleases(
+    {
+      "user": release.user,
+      "repo": release.repo
+    },
+    function (err, res) {
+      if (!err) {
+        var processed = false;
+        res.forEach(function (item) {
+          if (item.tag_name == "LatestDev") {
+            if (!processed) {
+              processed = true;
+              release.id = item.id;
+              client.repos.editRelease(
+                release,
+                function (err, res) {
+                  if (!err) {
+                    var assetCount = item.assets.length;
+                    if (assetCount > 0) {
+                      item.assets.forEach(function (asset) {
+                        client.repos.deleteReleaseAsset(
+                          {
+                            "user": release.user,
+                            "repo": release.repo,
+                            "id": asset.id
+                          },
+                          function (err, res) {
+                            if (--assetCount <= 0) {
+                              uploadAssets();
+                            }
+                          }
+                        );
+                      });
+                    } else {
+                      uploadAssets();
+                    }
+                  } else {
+                    console.log("repos.editRelease:\n", err);
+                  }
+                }
+              );
+            } else {
+              client.repos.deleteRelease(
+                {
+                  "user": release.user,
+                  "repo": release.repo,
+                  "id": item.id
+                },
+                function (err, res) {
+                  if (err) {
+                    console.log("repos.deleteRelease:\n", err);
+                  }
+                }
+              );
+            }
+          }
+        });
+        if (!processed) {
+          client.repos.createRelease(
+            release,
+            function (err, res) {
+              if (!err) {
+                release.id = res.id;
+                uploadAssets();
+              } else {
+                console.log("repos.createRelease:\n", err);
+              }
+            }
+          );
+        }
+      } else {
+        console.log("repos.getAllReleases:\n", err);
+      }
+    }
+  );
+}
+
+function uploadAssets() {
+  [
+    [ "openpgp.min.js", "text/javascript" ],
+    [ pkg.name + "-" + pkg.version + ".tgz", "application/x-tar"],
+    [ "docs.zip", "application/zip" ]
+  ].forEach(function (asset) {
+    client.repos.uploadReleaseAsset(
+      {
+        "user": release.user,
+        "repo": release.repo,
+        "id": release.id,
+        "name": asset[0],
+        "content": fs.readFileSync("dist/" + asset[0]),
+        "content_type": asset[1]
+      },
+      function (err, res) {
+        if (err) {
+          console.log("repos.uploadReleaseAsset:\n", err);
+        }
+      }
+    );
+  });
+}

--- a/travis/success.sh
+++ b/travis/success.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ "${TRAVIS_NODE_VERSION}" == "0.10" -a "${TRAVIS_BRANCH}" == "master" -a "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    grunt jsdoc
+    zip -r dist/docs.zip doc
+    git clone --branch gh-pages https://github.com/${TRAVIS_REPO_SLUG}.git travis/github
+    cd travis/github
+    export GIT_ASKPASS=/bin/true
+    git config user.name "Travis Build"
+    git config user.email "nobody@travis-ci.org"
+    git config credential.https://github.com.username ${GITHUB_TOKEN}
+    rm -rf doc
+    cp -r ../../doc .
+    git add --all doc
+    git commit -m "Travis CI Docs build ${TRAVIS_BUILD_NUMBER}"
+    git push
+    cd ../..
+    rm -rf travis/github
+    node travis/make-release.js
+fi


### PR DESCRIPTION
This is a set of scripts that will automatically create a dev release whenever something is checked into master if the travis tests succeed.  It is tagged with the lightweight tag "LatestDev".  Any existing releases for that tag will be replaced.

NOTE:  It uses the version in package.json to name the release so the "master" branch should always have the "-dev" suffix.  When creating a new release, remove the suffix after creating the branch and do it in the new branch.

It includes openpgp.min.js, openpgp-x.x.x.tgz and docs.zip in the release.

It also will update the docs into the gh-pages branch.  This can be used so that the generated docs don't have to be part of the checked in source.

To enable it you need to:
1. Create a github token using the web page
2. Install the travis cli "gem install travis"
3. Add the encrypted token to .travis.yml "travis encrypt GITHUB_TOKEN=<token from step1> --add"
4. Update travis/success.sh to release docs to a different location if desired.
