### PR TITLE
Allow private keys for verify methods in Cleartext and Message class.

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -82,22 +82,22 @@ CleartextMessage.prototype.sign = function(privateKeys) {
 
 /**
  * Verify signatures of cleartext signed message
- * @param {Array<module:key~Key>} publicKeys public keys to verify signatures
+ * @param {Array<module:key~Key>} keys array of keys to verify signatures
  * @return {Array<{keyid: module:type/keyid, valid: Boolean}>} list of signer's keyid and validity of signature
  */
-CleartextMessage.prototype.verify = function(publicKeys) {
+CleartextMessage.prototype.verify = function(keys) {
   var result = [];
   var signatureList = this.packets.filterByTag(enums.packet.signature);
   var literalDataPacket = new packet.Literal();
   // we assume that cleartext signature is generated based on UTF8 cleartext
   literalDataPacket.setText(this.text);
-  publicKeys.forEach(function(pubKey) {
+  keys.forEach(function(key) {
     for (var i = 0; i < signatureList.length; i++) {
-      var publicKeyPacket = pubKey.getPublicKeyPacket([signatureList[i].issuerKeyId]);
-      if (publicKeyPacket) {
+      var keyPacket = key.getKeyPacket([signatureList[i].issuerKeyId]);
+      if (keyPacket) {
         var verifiedSig = {};
         verifiedSig.keyid = signatureList[i].issuerKeyId;
-        verifiedSig.valid = signatureList[i].verify(publicKeyPacket, literalDataPacket);
+        verifiedSig.valid = signatureList[i].verify(keyPacket, literalDataPacket);
         result.push(verifiedSig);
         break;
       }

--- a/src/key.js
+++ b/src/key.js
@@ -154,14 +154,6 @@ Key.prototype.toPacketlist = function() {
 };
 
 /** 
- * Returns the primary key packet (secret or public)
- * @returns {(module:packet/secret_key|module:packet/public_key|null)} 
- */
-Key.prototype.getKeyPacket = function() {
-  return this.primaryKey;
-};
-
-/** 
  * Returns all the private and public subkey packets
  * @returns {Array<(module:packet/public_subkey|module:packet/secret_subkey)>} 
  */
@@ -180,7 +172,7 @@ Key.prototype.getSubkeyPackets = function() {
  * @returns {Array<(module:packet/public_subkey|module:packet/secret_subkey|module:packet/secret_key|module:packet/public_key)>} 
  */
 Key.prototype.getAllKeyPackets = function() {
-  return [this.getKeyPacket()].concat(this.getSubkeyPackets());
+  return [this.primaryKey].concat(this.getSubkeyPackets());
 };
 
 /** 
@@ -196,7 +188,14 @@ Key.prototype.getKeyIds = function() {
   return keyIds;
 };
 
-function findKey(keys, keyIds) {
+/**
+ * Returns first key packet for given array of key IDs
+ * @param  {Array<module:type/keyid>} keyIds
+ * @return {(module:packet/public_subkey|module:packet/public_key|
+ *           module:packet/secret_subkey|module:packet/secret_key|null)}
+ */
+Key.prototype.getKeyPacket = function(keyIds) {
+  var keys = this.getAllKeyPackets();
   for (var i = 0; i < keys.length; i++) {
     var keyId = keys[i].getKeyId(); 
     for (var j = 0; j < keyIds.length; j++) {
@@ -206,32 +205,6 @@ function findKey(keys, keyIds) {
     }
   }
   return null;
-}
-
-/**
- * Returns first public key packet for given array of key IDs
- * @param  {Array<module:type/keyid>} keyIds 
- * @return {(module:packet/public_subkey|module:packet/public_key|null)}
- */
-Key.prototype.getPublicKeyPacket = function(keyIds) {
-  if (this.primaryKey.tag == enums.packet.publicKey) {
-    return findKey(this.getAllKeyPackets(), keyIds);  
-  } else {
-    return null;
-  }  
-};
-
-/**
- * Returns first private key packet for given array of key IDs
- * @param  {Array<module:type/keyid>} keyIds
- * @return {(module:packet/secret_subkey|module:packet/secret_key|null)}
- */
-Key.prototype.getPrivateKeyPacket = function(keyIds) {
-  if (this.primaryKey.tag == enums.packet.secretKey) {
-    return findKey(this.getAllKeyPackets(), keyIds);  
-  } else {
-    return null;
-  }
 };
 
 /**

--- a/src/message.js
+++ b/src/message.js
@@ -92,7 +92,7 @@ Message.prototype.decrypt = function(privateKey) {
     // nothing to decrypt return unmodified message
     return this;
   }
-  var privateKeyPacket = privateKey.getPrivateKeyPacket(encryptionKeyIds);
+  var privateKeyPacket = privateKey.getKeyPacket(encryptionKeyIds);
   if (!privateKeyPacket.isDecrypted) throw new Error('Private key is not decrypted.');
   var pkESKeyPacketlist = this.packets.filterByTag(enums.packet.publicKeyEncryptedSessionKey);
   var pkESKeyPacket;
@@ -222,22 +222,22 @@ Message.prototype.sign = function(privateKeys) {
 
 /**
  * Verify message signatures
- * @param {Array<module:key~Key>} publicKeys public keys to verify signatures
+ * @param {Array<module:key~Key>} keys array of keys to verify signatures
  * @return {Array<({keyid: module:type/keyid, valid: Boolean})>} list of signer's keyid and validity of signature
  */
-Message.prototype.verify = function(publicKeys) {
+Message.prototype.verify = function(keys) {
   var result = [];
   var msg = this.unwrapCompressed();
   var literalDataList = msg.packets.filterByTag(enums.packet.literal);
   if (literalDataList.length !== 1) throw new Error('Can only verify message with one literal data packet.');
   var signatureList = msg.packets.filterByTag(enums.packet.signature);
-  publicKeys.forEach(function(pubKey) {
+  keys.forEach(function(key) {
     for (var i = 0; i < signatureList.length; i++) {
-      var publicKeyPacket = pubKey.getPublicKeyPacket([signatureList[i].issuerKeyId]);
-      if (publicKeyPacket) {
+      var keyPacket = key.getKeyPacket([signatureList[i].issuerKeyId]);
+      if (keyPacket) {
         var verifiedSig = {};
         verifiedSig.keyid = signatureList[i].issuerKeyId;
-        verifiedSig.valid = signatureList[i].verify(publicKeyPacket, literalDataList[0]);
+        verifiedSig.valid = signatureList[i].verify(keyPacket, literalDataList[0]);
         result.push(verifiedSig);
         break;
       }

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -603,7 +603,8 @@ Signature.prototype.calculateTrailer = function () {
 /**
  * verifys the signature packet. Note: not signature types are implemented
  * @param {String|Object} data data which on the signature applies
- * @param {module:packet/public_subkey|module:packet/public_key} key the public key to verify the signature
+ * @param {module:packet/public_subkey|module:packet/public_key|
+ *         module:packet/secret_subkey|module:packet/secret_key} key the public key to verify the signature
  * @return {boolean} True if message is verified, else false.
  */
 Signature.prototype.verify = function (key, data) {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -397,8 +397,8 @@ var pgp_desktop_priv =
     expect(pubKeys).to.exist;
     expect(pubKeys.err).to.not.exist;
     expect(pubKeys.keys).to.have.length(2);
-    expect(pubKeys.keys[0].getKeyPacket().getKeyId().toHex()).to.equal('4a63613a4d6e4094');
-    expect(pubKeys.keys[1].getKeyPacket().getKeyId().toHex()).to.equal('dbf223e870534df4');
+    expect(pubKeys.keys[0].primaryKey.getKeyId().toHex()).to.equal('4a63613a4d6e4094');
+    expect(pubKeys.keys[1].primaryKey.getKeyId().toHex()).to.equal('dbf223e870534df4');
     done();
   });
 
@@ -420,10 +420,10 @@ var pgp_desktop_priv =
     var pubKeyV3 = pubKeysV3.keys[0];
     expect(pubKeyV3).to.exist;
 
-    expect(pubKeyV4.getKeyPacket().getKeyId().toHex()).to.equal('4a63613a4d6e4094');
-    expect(pubKeyV4.getKeyPacket().getFingerprint()).to.equal('f470e50dcb1ad5f1e64e08644a63613a4d6e4094');
-    expect(pubKeyV3.getKeyPacket().getKeyId().toHex()).to.equal('e5b7a014a237ba9d');
-    expect(pubKeyV3.getKeyPacket().getFingerprint()).to.equal('a44fcee620436a443bc4913640ab3e49');
+    expect(pubKeyV4.primaryKey.getKeyId().toHex()).to.equal('4a63613a4d6e4094');
+    expect(pubKeyV4.primaryKey.getFingerprint()).to.equal('f470e50dcb1ad5f1e64e08644a63613a4d6e4094');
+    expect(pubKeyV3.primaryKey.getKeyId().toHex()).to.equal('e5b7a014a237ba9d');
+    expect(pubKeyV3.primaryKey.getFingerprint()).to.equal('a44fcee620436a443bc4913640ab3e49');
     done();
   });
 

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -455,8 +455,8 @@ describe("Signature", function() {
 
     var keyids = sMsg.getSigningKeyIds();
 
-    expect(pubKey2.getPublicKeyPacket(keyids)).to.exist;
-    expect(pubKey3.getPublicKeyPacket(keyids)).to.exist;
+    expect(pubKey2.getKeyPacket(keyids)).to.exist;
+    expect(pubKey3.getKeyPacket(keyids)).to.exist;
 
     expect(sMsg.getText()).to.equal(plaintext);
 
@@ -501,8 +501,8 @@ describe("Signature", function() {
 
     var keyids = csMsg.getSigningKeyIds();
 
-    expect(pubKey2.getPublicKeyPacket(keyids)).to.exist;
-    expect(pubKey3.getPublicKeyPacket(keyids)).to.exist;
+    expect(pubKey2.getKeyPacket(keyids)).to.exist;
+    expect(pubKey3.getKeyPacket(keyids)).to.exist;
 
     var cleartextSig = openpgp.verifyClearSignedMessage([pubKey2, pubKey3], csMsg);
 


### PR DESCRIPTION
Currently verify methods in `Cleartext` and `Message` class require `Key` objects as parameters which are public keys. It's an unnecessary limitation to not allow privat keys here. Also e.g. the encrypt method in the `Message` class supports both type of keys.

With this PR the limitation is removed and verify methods support also private keys. Actually the verify method of the signature packet always supported also private key packets.

With this comes a cleanup of the `Key` interface:
#### `getKeyPacket` method removed (or redefined, see next point)

The current `getKeyPacket()` just returns the `primaryKey` attribute. We don't have anywhere else these kind of simple getters. `key.getKeyPacket()` is therefore replaced with direct access to `key.primaryKey`.
#### `getPublicKeyPacket` and `getPrivateKeyPacket` replaced with `getKeyPacket`

There can never be public AND private key packets in a key. When we query for key packets of a key by keyid there don't need to be two methods for that. `getKeyPacket` returns either public or private key packets.

Instead of:

```
var keyPacket;
if (key.isPublic()) {
  keyPacket = key.getPublicKeyPacket([keyid]);
} else {
  keyPacket = key.getPrivateKeyPacket([keyid]);
}
```

we can have:

```
var keyPacket = key.getKeyPacket([keyid]);
```
