### PR TITLE
Bugfix in packet_length calculation

### DIFF
--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -227,8 +227,8 @@ module.exports = {
             mypos2 += tmplen;
           } else {
             mypos2++;
-            tmplen = (input.charCodeAt(mypos2++) << 24) | (input.charCodeAt(mypos2++) << 16) | (input[mypos2++]
-              .charCodeAt() << 8) | input.charCodeAt(mypos2++);
+            tmplen = (input.charCodeAt(mypos2++) << 24) | (input.charCodeAt(mypos2++) << 16) | (input
+              .charCodeAt(mypos2++) << 8) | input.charCodeAt(mypos2++);
             bodydata += input.substring(mypos2, mypos2 + tmplen);
             packet_length += tmplen;
             mypos2 += tmplen;


### PR DESCRIPTION
One of the bitshifts used to construct tmplen (lines 230-231) was inconsistent with the other expressions:

(input[mypos2++].charCodeAt() << 8)

causing following error:

TypeError: Cannot call method 'charCodeAt' of undefined
    at Object.module.exports.read (/home/scott/dev/keystone/fetch/node_modules/openpgp/src/packet/packet.js:231:16)

Corrected to 

(input.charCodeAt(mypos2++) << 8)
