### PR TITLE
Iterate over signature not keys to allow empty signatures array in case ...

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -231,24 +231,25 @@ Message.prototype.verify = function(keys) {
   var literalDataList = msg.packets.filterByTag(enums.packet.literal);
   if (literalDataList.length !== 1) throw new Error('Can only verify message with one literal data packet.');
   var signatureList = msg.packets.filterByTag(enums.packet.signature);
-  keys.forEach(function(key) {
+  for (var i = 0; i < signatureList.length; i++) {
     var keyPacket = null;
-    for (var i = 0; i < signatureList.length; i++) {
-      keyPacket = key.getKeyPacket([signatureList[i].issuerKeyId]);
+    for (var j = 0; j < keys.length; j++) {
+      keyPacket = keys[j].getKeyPacket([signatureList[i].issuerKeyId]);
       if (keyPacket) {
         break;
       }
     }
+
     var verifiedSig = {};
     if (keyPacket) {
       verifiedSig.keyid = signatureList[i].issuerKeyId;
       verifiedSig.valid = signatureList[i].verify(keyPacket, literalDataList[0]);
     } else {
-      verifiedSig.keyid = key.primaryKey.keyid;
+      verifiedSig.keyid = signatureList[i].issuerKeyId;
       verifiedSig.valid = null;
     }
     result.push(verifiedSig);
-  });
+  }
   return result;
 };
 


### PR DESCRIPTION
...the message has no signatures.

When calling `openpgp.decryptAndVerifyMessage` on a message that has no signatures, the signatures array was not empty because `message.verify` iterated over the public keys in the outer loop. This fixes that issue.
