### PR TITLE
Specify a filename in encrypt fromBinary [Closes #284]

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -327,11 +327,15 @@ function fromText(text) {
 /**
  * creates new message object from binary data
  * @param {String} bytes
+ * @param {String} filename
  * @return {module:message~Message} new message object
  * @static
  */
-function fromBinary(bytes) {
+function fromBinary(bytes, filename) {
   var literalDataPacket = new packet.Literal();
+  if (filename) {
+    literalDataPacket.setFilename(filename);
+  }
   literalDataPacket.setBytes(bytes, enums.read(enums.literal, enums.literal.binary));
   var literalDataPacketlist = new packet.List();
   literalDataPacketlist.push(literalDataPacket);

--- a/test/general/basic.js
+++ b/test/general/basic.js
@@ -141,7 +141,7 @@ describe('Basic', function() {
 
         // sign and encrypt
         var msg, encrypted;
-        msg = openpgp.message.fromBinary(message);
+        msg = openpgp.message.fromBinary(message, "test.txt");
         msg = msg.sign([privKey]);
         msg = msg.encrypt([pubKey]);
         encrypted = openpgp.armor.encode(openpgp.enums.armor.message, msg.packets.write());


### PR DESCRIPTION
- Follows the original suggestion in #176 to add a filename option to openpgp.message.fromBinary
- Adds a filename to the performance test to make sure this doesn't cause significant problems

I would be open to adding another test to verify the output file has the right filename, but I'm not sure how it'd work