### PR TITLE
Generate openpgp.js without source map. New source map target is openpgp...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,18 +4,18 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     browserify: {
-      openpgp_nodebug: {
+      openpgp: {
         files: {
-          'dist/openpgp_nodebug.js': [ './src/index.js' ]
+          'dist/openpgp.js': [ './src/index.js' ]
         },
         options: {
           standalone: 'openpgp',
           external: [ 'crypto', 'node-localstorage' ]
         }
       },
-      openpgp: {
+      openpgp_debug: {
         files: {
-          'dist/openpgp.js': [ './src/index.js' ]
+          'dist/openpgp_debug.js': [ './src/index.js' ]
         },
         options: {
           debug: true,
@@ -28,14 +28,17 @@ module.exports = function(grunt) {
           'dist/openpgp.worker.js': [ './src/worker/worker.js' ]
         }
       },
+      worker_min: {
+        files: {
+          'dist/openpgp.worker.min.js': [ './src/worker/worker.js' ]
+        }
+      },
       unittests: {
         files: {
-          'test/lib/unittests-bundle.js': []
+          'test/lib/unittests-bundle.js': [ './test/unittests.js' ]
         },
         options: {
-          debug: true,
-          alias: './test/unittests.js:unittests',
-          external: [ 'openpgp' ]
+          external: [ 'openpgp', 'crypto', 'node-localstorage' ]
         }
       }
     },
@@ -48,19 +51,28 @@ module.exports = function(grunt) {
           to: 'OpenPGP.js v<%= pkg.version %>'
         }]
       },
-      openpgp_nodebug: {
-        src: ['dist/openpgp_nodebug.js'],
-        dest: ['dist/openpgp_nodebug.js'],
+      openpgp_debug: {
+        src: ['dist/openpgp_debug.js'],
+        dest: ['dist/openpgp_debug.js'],
         replacements: [{
           from: /OpenPGP.js VERSION/g,
           to: 'OpenPGP.js v<%= pkg.version %>'
+        }]
+      },
+      worker_min: {
+        src: ['dist/openpgp.worker.min.js'],
+        dest: ['dist/openpgp.worker.min.js'],
+        replacements: [{
+          from: "importScripts('openpgp.js')",
+          to: "importScripts('openpgp.min.js')"
         }]
       }
     },
     uglify: {
       openpgp: {
         files: {
-          'dist/openpgp.min.js' : [ 'dist/openpgp_nodebug.js' ]
+          'dist/openpgp.min.js' : [ 'dist/openpgp.js' ],
+          'dist/openpgp.worker.min.js' : [ 'dist/openpgp.worker.min.js' ]
         }
       },
       options: {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -17,7 +17,7 @@
 
 window = {}; // to make UMD bundles work
 
-importScripts('openpgp.min.js');
+importScripts('openpgp.js');
 
 var MIN_SIZE_RANDOM_BUFFER = 40000;
 var MAX_SIZE_RANDOM_BUFFER = 60000;

--- a/test/crypto/cipher/aes.js
+++ b/test/crypto/cipher/aes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   chai = require('chai'),

--- a/test/crypto/cipher/blowfish.js
+++ b/test/crypto/cipher/blowfish.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   BFencrypt = openpgp.crypto.cipher.blowfish,

--- a/test/crypto/cipher/cast5.js
+++ b/test/crypto/cipher/cast5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   chai = require('chai'),

--- a/test/crypto/cipher/des.js
+++ b/test/crypto/cipher/des.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   chai = require('chai'),

--- a/test/crypto/cipher/twofish.js
+++ b/test/crypto/cipher/twofish.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   chai = require('chai'),

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
 	expect = chai.expect;

--- a/test/crypto/hash/md5.js
+++ b/test/crypto/hash/md5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   MD5 = openpgp.crypto.hash.md5,

--- a/test/crypto/hash/ripemd.js
+++ b/test/crypto/hash/ripemd.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   RMDstring = openpgp.crypto.hash.ripemd,

--- a/test/crypto/hash/sha.js
+++ b/test/crypto/hash/sha.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var util = openpgp.util,
   hash = openpgp.crypto.hash,

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
   expect = chai.expect;

--- a/test/general/basic.js
+++ b/test/general/basic.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
   expect = chai.expect;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
 	expect = chai.expect;

--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var keyring = new openpgp.Keyring(),
   chai = require('chai'),

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
   expect = chai.expect;

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
 	expect = chai.expect;

--- a/test/unittests.html
+++ b/test/unittests.html
@@ -18,7 +18,6 @@
     </script>
     <script src="lib/unittests-bundle.js"></script>
     <script>
-        require('unittests');
         if (window.mochaPhantomJS) {
           mochaPhantomJS.run();
         } else {

--- a/test/worker/api.js
+++ b/test/worker/api.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('../../src/index');
+var openpgp = typeof window != 'undefined' && window.openpgp ? window.openpgp : require('openpgp');
 
 var chai = require('chai'),
   expect = chai.expect;


### PR DESCRIPTION
..._debug.js. Change dependency of workers: openpgp.worker.js -> openpgp.js, openpgp.worker.min.js -> openpgp.min.js. Remove openpgp.js with maps from unittests-bundle.js
