### PR TITLE
Check validity of key packet before signature verification

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -70,6 +70,9 @@ CleartextMessage.prototype.sign = function(privateKeys) {
   var literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
   for (var i = 0; i < privateKeys.length; i++) {
+    if (privateKeys[i].isPublic()) {
+      throw new Error('Need private key for signing');
+    }
     var signaturePacket = new packet.Signature();
     signaturePacket.signatureType = enums.signature.text;
     signaturePacket.hashAlgorithm = config.prefer_hash_algorithm;
@@ -96,7 +99,7 @@ CleartextMessage.prototype.verify = function(keys) {
   for (var i = 0; i < signatureList.length; i++) {
     var keyPacket = null;
     for (var j = 0; j < keys.length; j++) {
-      keyPacket = keys[j].getKeyPacket([signatureList[i].issuerKeyId]);
+      keyPacket = keys[j].getSigningKeyPacket(signatureList[i].issuerKeyId);
       if (keyPacket) {
         break;
       }

--- a/src/key.js
+++ b/src/key.js
@@ -278,21 +278,21 @@ Key.prototype.armor = function() {
 };
 
 /**
- * Returns first key packet that is available for signing
+ * Returns first key packet or key packet by given keyId that is available for signing or signature verification
+ * @param  {module:type/keyid} keyId, optional
  * @return {(module:packet/secret_subkey|module:packet/secret_key|null)} key packet or null if no signing key has been found
  */
-Key.prototype.getSigningKeyPacket = function() {
-  if (this.isPublic()) {
-    throw new Error('Need private key for signing');
-  }
+Key.prototype.getSigningKeyPacket = function(keyId) {
   var primaryUser = this.getPrimaryUser();
   if (primaryUser &&
-      isValidSigningKeyPacket(this.primaryKey, primaryUser.selfCertificate)) {
+      isValidSigningKeyPacket(this.primaryKey, primaryUser.selfCertificate) &&
+      (!keyId || this.primaryKey.getKeyId().equals(keyId))) {
     return this.primaryKey;
   }
   if (this.subKeys) {
     for (var i = 0; i < this.subKeys.length; i++) {
-      if (this.subKeys[i].isValidSigningKey(this.primaryKey)) {
+      if (this.subKeys[i].isValidSigningKey(this.primaryKey) &&
+          (!keyId || this.subKeys[i].subKey.getKeyId().equals(keyId))) {
         return this.subKeys[i].subKey;
       }
     }

--- a/src/message.js
+++ b/src/message.js
@@ -194,6 +194,9 @@ Message.prototype.sign = function(privateKeys) {
                       enums.signature.binary : enums.signature.text;
   var i;
   for (i = 0; i < privateKeys.length; i++) {
+    if (privateKeys[i].isPublic()) {
+      throw new Error('Need private key for signing');
+    }
     var onePassSig = new packet.OnePassSignature();
     onePassSig.type = signatureType;
     //TODO get preferred hashg algo from key signature
@@ -236,7 +239,7 @@ Message.prototype.verify = function(keys) {
   for (var i = 0; i < signatureList.length; i++) {
     var keyPacket = null;
     for (var j = 0; j < keys.length; j++) {
-      keyPacket = keys[j].getKeyPacket([signatureList[i].issuerKeyId]);
+      keyPacket = keys[j].getSigningKeyPacket(signatureList[i].issuerKeyId);
       if (keyPacket) {
         break;
       }


### PR DESCRIPTION
OpenPGP.js does not validate sub keys before using them for signature verification.

Attack scenario:
Alice uses insecure channel to send public key to Bob. MITM attacker adds subkey to Alice's key. Bob verifies fingerprint of Alice's key but not of the subkeys. Attacker can send messages to Bob signed with the fake subkey, pretending to come from Alice.

With this fix primary and subkey packets are validated before used in signature verification.

Bug reported by: @cure53