### PR TITLE
Codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 addons:
     code_climate:
-        repo_token: tanxchangeme!46ecd492907f8224b0ae64890d4befb4bbd9ebbeba55b5acb38
+        repo_token: $CODECLIMATE_REPO_TOKEN
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+addons:
+    code_climate:
+        repo_token: tanxchangeme!46ecd492907f8224b0ae64890d4befb4bbd9ebbeba55b5acb38
 matrix:
   fast_finish: true
   include:
@@ -52,6 +55,6 @@ matrix:
     - env: OPENPGPJSTEST='end2end-12' BROWSER='iphone 7.0'
     - env: OPENPGPJSTEST='end2end-13' BROWSER='iphone 9.1'
 before_script:
-  - npm install -g grunt-cli
+  - npm install -g grunt-cli codeclimate-test-reporter
 script:
   - $TRAVIS_BUILD_DIR/travis.sh

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,15 +136,6 @@ module.exports = function(grunt) {
           root: '.',
           timeout: 240000,
         }
-      },
-      coveralls: {
-        src: ['test'],
-        options: {
-          root: '.',
-          timeout: 240000,
-          coverage: true,
-          reportFormats: ['cobertura','lcovonly']
-        }
       }
     },
     mochaTest: {
@@ -254,18 +245,8 @@ module.exports = function(grunt) {
 
   grunt.registerTask('documentation', ['jsdoc']);
 
-  grunt.event.on('coverage', function(lcov, done){
-    require('coveralls').handleInput(lcov, function(err){
-      if (err) {
-        return done(err);
-      }
-      done();
-    });
-  });
-
   // Test/Dev tasks
   grunt.registerTask('test', ['jshint:build', 'jscs:build', 'copy:zlib', 'mochaTest']);
   grunt.registerTask('coverage', ['copy:zlib', 'mocha_istanbul:coverage']);
-  grunt.registerTask('coveralls', ['copy:zlib', 'mocha_istanbul:coveralls']);
   grunt.registerTask('saucelabs', ['default', 'copy:browsertest', 'connect', 'saucelabs-mocha']);
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OpenPGP.js [![Build Status](https://travis-ci.org/openpgpjs/openpgpjs.svg?branch=master)](https://travis-ci.org/openpgpjs/openpgpjs) [![Coverage Status](https://coveralls.io/repos/openpgpjs/openpgpjs/badge.svg)](https://coveralls.io/r/openpgpjs/openpgpjs)
+OpenPGP.js [![Build Status](https://travis-ci.org/openpgpjs/openpgpjs.svg?branch=master)](https://travis-ci.org/openpgpjs/openpgpjs) [![Test Coverage](https://codeclimate.com/github/openpgpjs/openpgpjs/badges/coverage.svg)](https://codeclimate.com/github/openpgpjs/openpgpjs/coverage) [![Code Climate](https://codeclimate.com/github/openpgpjs/openpgpjs/badges/gpa.svg)](https://codeclimate.com/github/openpgpjs/openpgpjs)
 ==========
 
 [OpenPGP.js](http://openpgpjs.org/) is a Javascript implementation of the OpenPGP protocol. This is defined in [RFC 4880](http://tools.ietf.org/html/rfc4880).

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "chai": "~3.4.1",
-    "coveralls": "^2.11.2",
     "grunt": "~0.4.5",
     "grunt-browserify": "~4.0.1",
     "grunt-contrib-clean": "~0.7.0",

--- a/travis.sh
+++ b/travis.sh
@@ -4,7 +4,8 @@ set -e
 
 if [ $OPENPGPJSTEST = "unit" ]; then
   echo "Running OpenPGP.js unit-tests"
-  grunt coveralls
+  grunt coverage
+  codeclimate-test-reporter < coverage/lcov.info
 
 elif [[ $OPENPGPJSTEST =~ ^end2end-.* ]]; then
   echo "Running browser-testing on Saucelabs"


### PR DESCRIPTION
As done for [dchest/scrypt-async-js](https://github.com/dchest/scrypt-async-js/pull/21) i'm here proposing this improvement:

This pull requests:
- Add tracking of code quality with Codeclimate
- replace Coveralls with Codeclimate coverage

since the integration it will be possible to have the following outputs:
![screenshot from 2016-01-24 20 26 18](https://cloud.githubusercontent.com/assets/217034/12538393/0d03dc76-c2d9-11e5-8350-c6676ab22213.png)
![screenshot from 2016-01-24 20 26 37](https://cloud.githubusercontent.com/assets/217034/12538395/12a00f06-c2d9-11e5-9da2-2592de363d35.png)
![screenshot from 2016-01-24 20 27 59](https://cloud.githubusercontent.com/assets/217034/12538398/1810e7a8-c2d9-11e5-8b36-8d43e9300d3f.png)


it will be easy then fix issues in the code related to not standard/interoperable syntaxes

After integration the codeclimate token should be replaced with a token specific for the dchest/scrypt-async-js to be taken loggin onto https://codeclimate.com/dashboard