### PR TITLE
Implement Symmetric-Key Message Encryption using a passphrase

### DIFF
--- a/test/general/basic.js
+++ b/test/general/basic.js
@@ -323,6 +323,25 @@ describe('Basic', function() {
 
   });
 
+  describe('Encrypt message symmetrically using passphrase', function() {
+    it('should encrypt/decrypt successfully', function() {
+      var passphrase = 'passphrase';
+      var plaintext = 'secret stuff';
+
+      // encrypt
+      var msg = openpgp.message.fromText(plaintext);
+      msg = msg.symEncrypt(passphrase);
+      var encrypted = msg.armor();
+
+      // decrypt
+      var msg2 = openpgp.message.readArmored(encrypted);
+      msg2 = msg2.symDecrypt(passphrase);
+      var decrypted = msg2.getText();
+
+      expect(decrypted).to.equal(plaintext);
+    });
+  });
+
   describe("Message 3DES decryption", function() {
     var pgp_msg =
         ['-----BEGIN PGP MESSAGE-----',


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc4880#section-3.7.2.2

This new api can be used together with a high entropy backup code in our [private key sync proposal](https://github.com/whiteout-io/mail-html5/wiki/Secure-OpenPGP-Key-Pair-Synchronization-via-IMAP) to securely sync a user's private key between devices.

The standard ascii armored output will replace the custom packet structure in the current version of the key sync spec and allow the usage of existing ciphers already in OpenPGP implementations today. This should ease adoption for other mail user agents that are interested in supporting key sync. I tested this against GPG v2.0.27 and it was able to decrypt the generated format.

Note: the key sync RFC will recommend to use the AES-256 symmetric cipher as well as SHA-256 for generating the passphrase via S2K.

Thanks @koto and Werner Koch for your feedback!