### PR TITLE
Fix for bad instance name in browsers

### DIFF
--- a/src/crypto/public_key/rsa.js
+++ b/src/crypto/public_key/rsa.js
@@ -167,7 +167,7 @@ function RSA() {
         };
         
         keys = webCrypto.generateKey(keyGenOpt, true, ['sign', 'verify']);
-        if (!(keys instanceof Promise)) { // IE11 KeyOperation
+        if ('function' !== typeof keys.then) { // IE11 KeyOperation
           keys = convertKeyOperation(keys, 'Error generating RSA key pair.');
         }
       }
@@ -185,7 +185,7 @@ function RSA() {
       // export the generated keys as JsonWebKey (JWK)
       // https://tools.ietf.org/html/draft-ietf-jose-json-web-key-33
       var key = webCrypto.exportKey('jwk', keypair.privateKey);
-      if (!(key instanceof Promise)) { // IE11 KeyOperation
+      if ('function' !== typeof keys.then) { // IE11 KeyOperation
         key = convertKeyOperation(key, 'Error exporting RSA key pair.');
       }
       return key;


### PR DESCRIPTION
I just spent 6 hours scratching my head, analyzing why openpgp wouldn't work in my setup. 
It turns out it has something to do either with the previous polyfill of Promise in `core.js` or the way `System.js` resolves dependencies - either way I don't have the will to test which anymore. 
What would happen is when I started generating a key pair, the promise would be dispatched and then... nothing. No error, no key pair. Anyway, after stepping through the Promise generation I noticed that the culprit is the `if (!(keys instanceof Promise))` which was evaluating incorrectly. For some reason the `typeof keys` was returning `object` instead of `Promise`. After some googling around it seems this is also required for Safari compatibility.
Following this [thread](http://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise), I've made the necessary corrections (only two lines). The code executes correctly now. I believe it has no security implications so it should be safe to pull.