### PR TITLE
Comparison fix for broken getRandomBigIntegerInRange function

### DIFF
--- a/src/crypto/random.js
+++ b/src/crypto/random.js
@@ -124,7 +124,7 @@ module.exports = {
 
     var range = max.subtract(min);
     var r = this.getRandomBigInteger(range.bitLength());
-    while (r > range) {
+    while (r.compareTo(range) > 0) {
       r = this.getRandomBigInteger(range.bitLength());
     }
     return min.add(r);


### PR DESCRIPTION
Current comparison is a string comparison in lexical order. This results in the wrong function result, and also for certain choices of 'max' can empty the random number buffer when run in a Web Worker.