### PR TITLE
Add bower support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ For server side use, install via npm:
 
     npm install openpgp
 
+
+### Browser support
+
+For use in browser, install via bower:
+
+    bower install --save openpgp
+
+Or Fetch a minified build under [releases](https://github.com/openpgpjs/openpgpjs/releases). 
+
+The library can be loaded via  AMD/require.js or accessed globally via `window.openpgp`.
+
+
 ### Examples
 
 #### Encryption
@@ -30,9 +42,7 @@ For server side use, install via npm:
     pgpMessage = openpgp.message.readArmored(pgpMessage);
     var plaintext = openpgp.decryptMessage(privateKey, pgpMessage);
 
-### Browser support
 
-Fetch a minified build under [releases](https://github.com/openpgpjs/openpgpjs/releases). The library can be loaded via  AMD/require.js or accessed globally via `window.openpgp`.
 
 OpenPGP.js currently only fully supports browsers that implement `window.crypto.getRandomValues`. If you can help us support more browsers and runtimes, please chip in!
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "openpgpjs",
+  "version": "0.7.2",
+  "homepage": "http://openpgpjs.org/",
+  "authors": [
+    "OpenPGP Development Team <list@openpgpjs.org> (https://github.com/openpgpjs/openpgpjs/graphs/contributors)"
+  ],
+  "description": "OpenPGP.js is a Javascript implementation of the OpenPGP protocol. This is defined in RFC 4880.",
+  "main": "src/index.js",
+  "moduleType": [
+    "amd",
+    "es6",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "crypto",
+    "gpg",
+    "pgp",
+    "openpgp",
+    "encryption"
+  ],
+  "license": "LGPL 2.1",
+  "ignore": [
+    "**/.*",
+    "dist/openpgp*.tgz",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "dist",
+    "doc"
+  ]
+}
+


### PR DESCRIPTION
Hello,

This pull request adds bower support, I have already registered the package  ( https://github.com/openpgpjs/openpgpjs) as openpgpjs[1] to bower as well.
##### On Building /dist:

For security and transparency reasons, it is ideal that the /dist should be build in a public platform. I am not sure if it is possible to push the /dist from travis-ci to github or alternatives, something along the lines of Docker's [Trusted Builds](http://blog.docker.com/2013/11/introducing-trusted-builds/) would be nice.

[1] openpgp is taken by @luisivan, Do you think you can release the name as you don't seem to be keep it up to date with the upstream?
