### PR TITLE
Keyring: support plain email addresses (without name) as user IDs.

### DIFF
--- a/src/keyring/keyring.js
+++ b/src/keyring/keyring.js
@@ -123,12 +123,14 @@ KeyArray.prototype.getForAddress = function(email) {
  * @return {Boolean} True if the email address is defined in the specified key
  */
 function emailCheck(email, key) {
+  email = email.toLowerCase();
   // escape email before using in regular expression
-  email = email.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  var emailRegex = new RegExp('<' + email + '>');
-  var keyEmails = key.getUserIds();
-  for (var i = 0; i < keyEmails.length; i++) {
-    if (emailRegex.test(keyEmails[i].toLowerCase())) {
+  var emailEsc = email.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  var emailRegex = new RegExp('<' + emailEsc + '>');
+  var userIds = key.getUserIds();
+  for (var i = 0; i < userIds.length; i++) {
+    var userId = userIds[i].toLowerCase();
+    if (email === userId || emailRegex.test(userId)) {
       return true;
     }
   }

--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -82,6 +82,28 @@ describe("Keyring", function() {
       'y61IhKbJCOlQxyem+kepjNapkhKDAQDIDL38bZWU4Rm0nq82Xb4yaI0BCWDcFkHV',
       'og2umGfGng==',
       '=v3+L',
+      '-----END PGP PUBLIC KEY BLOCK-----'].join('\n'),
+    user3 = 'plain@email.org',
+    keyFingerP3 = 'f9972bf320a86a93c6614711ed241e1de755d53c',
+    pubkey3 =
+      ['-----BEGIN PGP PUBLIC KEY BLOCK-----',
+      '',
+      'xo0EVe6wawEEAKG4LDE9946jdvvbfVTF9qWtOyxHYjb40z7hgcZsPEGd6QfN',
+      'XbfNJBeQ5S9j/2jRu8NwBgdXIpMp4QwB2Q/cEp1rbw5kUVuRbhfsb2BzuiBr',
+      'Q5jHa5oZSGbbLWRoOXTvJH8VE2gbKSj/km1VaXzq2Qmv+YIHxav1it7vNmg5',
+      'E2kBABEBAAHND3BsYWluQGVtYWlsLm9yZ8K1BBABCAApBQJV7rBrBgsJCAcD',
+      'AgkQ7SQeHedV1TwEFQgCCgMWAgECGQECGwMCHgEAAGJmBACVJPoFtW96UkIW',
+      'GX1bgW99c4K87Me+5ZCHqPOdXFpRinAPBdJT9vkBWLb/aOQQCDWJvdVXKFLD',
+      'FCbSBjcohR71n6145F5im8b0XzXnKh+MRRv/0UHiHGtB/Pkg38jbLeXbVfCM',
+      '9JJm+s+PFef+8wN84sEtD/MX2cj61teuPf2VEs6NBFXusGsBBACoJW/0y5Ea',
+      'FH0nJOuoenrEBZkFtGbdwo8A4ufCCrm9ppFHVVnw4uTPH9dOjw8IAnNy7wA8',
+      '8yZCkreQ491em09knR7k2YdJccWwW8mGRILHQDDEPetZO1dSVW+MA9X7Pcle',
+      'wbFEHCIkWEgymn3zenie1LXIljPzizHje5vWBrSlFwARAQABwp8EGAEIABMF',
+      'AlXusGsJEO0kHh3nVdU8AhsMAACB2AP/eRJFAVTyiP5MnMjsSBuNMNBp1X0Y',
+      '+RrWDpO9H929+fm9oFTedohf/Ja5w9hsRk2VzjLOXe/uHdrcgaBmAdFunbvv',
+      'IWneczohBvLOarevZj1J+H3Ej/DVF2W7kJZLpvPfh7eo0biClS/GQUVw1rlE',
+      'ph10hhUaSJ326LsFJccT3jk=',
+      '=4jat',
       '-----END PGP PUBLIC KEY BLOCK-----'].join('\n');
 
   it('Import key pair', function() {
@@ -178,6 +200,13 @@ describe("Keyring", function() {
 
   it('publicKeys.getForAddress() - valid address', function() {
     var keys = keyring.publicKeys.getForAddress(user);
+    expect(keys).to.exist.and.have.length(1);
+  });
+
+  it('publicKeys.getForAddress() - valid address, plain email user id', function() {
+    keyring.publicKeys.importKey(pubkey3);
+    var keys = keyring.publicKeys.getForAddress(user3);
+    keyring.removeKeysForId(keyFingerP3);
     expect(keys).to.exist.and.have.length(1);
   });
 


### PR DESCRIPTION
A user ID which is not in the form `Name <abc@def.gh>` but instead only consists of an email address is currently not recognized in the `getForAddress()` methods of the keyring.
This PR fixes the email check function.