### PR TITLE
fix JSON.parse(null)

### DIFF
--- a/src/config/localStorage.js
+++ b/src/config/localStorage.js
@@ -17,7 +17,8 @@ function LocalStorage() {
  * if config is null the default config will be used
  */
 LocalStorage.prototype.read = function () {
-  var cf = JSON.parse(window.localStorage.getItem("config"));
+  var raw = window.localStorage.getItem("config");
+  var cf = (raw === null ? null : JSON.parse(raw));
   if (cf === null) {
     this.config = this.default_config;
     this.write();


### PR DESCRIPTION
if window.localStorage.config is null then JSON.parse returns an error about "u" not being valid (the word "undefined" is not valid JSON apparently :). So I test for null-ness first.
