### PR TITLE
Add getter method for worker to high level API. Initialization options for AsyncProxy: path and worker.

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -37,6 +37,7 @@ module.exports = {
   compression: enums.compression.zip,
   integrity_protect: true,
   rsa_blinding: true,
+  useWebCrypto: true,
 
   show_version: true,
   show_comment: true,

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -46,14 +46,29 @@ if (typeof Promise === 'undefined') {
   require('es6-promise').polyfill();
 }
 
-var asyncProxy; // instance of the asyncproxy
+var asyncProxy = null; // instance of the asyncproxy
 
 /**
  * Set the path for the web worker script and create an instance of the async proxy
- * @param {String} path relative path to the worker scripts
+ * @param {Object} [options.path=String] relative path to the worker scripts, default: 'openpgp.worker.js'
+ *                 [options.worker=module:async_proxy~AsyncProxy] initialized AsyncProxy object to be used as a worker
+ * @return {Boolean} true if worker created successfully
  */
-function initWorker(path) {
-  asyncProxy = new AsyncProxy(path);
+function initWorker(options) {
+  if (!options.worker &&
+     (typeof window === 'undefined' || !window.Worker)) {
+    return false;
+  }
+  asyncProxy = new AsyncProxy(options);
+  return true;
+}
+
+/**
+ * Returns a reference to the async proxy if the worker was initialized with openpgp.initWorker()
+ * @return {module:worker/async_proxy~AsyncProxy|null} the async proxy or null if not initialized
+ */
+function getWorker() {
+  return asyncProxy;
 }
 
 /**
@@ -68,7 +83,7 @@ function encryptMessage(keys, text) {
     keys = [keys];
   }
 
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.encryptMessage(keys, text);
   }
 
@@ -95,7 +110,7 @@ function signAndEncryptMessage(publicKeys, privateKey, text) {
     publicKeys = [publicKeys];
   }
 
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.signAndEncryptMessage(publicKeys, privateKey, text);
   }
 
@@ -119,7 +134,7 @@ function signAndEncryptMessage(publicKeys, privateKey, text) {
  * @static
  */
 function decryptMessage(privateKey, msg) {
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.decryptMessage(privateKey, msg);
   }
 
@@ -145,7 +160,7 @@ function decryptAndVerifyMessage(privateKey, publicKeys, msg) {
     publicKeys = [publicKeys];
   }
 
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.decryptAndVerifyMessage(privateKey, publicKeys, msg);
   }
 
@@ -174,7 +189,7 @@ function signClearMessage(privateKeys, text) {
     privateKeys = [privateKeys];
   }
 
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.signClearMessage(privateKeys, text);
   }
 
@@ -199,7 +214,7 @@ function verifyClearSignedMessage(publicKeys, msg) {
     publicKeys = [publicKeys];
   }
 
-  if (useWorker()) {
+  if (asyncProxy) {
     return asyncProxy.verifyClearSignedMessage(publicKeys, msg);
   }
 
@@ -229,7 +244,7 @@ function verifyClearSignedMessage(publicKeys, msg) {
  */
 function generateKeyPair(options) {
   // use web worker if web crypto apis are not supported
-  if (!util.getWebCrypto() && useWorker()) {
+  if (!util.getWebCrypto() && asyncProxy) {
     return asyncProxy.generateKeyPair(options);
   }
 
@@ -258,22 +273,6 @@ function generateKeyPair(options) {
 //
 // helper functions
 //
-
-/**
- * Are we in a browser and do we support worker?
- */
-function useWorker() {
-  if (typeof window === 'undefined' || !window.Worker) {
-    return false;
-  }
-
-  if (!asyncProxy) {
-    console.log('You need to set the worker path!');
-    return false;
-  }
-
-  return true;
-}
 
 /**
  * Command pattern that wraps synchronous code into a promise
@@ -307,6 +306,7 @@ function onError(message, error) {
 }
 
 exports.initWorker = initWorker;
+exports.getWorker = getWorker;
 exports.encryptMessage = encryptMessage;
 exports.signAndEncryptMessage = signAndEncryptMessage;
 exports.decryptMessage = decryptMessage;

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -50,17 +50,19 @@ var asyncProxy = null; // instance of the asyncproxy
 
 /**
  * Set the path for the web worker script and create an instance of the async proxy
- * @param {Object} [options.path=String] relative path to the worker scripts, default: 'openpgp.worker.js'
- *                 [options.worker=module:async_proxy~AsyncProxy] initialized AsyncProxy object to be used as a worker
+ * @param {String} path relative path to the worker scripts, default: 'openpgp.worker.js'
+ * @param {Object} [options.worker=Object] alternative to path parameter:
+ *                                         web worker initialized with 'openpgp.worker.js'
  * @return {Boolean} true if worker created successfully
  */
-function initWorker(options) {
-  if (!options.worker &&
-     (typeof window === 'undefined' || !window.Worker)) {
+function initWorker(path, options) {
+  if (options && options.worker ||
+      typeof window !== 'undefined' && window.Worker) {
+    asyncProxy = new AsyncProxy(path, options);
+    return true;
+  } else {
     return false;
   }
-  asyncProxy = new AsyncProxy(options);
-  return true;
 }
 
 /**

--- a/src/type/keyid.js
+++ b/src/type/keyid.js
@@ -71,3 +71,9 @@ module.exports.fromClone = function (clone) {
   keyid.bytes = clone.bytes;
   return keyid;
 };
+
+module.exports.fromId = function (hex) {
+  var keyid = new Keyid();
+  keyid.read(util.hex2bin(hex));
+  return keyid;
+};

--- a/src/worker/async_proxy.js
+++ b/src/worker/async_proxy.js
@@ -39,8 +39,12 @@ var INITIAL_RANDOM_SEED = 50000, // random bytes seeded to worker
  * @constructor
  * @param {String} path The path to the worker or 'openpgp.worker.js' by default
  */
-function AsyncProxy(path) {
-  this.worker = new Worker(path || 'openpgp.worker.js');
+function AsyncProxy(options) {
+  if (options && options.worker) {
+    this.worker = options.worker;
+  } else {
+    this.worker = new Worker(options && options.path || 'openpgp.worker.js');
+  }
   this.worker.onmessage = this.onMessage.bind(this);
   this.worker.onerror = function(e) {
     throw new Error('Unhandled error in openpgp worker: ' + e.message + ' (' + e.filename + ':' + e.lineno + ')');

--- a/src/worker/async_proxy.js
+++ b/src/worker/async_proxy.js
@@ -38,12 +38,14 @@ var INITIAL_RANDOM_SEED = 50000, // random bytes seeded to worker
  * Initializes a new proxy and loads the web worker
  * @constructor
  * @param {String} path The path to the worker or 'openpgp.worker.js' by default
+ * @param {Object} [options.worker=Object] alternative to path parameter:
+ *                                         web worker initialized with 'openpgp.worker.js'
  */
-function AsyncProxy(options) {
+function AsyncProxy(path, options) {
   if (options && options.worker) {
     this.worker = options.worker;
   } else {
-    this.worker = new Worker(options && options.path || 'openpgp.worker.js');
+    this.worker = new Worker(path || 'openpgp.worker.js');
   }
   this.worker.onmessage = this.onMessage.bind(this);
   this.worker.onerror = function(e) {

--- a/test/worker/api.js
+++ b/test/worker/api.js
@@ -178,7 +178,7 @@ describe('Init Worker', function() {
 
   it('openpgp.getWorker method', function (done) {
     expect(openpgp.getWorker()).to.be.null;
-    var workerAvailable = openpgp.initWorker({path: '../dist/openpgp.worker.js'});
+    var workerAvailable = openpgp.initWorker('../dist/openpgp.worker.js');
     expect(workerAvailable).to.be.true;
     expect(openpgp.getWorker()).to.exist;
     privKeyRSA = openpgp.key.readArmored(priv_key_rsa).keys[0];
@@ -196,7 +196,7 @@ describe('High level API', function() {
   this.timeout(0);
 
   before(function() {
-    openpgp.initWorker({path: '../dist/openpgp.worker.js'});
+    openpgp.initWorker('../dist/openpgp.worker.js');
     initKeys();
   });
 
@@ -372,7 +372,7 @@ describe('High level API', function() {
     });
 
     it('Depleted random buffer in worker gives error', function (done) {
-      var wProxy = new openpgp.AsyncProxy({path: '../dist/openpgp.worker.js'});
+      var wProxy = new openpgp.AsyncProxy('../dist/openpgp.worker.js');
       wProxy.worker = new Worker('../dist/openpgp.worker.js');
       wProxy.worker.onmessage = wProxy.onMessage.bind(wProxy);
       wProxy.seedRandom(10);
@@ -404,7 +404,7 @@ describe('High level API', function() {
     var msg, proxy;
 
     beforeEach(function() {
-      proxy = new openpgp.AsyncProxy({path: '../dist/openpgp.worker.js'});
+      proxy = new openpgp.AsyncProxy('../dist/openpgp.worker.js');
       initKeys();
       msg = openpgp.message.fromText(plaintext).encrypt([pubKeyRSA]);
     });

--- a/test/worker/api.js
+++ b/test/worker/api.js
@@ -172,12 +172,31 @@ var priv_key_de =
     expect(privKeyDE).to.exist;
   }
 
+describe('Init Worker', function() {
+
+  this.timeout(0);
+
+  it('openpgp.getWorker method', function (done) {
+    expect(openpgp.getWorker()).to.be.null;
+    var workerAvailable = openpgp.initWorker({path: '../dist/openpgp.worker.js'});
+    expect(workerAvailable).to.be.true;
+    expect(openpgp.getWorker()).to.exist;
+    privKeyRSA = openpgp.key.readArmored(priv_key_rsa).keys[0];
+    expect(privKeyRSA.primaryKey.isDecrypted).to.be.false;
+    openpgp.getWorker().decryptKeyPacket(privKeyRSA, [privKeyRSA.primaryKey.getKeyId()], 'hello world').then(function(key) {
+      expect(key.primaryKey.isDecrypted).to.be.true;
+      done();
+    }).catch(done);
+  });
+
+});
+
 describe('High level API', function() {
 
   this.timeout(0);
 
   before(function() {
-    openpgp.initWorker('../dist/openpgp.worker.js');
+    openpgp.initWorker({path: '../dist/openpgp.worker.js'});
     initKeys();
   });
 
@@ -353,7 +372,7 @@ describe('High level API', function() {
     });
 
     it('Depleted random buffer in worker gives error', function (done) {
-      var wProxy = new openpgp.AsyncProxy('../dist/openpgp.worker.js');
+      var wProxy = new openpgp.AsyncProxy({path: '../dist/openpgp.worker.js'});
       wProxy.worker = new Worker('../dist/openpgp.worker.js');
       wProxy.worker.onmessage = wProxy.onMessage.bind(wProxy);
       wProxy.seedRandom(10);
@@ -385,7 +404,7 @@ describe('High level API', function() {
     var msg, proxy;
 
     beforeEach(function() {
-      proxy = new openpgp.AsyncProxy('../dist/openpgp.worker.js');
+      proxy = new openpgp.AsyncProxy({path: '../dist/openpgp.worker.js'});
       initKeys();
       msg = openpgp.message.fromText(plaintext).encrypt([pubKeyRSA]);
     });


### PR DESCRIPTION
Currently if you initialize a worker with `openpgp.initWorker` you can't directly access the newly created AsyncProxy object. Access to methods like `AsyncProxy.prototype.decryptKeyPacket` therefore requires a second worker instantiation.

With this PR:

- the new method `openpgp.getWorker` returns the AsyncProxy if it was initialized with `openpgp.initWorker`
- `openpgp.initWorker` returns a Boolean which indicates successful Worker initialization
- `openpgp.initWorker`: the path parameter was replaced with an options parameter:
```
options.path relative path to the worker scripts, default: 'openpgp.worker.js'
options.worker initialized AsyncProxy object to be used as a worker
```
This breaks API compatibility, but with https://github.com/openpgpjs/openpgpjs/pull/261 on the way we will have here a third parameter therefore I think it makes sense to use options.
- removes the warning "You need to set the worker path", see also #269
- a helper method is added to get a Keyid object from a hex keyid