### PR TITLE
Promise polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
       env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='0.12'
     - node_js: "4.2"
       env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='4.2'
+    - node_js: "5"
+      env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='5'
     - node_js: "0.12"
       env: OPENPGPJSTEST='end2end-0' BROWSER='firefox 38'
     - node_js: "0.12"
@@ -37,6 +39,7 @@ matrix:
       env: OPENPGPJSTEST='end2end-13' BROWSER='iphone 9.1'
   allow_failures:
     - env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='4.2'
+    - env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='5'
     - env: OPENPGPJSTEST='end2end-0' BROWSER='firefox 38'
     - env: OPENPGPJSTEST='end2end-1' BROWSER='firefox 42'
     - env: OPENPGPJSTEST='end2end-2' BROWSER='firefox beta'

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fsevents": "^1.0.6"
   },
   "dependencies": {
-    "es6-promise": "~3.0.2",
+    "es6-promise": "^1.0.0",
     "node-fetch": "^1.3.3",
     "node-localstorage": "~1.1.2",
     "zlibjs": "~0.2.0"

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -41,10 +41,7 @@ var armor = require('./encoding/armor.js'),
   util = require('./util'),
   AsyncProxy = require('./worker/async_proxy.js');
 
-if (typeof Promise === 'undefined') {
-  // load ES6 Promises polyfill
-  require('es6-promise').polyfill();
-}
+require('es6-promise').polyfill(); // load ES6 Promises polyfill
 
 var asyncProxy = null; // instance of the asyncproxy
 


### PR DESCRIPTION
This PR goes back to using v1.0.0 of the es6-promise polyfill since the newer version break the phantom.js tests on hoodiecrow. It also adds node v5 to the travis build as an optional build.