### PR TITLE
Support string message in verifyClearSignedMessage

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -207,7 +207,7 @@ function signClearMessage(privateKeys, text) {
 /**
  * Verifies signatures of cleartext signed message
  * @param  {(Array<module:key~Key>|module:key~Key)}  publicKeys array of keys or single key, to verify signatures
- * @param  {module:cleartext~CleartextMessage} msg    cleartext message object with signatures
+ * @param  {module:cleartext~CleartextMessage|String} msg    cleartext message object with signatures, or armored string
  * @return {Promise<{text: String, signatures: Array<{keyid: module:type/keyid, valid: Boolean}>}>}
  *                                       cleartext with status of verified signatures
  * @static
@@ -215,6 +215,10 @@ function signClearMessage(privateKeys, text) {
 function verifyClearSignedMessage(publicKeys, msg) {
   if (!publicKeys.length) {
     publicKeys = [publicKeys];
+  }
+  
+  if (typeof msg === 'string') {
+    msg = new cleartext.readArmored(msg);
   }
 
   if (asyncProxy) {


### PR DESCRIPTION
This updates `verifyClearSignedMessage` to also accept cleartext messages as armored string, making the method symmetric with `signClearMessage` which already returns an armored string. I think this a more typical use case for consumers of this library than having a wrapping cleartext message object already constructed, so this makes things easier.

Let me know if there is interest, then I can add some unit tests.