### PR TITLE
Verify subkey revocation signatures according to: RFC4880 Errata ID: 3298

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -640,7 +640,7 @@ SubKey.prototype.verify = function(primaryKey) {
   // check subkey revocation signature
   if (this.revocationSignature && !this.revocationSignature.isExpired() && 
      (this.revocationSignature.verified || 
-      this.revocationSignature.verify(primaryKey, {key: this.subKey}))) {
+      this.revocationSignature.verify(primaryKey, {key:primaryKey, bind: this.subKey}))) {
     return enums.keyStatus.revoked;
   }
   // check V3 expiration time

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -551,6 +551,7 @@ Signature.prototype.toSign = function (type, data) {
       break;
 
     case t.subkey_binding:
+    case t.subkey_revocation:
     case t.key_binding:
       return this.toSign(t.key, data) + this.toSign(t.key, {
         key: data.bind
@@ -563,7 +564,6 @@ Signature.prototype.toSign = function (type, data) {
       return data.key.writeOld();
 
     case t.key_revocation:
-    case t.subkey_revocation:
       return this.toSign(t.key, data);
     case t.timestamp:
       return '';

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -278,7 +278,7 @@ describe('Key', function() {
     done();
   });
 
-  it.skip('Verify status of revoked subkey', function(done) {
+  it('Verify status of revoked subkey', function(done) {
     var pubKeys = openpgp.key.readArmored(pub_sig_test);
     expect(pubKeys).to.exist;
     expect(pubKeys.err).to.not.exist;

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -545,10 +545,10 @@ describe("Signature", function() {
     done();
   });
 
-  it.skip('Verify subkey revocation signature', function(done) {
+  it('Verify subkey revocation signature', function(done) {
     var pubKey = openpgp.key.readArmored(pub_revoked).keys[0];
 
-    var verified = pubKey.subKeys[0].revocationSignature.verify(pubKey.primaryKey, {key: pubKey.subKeys[0].subKey});
+    var verified = pubKey.subKeys[0].revocationSignature.verify(pubKey.primaryKey, {key: pubKey.primaryKey, bind: pubKey.subKeys[0].subKey});
 
     expect(verified).to.be.true;
     done();


### PR DESCRIPTION
http://www.rfc-editor.org/errata_search.php?rfc=4880&eid=3298
This is now compliant to GPG (and other implementations).
See: http://lists.gnupg.org/pipermail/gnupg-devel/2014-February/028267.html
Activated skipped unit tests
