### PR TITLE
If you attempt to store an empty keylist then delete the storage key

### DIFF
--- a/src/keyring/localstore.js
+++ b/src/keyring/localstore.js
@@ -97,8 +97,12 @@ LocalStore.prototype.storePrivate = function (keys) {
 
 function storeKeys(storage, itemname, keys) {
   var armoredKeys = [];
-  for (var i = 0; i < keys.length; i++) {
-    armoredKeys.push(keys[i].armor());
+  if (keys.length) {
+    for (var i = 0; i < keys.length; i++) {
+      armoredKeys.push(keys[i].armor());
+    }
+    storage.setItem(itemname, JSON.stringify(armoredKeys));
+  } else {
+    storage.removeItem(itemname);
   }
-  storage.setItem(itemname, JSON.stringify(armoredKeys));
 }

--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -248,6 +248,21 @@ describe("Keyring", function() {
     expect(localstore3.loadPublic()).to.have.length(0);
   });
 
+  it('emptying keyring and storing removes keys', function() {
+    var key = openpgp.key.readArmored(pubkey).keys[0];
+
+    var localstore = new openpgp.Keyring.localstore('remove-prefix-');
+
+    localstore.storePublic([]);
+    expect(localstore.storage.getItem('remove-prefix-public-keys')).to.be.null;
+
+    localstore.storePublic([key]);
+    expect(localstore.storage.getItem('remove-prefix-public-keys')).to.be.not.null;
+    
+    localstore.storePublic([]);
+    expect(localstore.storage.getItem('remove-prefix-public-keys')).to.be.null;
+  })
+
   it('removeKeysForId() - unknown id', function() {
     keyring.publicKeys.importKey(pubkey);
     keyring.publicKeys.importKey(pubkey2);


### PR DESCRIPTION
I guess this is a minor point, but if you remove all the keys from a keyring and then save it to storage, the storage key remains but with a value of "[]". This small fix deletes the key itself so that there's no empty keys left behind.

Hope this is ok.