### PR TITLE
Off by one in jsbn methods

### DIFF
--- a/src/crypto/public_key/jsbn.js
+++ b/src/crypto/public_key/jsbn.js
@@ -171,7 +171,7 @@ function bnpFromInt(x) {
   this.t = 1;
   this.s = (x < 0) ? -1 : 0;
   if (x > 0) this[0] = x;
-  else if (x < -1) this[0] = x + this.DV;
+  else if (x <= -1) this[0] = x + this.DV;
   else this.t = 0;
 }
 

--- a/src/crypto/public_key/jsbn.js
+++ b/src/crypto/public_key/jsbn.js
@@ -423,7 +423,7 @@ function bnpSubTo(a, r) {
     c -= a.s;
   }
   r.s = (c < 0) ? -1 : 0;
-  if (c < -1) r[i++] = this.DV + c;
+  if (c <= -1) r[i++] = this.DV + c;
   else if (c > 0) r[i++] = c;
   r.t = i;
   r.clamp();
@@ -1169,7 +1169,7 @@ function bnpAddTo(a, r) {
   }
   r.s = (c < 0) ? -1 : 0;
   if (c > 0) r[i++] = c;
-  else if (c < -1) r[i++] = this.DV + c;
+  else if (c <= -1) r[i++] = this.DV + c;
   r.t = i;
   r.clamp();
 }

--- a/src/crypto/public_key/jsbn.js
+++ b/src/crypto/public_key/jsbn.js
@@ -51,10 +51,11 @@ var j_lm = ((canary & 0xffffff) == 0xefcafe);
 // (public) Constructor
 
 function BigInteger(a, b, c) {
-  if (a != null)
+  if (a != null) {
     if ("number" == typeof a) this.fromNumber(a, b, c);
     else if (b == null && "string" != typeof a) this.fromString(a, 256);
-  else this.fromString(a, b);
+    else this.fromString(a, b);
+  }
 }
 
 // return new, unset BigInteger


### PR DESCRIPTION
Just played with your library and discovered an off by one in jsbn.js bnpFromInt() through some unit tests.

#### Problem
A *-1* as input parameter is not properly converted and stored as *BigInteger {0: 0, t: 0, s: -1}* but it should be *BigInteger {0: 67108863, t: 1, s: -1}* (always asuming BigInteger.DB == 26).

```javascript
var bigInt =  new BigInteger(null);
bigInt.fromInt(-1);
var byteArray = bigInt.toByteArray();       /// [-1] instead of the expected [255, 255, 255]
var binString = util.bin2str(byteArray);     /// '￿' instead of the expected 'ÿÿÿ'
```

#### Additions
This error also ocures in the original library published by Tom Wu and the related npm package by Andy Perlitch.