### PR TITLE
Minimize signature verifications to evaluate primary user

### DIFF
--- a/test/general/key.js
+++ b/test/general/key.js
@@ -546,5 +546,13 @@ describe('Key', function() {
     expect(key.users[1].userAttribute).eql(key2.users[1].userAttribute);
   });
 
+  it('getPrimaryUser()', function() {
+    var key = openpgp.key.readArmored(pub_sig_test).keys[0];
+    var primUser = key.getPrimaryUser();
+    expect(primUser).to.exist;
+    expect(primUser.user.userId.userid).to.equal('Signature Test <signature@test.com>');
+    expect(primUser.selfCertificate).to.be.an.instanceof(openpgp.packet.Signature);
+  });
+
 });
 


### PR DESCRIPTION
Signature verification is relatively time-consuming. The current getPrimaryUser method checks all self certificates of all users to get the primary user. With this PR signature verifications are minimized to only one verification per key in the ideal case.
