### PR TITLE
put `sudo: false` in `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.12.2"


### PR DESCRIPTION
May reduce the time of Travis CI testing as mentioned by @toberndo at https://github.com/openpgpjs/openpgpjs/pull/375#issuecomment-160397424.