### PR TITLE
Only use required files in bower main array

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,7 @@
   ],
   "description": "OpenPGP.js is a Javascript implementation of the OpenPGP protocol. This is defined in RFC 4880.",
   "main": [
-    "dist/openpgp.js",
-    "dist/openpgp.worker.js",
-    "dist/openpgp.min.js",
-    "dist/openpgp.worker.min.js"
+    "dist/openpgp.js"
   ],
   "moduleType": [
     "amd",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "openpgp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "LGPL-3.0+",
   "homepage": "http://openpgpjs.org/",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,7 @@
     "OpenPGP Development Team <list@openpgpjs.org> (https://github.com/openpgpjs/openpgpjs/graphs/contributors)"
   ],
   "description": "OpenPGP.js is a Javascript implementation of the OpenPGP protocol. This is defined in RFC 4880.",
-  "main": [
-    "dist/openpgp.js"
-  ],
+  "main": "dist/openpgp.js",
   "moduleType": [
     "amd",
     "es6",


### PR DESCRIPTION
This is because of `wiredep`. Don't know if this fits your repository requirements.