### PR TITLE
Fix packet partial body length

### DIFF
--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -235,7 +235,7 @@ module.exports = {
             break;
           }
         }
-        real_packet_length = mypos2;
+        real_packet_length = mypos2 - mypos;
         // 4.2.2.3. Five-Octet Lengths
       } else {
         mypos++;


### PR DESCRIPTION
I can confirm https://github.com/openpgpjs/openpgpjs/issues/123

Only have a private message to test with. The message contains a compressed packets with a signature packet that was not readable and failed at:

```
// some sanity checks
    if (input === null || input.length <= position || input.substring(position).length < 2 || (input.charCodeAt(position) &
      0x80) === 0) {
      throw new Error("Error during parsing. This message / key is probably not containing a valid OpenPGP format.");
    }
```
