### PR TITLE
Handle carriage-return-only newlines

### DIFF
--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -48,7 +48,7 @@ export default function Literal() {
  */
 Literal.prototype.setText = function(text) {
   // normalize EOL to \r\n
-  text = text.replace(/\r/g, '').replace(/\n/g, '\r\n');
+  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
   // encode UTF8
   this.data = this.format === 'utf8' ? util.str2Uint8Array(util.encode_utf8(text)) : util.str2Uint8Array(text);
 };


### PR DESCRIPTION
Newlines are normalised to \r\n, but that previously assumed that only \r\n and \n newline characters could be present. Even though \r newlines are rarely used in the wild, it's be helpful to support them - currently, they're just removed entirely.

On related note - does anyone know *why* newlines are normalised before data is encrypted?