### PR TITLE
Enable ES6 support by using babelify transform in browserify build

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
 	"trailing": true,
 	"undef": true,
 	"unused": true,
+	"esnext": true,
 
 	"predef": [
 			"console",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,13 @@ module.exports = function(grunt) {
           browserifyOptions: {
             standalone: 'openpgp'
           },
-          external: [ 'crypto', 'node-localstorage' ]
+          external: [ 'crypto', 'node-localstorage' ],
+          transform: [
+            ["babelify", {
+              ignore: ['*.min.js'],
+              presets: ["es2015"]
+            }]
+          ]
         }
       },
       openpgp_debug: {
@@ -30,7 +36,13 @@ module.exports = function(grunt) {
             debug: true,
             standalone: 'openpgp'
           },
-          external: [ 'crypto', 'node-localstorage' ]
+          external: [ 'crypto', 'node-localstorage' ],
+          transform: [
+            ["babelify", {
+              ignore: ['*.min.js'],
+              presets: ["es2015"]
+            }]
+          ]
         }
       },
       worker: {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.3.13",
+    "babelify": "^7.2.0",
     "chai": "~3.4.1",
     "coveralls": "^2.11.2",
     "grunt": "~0.4.5",


### PR DESCRIPTION
* Add babelify as dev dependency
* Add babelify transform to browserify build
* Enable es6 support for jshint
* Ignore minified js files in babel transform

**N.B. This PR just enables support for ES6 in our browserify build. It does not change any source code. It does however change some semantics e.g. all code is now automatically executed in ES5 strict mode as explained [here](http://blog.shinetech.com/2015/07/07/es6-with-babel-js/). Any ES6 module patches are currently maintained in the [es6-modules branch](https://github.com/openpgpjs/openpgpjs/compare/es6...es6-modules) until after we review/merge some other open PRs.**