### PR TITLE
Ignore mdc error flag

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -35,7 +35,10 @@ module.exports = {
   prefer_hash_algorithm: enums.hash.sha256,
   encryption_cipher: enums.symmetric.aes256,
   compression: enums.compression.zip,
+  // use integrity protection for symmetric encryption
   integrity_protect: true,
+  // fail on decrypt if message is not integrity protected
+  ignore_mdc_error: false,
   rsa_blinding: true,
   useWebCrypto: true,
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -53,6 +53,29 @@ describe("Packet", function() {
     message.push(enc);
     enc.packets.push(literal);
 
+    var key = '123456789012345678901234',
+        algo = 'tripledes';
+
+    enc.encrypt(algo, key);
+
+    var msg2 = new openpgp.packet.List();
+    msg2.read(message.write());
+    msg2[0].decrypt(algo, key);
+
+    expect(msg2[0].packets[0].data).to.equal(literal.data);
+    done();
+  });
+
+  it('Symmetrically encrypted packet - MDC error for modern cipher', function() {
+    var message = new openpgp.packet.List();
+
+    var literal = new openpgp.packet.Literal();
+    literal.setText('Hello world');
+
+    var enc = new openpgp.packet.SymmetricallyEncrypted();
+    message.push(enc);
+    enc.packets.push(literal);
+
     var key = '12345678901234567890123456789012',
         algo = 'aes256';
 
@@ -60,11 +83,7 @@ describe("Packet", function() {
 
     var msg2 = new openpgp.packet.List();
     msg2.read(message.write());
-
-    msg2[0].decrypt(algo, key);
-
-    expect(msg2[0].packets[0].data).to.equal(literal.data);
-    done();
+    expect(msg2[0].decrypt.bind(msg2[0], algo, key)).to.throw('Decryption failed due to missing MDC in combination with modern cipher.');
   });
 
   it('Sym. encrypted integrity protected packet', function(done) {


### PR DESCRIPTION
This is a refinement of https://github.com/openpgpjs/openpgpjs/pull/360

Instead of completely deprecating tag 9, MDC is by default only required for modern ciphers (AES, except for Twofish).

This is aligned with the `ignore_mdc_error` flag in GPG: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=625e292108cc0fd9077769587a8c22abe7805e33
Starting with Release 2.1.9 GPG will:
```
* gpg: Fail with an error instead of a warning if a modern cipher
   algorithm is used without a MDC.
```
From: https://lists.gnupg.org/pipermail/gnupg-announce/2015q4/000380.html