### PR TITLE
getKeyForAddress Test

### DIFF
--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -7,7 +7,7 @@ var keyring = new openpgp.Keyring(),
   expect = chai.expect;
 
 describe("Keyring", function() {
-  var user = 'test@t-online.de',
+  var user = 'whiteout.test@t-online.de',
     passphrase = 'asdf',
     keySize = 512,
     keyId = 'F6F60E9B42CDFF4C',


### PR DESCRIPTION
Currently the tests for getPublicKeyForAddress() and getPrivateKeyForAddress() receive and accept an empty array. It looks to me like the test keys were generated with 'whiteout.test@t-online.de' as the email as opposed to 'test@t-online.de'. Changing the address fixes the result when searching for public keys, but searching for private keys seems to remain broken.

Apologies if I'm missing something basic, it's 5am local time ><
