### PR TITLE
Possibility to set filename of literal data packet (tag 11)

### DIFF
--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -38,6 +38,7 @@ function Literal() {
   this.format = 'utf8'; // default format for literal data packets
   this.data = ''; // literal data representation as native JavaScript string or bytes
   this.date = new Date();
+  this.filename = 'msg.txt';
 }
 
 /**
@@ -85,6 +86,24 @@ Literal.prototype.getBytes = function () {
 
 
 /**
+ * Sets the filename of the literal packet data
+ * @param {String} filename Any native javascript string
+ */
+Literal.prototype.setFilename = function (filename) {
+  this.filename = filename;
+};
+
+
+/**
+ * Get the filename of the literal packet data
+ * @returns {String} filename 
+ */
+Literal.prototype.getFilename = function() {
+  return this.filename;
+};
+
+
+/**
  * Parsing function for a literal data packet (tag 11).
  *
  * @param {String} input Payload of a tag 11 packet
@@ -117,7 +136,7 @@ Literal.prototype.read = function (bytes) {
  * @return {String} string-representation of the packet
  */
 Literal.prototype.write = function () {
-  var filename = util.encode_utf8("msg.txt");
+  var filename = util.encode_utf8(this.filename);
 
   var data = this.getBytes();
 


### PR DESCRIPTION
The filename of the literal data packet was hardcoded to msg.txt. Now one has the possibility to manually set the filename of the literal data packet. This is relevant if you encrypt binary data. On decryption it is possible to restore the original filename.
