### PR TITLE
fix symkey version

### DIFF
--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -46,6 +46,7 @@ module.exports = SymEncryptedSessionKey;
  */
 function SymEncryptedSessionKey() {
   this.tag = enums.packet.symEncryptedSessionKey;
+  this.version = 4;
   this.sessionKeyEncryptionAlgorithm = null;
   this.sessionKeyAlgorithm = 'aes256';
   this.encrypted = null;


### PR DESCRIPTION
The SymEncryptedSessionKey version is missing.

Can be tested with `gpg --list-packets`

> gpg: packet(3) with unknown version 0

vs

> :symkey enc packet: version 4, cipher 9, s2k 3, hash 10
> ...

when fixed.
