### PR TITLE
Add option for deprecation of Symmetrically Encrypted Data Packet (Tag 9)

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -35,7 +35,10 @@ module.exports = {
   prefer_hash_algorithm: enums.hash.sha256,
   encryption_cipher: enums.symmetric.aes256,
   compression: enums.compression.zip,
+  // use integrity protection for symmetric encryption
   integrity_protect: true,
+  // only allow integrity protected messages to decrypt
+  enforce_integrity_protection: true,
   rsa_blinding: true,
   useWebCrypto: true,
 

--- a/src/packet/symmetrically_encrypted.js
+++ b/src/packet/symmetrically_encrypted.js
@@ -31,7 +31,8 @@
 module.exports = SymmetricallyEncrypted;
 
 var crypto = require('../crypto'),
-  enums = require('../enums.js');
+  enums = require('../enums.js'),
+  config = require('../config');
 
 /**
  * @constructor
@@ -42,13 +43,20 @@ function SymmetricallyEncrypted() {
   /** Decrypted packets contained within. 
    * @type {module:packet/packetlist} */
   this.packets =  null;
+  this.enforce_integrity_protection = config.enforce_integrity_protection;
 }
 
 SymmetricallyEncrypted.prototype.read = function (bytes) {
+  if (this.enforce_integrity_protection) {
+    throw new Error('Support for Symmetrically Encrypted Data Packet (Tag 9) deactivated.');
+  }
   this.encrypted = bytes;
 };
 
 SymmetricallyEncrypted.prototype.write = function () {
+  if (this.enforce_integrity_protection) {
+    throw new Error('Support for Symmetrically Encrypted Data Packet (Tag 9) deactivated.');
+  }
   return this.encrypted;
 };
 


### PR DESCRIPTION
There is a recent analysis of chosen-ciphertext attacks to downgrade a Sym. Encrypted Integrity Protected Data Packet (Tag 18) packet to a plain Symmetrically Encrypted Data Packet (Tag 9).

The author Jonas Magazinius points out: "The implications are among others, that an encrypted and signed message can be stripped of its signature and modified arbitrarily, with certain restrictions, by an attacker without knowing the key."

Full details here: http://www.metzdowd.com/pipermail/cryptography/2015-October/026685.html

This seems to be known issue for years. GPG triggers a warning when a tag 9 packet (without integrity protection) is used. But this requires the user to understand the implications. And from a practical perspective tag 9 is never used as all relevant PGP implementations create messages only with integrity protection (tag 18). Then why keep this hole open?

I propose to deprecate tag 9. With this PR decryption of a message with tag 9 will throw an exception.

For legacy use cases there is the config.enforce_integrity_protection which can be set to false and bring back tag 9.