### PR TITLE
Redefine Regex for blank line after armor header

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -211,7 +211,8 @@ function createcrc24(input) {
  * and an attribute "body" containing the body.
  */
 function splitHeaders(text) {
-  var reEmptyLine = /^\s*\n/m;
+  // empty line with whitespace characters
+  var reEmptyLine = /^[ \f\r\t\u00a0\u2000-\u200a\u202f\u205f\u3000]*\n/m;
   var headers = '';
   var body = text;
 

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -84,7 +84,7 @@ describe("ASCII armor", function() {
     var msg =
       ['-----BEGIN PGP SIGNED MESSAGE-----',
       'Hash: SHA1',
-      '\u000b\u00a0',
+      ' \f\r\t\u00a0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000',
       'sign this',
       '-----BEGIN PGP SIGNATURE-----',
       'Version: GnuPG v2.0.22 (GNU/Linux)',
@@ -181,6 +181,12 @@ describe("ASCII armor", function() {
     var result = openpgp.key.readArmored(privKey);
     expect(result.err).to.not.exist;
     expect(result.keys[0]).to.be.an.instanceof(openpgp.key.Key);
+  });
+
+  it('Do not filter blank lines after header', function () {
+    var msg = getArmor(['Hash: SHA1', '']);
+    msg = openpgp.cleartext.readArmored(msg);
+    expect(msg.text).to.equal('\r\nsign this');
   });
 
 });


### PR DESCRIPTION
This fixes an issue with truncated blank lines at the beginning of cleartext signed messages.
Fixes https://github.com/openpgpjs/openpgpjs/issues/209

We have to deal with all sorts of whitespace characters in armored messages, see also https://github.com/openpgpjs/openpgpjs/issues/193

The previously used regex to split the armor header `/^\s*\n/m` did also include multiple consecutive newline.

The new one splits only at a blank line with whitespace characters:

`/^[ \f\r\t\u00a0\u2000-\u200a\u202f\u205f\u3000]*\n/m`

I took the definition of `\s` from https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions

```
Matches a single white space character, including space, tab, form feed, line feed. 
Equivalent to [ \f\n\r\t\v​\u00a0\u1680​\u180e\u2000​\u2001\u2002​\u2003\u2004​\u2005
\u2006​\u2007\u2008​\u2009\u200a​\u2028\u2029​​\u202f\u205f​\u3000].
```

But removed `\v\u1680​\u180e\u2028\u2029` as they gave non-whitespace characters on either Chrome, Firefox, IE9 or Safari 5.
