### PR TITLE
Fixing typo as reported in issue #172

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -329,7 +329,7 @@ function armor(messagetype, body, partindex, parttotal) {
       result += "\r\n=" + getCheckSum(body) + "\r\n";
       result += "-----END PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\r\n";
       break;
-    case enums.armor.mutlipart_last:
+    case enums.armor.multipart_last:
       result += "-----BEGIN PGP MESSAGE, PART " + partindex + "-----\r\n";
       result += addheader();
       result += base64.encode(body);


### PR DESCRIPTION
I found the typo in multiple files, but all of them appeared to be built from this single source.
