### PR TITLE
Add option for encryption iteration/octet count

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -909,6 +909,7 @@ function readArmored(armoredText) {
  * @param {String}  options.userId     assumes already in form of "User Name <username@email.com>"
  * @param {String}  options.passphrase The passphrase used to encrypt the resulting private key
  * @param {Boolean} [options.unlocked=false]    The secret part of the generated key is unlocked
+ * @param {Integer}  options.encryptCount iteration octet count for encrypting the resulting private key (default 65536)
  * @return {module:key~Key}
  * @static
  */
@@ -945,8 +946,9 @@ function generate(options) {
   function wrapKeyObject() {
     // set passphrase protection
     if (options.passphrase) {
-      secretKeyPacket.encrypt(options.passphrase);
-      secretSubkeyPacket.encrypt(options.passphrase);
+      var encryptOptions = {count: options.encryptCount};
+      secretKeyPacket.encrypt(options.passphrase, encryptOptions);
+      secretSubkeyPacket.encrypt(options.passphrase, encryptOptions);
     }
 
     packetlist = new packet.List();

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -184,16 +184,16 @@ SecretKey.prototype.encrypt = function (passphrase, options) {
   }
 
   var s2k = new type_s2k(),
-    symmetric = 'aes256',
-    cleartext = write_cleartext_mpi('sha1', this.algorithm, this.mpi),
-    key = produceEncryptionKey(s2k, passphrase, symmetric),
-    blockLen = crypto.cipher[symmetric].blockSize,
-    iv = crypto.random.getRandomBytes(blockLen);
-
   options = options || {};
   if (options.count) {
     s2k.set_count(options.count);
   }
+  
+  var symmetric = 'aes256';
+    cleartext = write_cleartext_mpi('sha1', this.algorithm, this.mpi),
+    key = produceEncryptionKey(s2k, passphrase, symmetric),
+    blockLen = crypto.cipher[symmetric].blockSize,
+    iv = crypto.random.getRandomBytes(blockLen);
 
   this.encrypted = '';
   this.encrypted += String.fromCharCode(254);

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -175,7 +175,7 @@ SecretKey.prototype.write = function () {
  * This can be used to remove passphrase protection after calling decrypt().
  * @param {String} passphrase
  */
-SecretKey.prototype.encrypt = function (passphrase) {
+SecretKey.prototype.encrypt = function (passphrase, options) {
   if (this.isDecrypted && !passphrase) {
     this.encrypted = null;
     return;
@@ -189,6 +189,11 @@ SecretKey.prototype.encrypt = function (passphrase) {
     key = produceEncryptionKey(s2k, passphrase, symmetric),
     blockLen = crypto.cipher[symmetric].blockSize,
     iv = crypto.random.getRandomBytes(blockLen);
+
+  options = options || {};
+  if (options.count) {
+    s2k.set_count(options.count);
+  }
 
   this.encrypted = '';
   this.encrypted += String.fromCharCode(254);

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -71,7 +71,6 @@ S2K.prototype.set_count = function (count) {
   }
 
   this.c = lowerBits + (upperBits << 4);
-  console.log('Setting encryption count: ' + count + ' -> ' + this.get_count());
   return this.get_count();
 };
 

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -57,6 +57,24 @@ S2K.prototype.get_count = function () {
   return (16 + (this.c & 15)) << ((this.c >> 4) + expbias);
 };
 
+S2K.prototype.set_count = function (count) {
+  var expbias = 6;
+  
+  var upperBits = 0;
+  while (upperBits < 15 && count > (31 << (upperBits + expbias))) {
+    upperBits++;
+  }
+  
+  var lowerBits = 0;
+  while (lowerBits < 15 && count > (16 + lowerBits) << (upperBits + expbias)) {
+    lowerBits++;
+  }
+
+  this.c = lowerBits + (upperBits << 4);
+  console.log('Setting encryption count: ' + count + ' -> ' + this.get_count());
+  return this.get_count();
+};
+
 /**
  * Parsing function for a string-to-key specifier ({@link http://tools.ietf.org/html/rfc4880#section-3.7|RFC 4880 3.7}).
  * @param {String} input Payload of string-to-key specifier


### PR DESCRIPTION
I wanted to be able to alter the iteration count when encrypting the private-key, so I added an option for it.

Existing tests still pass - I wasn't sure where to put a new test or what it should be, though.
