### PR TITLE
allow to use worker from blob url

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,19 +108,22 @@ module.exports = function(grunt) {
           to: 'OpenPGP.js v<%= pkg.version %>'
         }]
       },
-      worker_min: {
-        src: ['dist/openpgp.worker.min.js'],
-        dest: ['dist/openpgp.worker.min.js'],
+      openpgp_min: {
+        src: ['dist/openpgp.js'],
+        dest: ['dist/openpgp.min.js'],
         replacements: [{
-          from: "importScripts('openpgp.js')",
-          to: "importScripts('openpgp.min.js')"
+          from: "'openpgp.worker.js'",
+          to: "'openpgp.worker.min.js'"
+        }, {
+          from: "'openpgp.js'",
+          to: "'openpgp.min.js'"
         }]
       }
     },
     uglify: {
       openpgp: {
         files: {
-          'dist/openpgp.min.js' : [ 'dist/openpgp.js' ],
+          'dist/openpgp.min.js' : [ 'dist/openpgp.min.js' ],
           'dist/openpgp.worker.min.js' : [ 'dist/openpgp.worker.min.js' ]
         }
       },

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -54,11 +54,12 @@ let asyncProxy; // instance of the asyncproxy
 /**
  * Set the path for the web worker script and create an instance of the async proxy
  * @param {String} path     relative path to the worker scripts, default: 'openpgp.worker.js'
+ * @param {String} pgpPath  relative path to OpenPGP.js, default: 'openpgp.js'
  * @param {Object} worker   alternative to path parameter: web worker initialized with 'openpgp.worker.js'
  */
-export function initWorker({ path='openpgp.worker.js', worker } = {}) {
+export function initWorker({ path='openpgp.worker.js', pgpPath='openpgp.js', worker } = {}) {
   if (worker || typeof window !== 'undefined' && window.Worker) {
-    asyncProxy = new AsyncProxy({ path, worker, config });
+    asyncProxy = new AsyncProxy({ path, pgpPath, worker, config });
     return true;
   }
 }

--- a/src/worker/async_proxy.js
+++ b/src/worker/async_proxy.js
@@ -28,16 +28,18 @@ const INITIAL_RANDOM_SEED = 50000, // random bytes seeded to worker
  * Initializes a new proxy and loads the web worker
  * @constructor
  * @param {String} path     The path to the worker or 'openpgp.worker.js' by default
+ * @param {String} pgpPath  The path to OpenPGP.js or 'openpgp.js' by default
  * @param {Object} config   config The worker configuration
  * @param {Object} worker   alternative to path parameter: web worker initialized with 'openpgp.worker.js'
  * @return {Promise}
  */
-export default function AsyncProxy({ path='openpgp.worker.js', worker, config } = {}) {
+export default function AsyncProxy({ path='openpgp.worker.js', pgpPath='openpgp.js', worker, config } = {}) {
   this.worker = worker || new Worker(path);
   this.worker.onmessage = this.onMessage.bind(this);
   this.worker.onerror = e => {
     throw new Error('Unhandled error in openpgp worker: ' + e.message + ' (' + e.filename + ':' + e.lineno + ')');
   };
+  this.loadOpenPGP(pgpPath);
   this.seedRandom(INITIAL_RANDOM_SEED);
   // FIFO
   this.tasks = [];
@@ -67,6 +69,14 @@ AsyncProxy.prototype.onMessage = function(event) {
     default:
       throw new Error('Unknown Worker Event.');
   }
+};
+
+/**
+ * Send message to worker with url of openpgp.js
+ * @param  {String} url Url of OpenPGP.js
+ */
+AsyncProxy.prototype.loadOpenPGP = function(url) {
+  this.worker.postMessage({ event:'openpgp-url', url });
 };
 
 /**

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -24,25 +24,17 @@ var MAX_SIZE_RANDOM_BUFFER = 60000;
 
 var openpgp;
 
-function importOpenPGP(url) {
-  importScripts(url || 'openpgp.js');
-  openpgp = window.openpgp;
-  openpgp.crypto.random.randomBuffer.init(MAX_SIZE_RANDOM_BUFFER);
-}
-
-if (location.protocol !== 'blob:') {
-  importOpenPGP();
-}
-
 self.onmessage = function (event) {
   var msg = event.data || {},
       options = msg.options || {};
 
   switch (msg.event) {
     case 'openpgp-url':
-      if (!window.openpgp) {
+      if (!window.openpgp && msg.url) {
         var onmessage = self.onmessage;
-        importOpenPGP(msg.url);
+        importScripts(msg.url);
+        openpgp = window.openpgp;
+        openpgp.crypto.random.randomBuffer.init(MAX_SIZE_RANDOM_BUFFER);
         self.onmessage = onmessage;
       }
       break;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -19,19 +19,34 @@
 
 self.window = {}; // to make UMD bundles work
 
-importScripts('openpgp.js');
-var openpgp = window.openpgp;
-
 var MIN_SIZE_RANDOM_BUFFER = 40000;
 var MAX_SIZE_RANDOM_BUFFER = 60000;
 
-openpgp.crypto.random.randomBuffer.init(MAX_SIZE_RANDOM_BUFFER);
+var openpgp;
+
+function importOpenPGP(url) {
+  importScripts(url || 'openpgp.js');
+  openpgp = window.openpgp;
+  openpgp.crypto.random.randomBuffer.init(MAX_SIZE_RANDOM_BUFFER);
+}
+
+if (location.protocol !== 'blob:') {
+  importOpenPGP();
+}
 
 self.onmessage = function (event) {
   var msg = event.data || {},
       options = msg.options || {};
 
   switch (msg.event) {
+    case 'openpgp-url':
+      if (!window.openpgp) {
+        var onmessage = self.onmessage;
+        importOpenPGP(msg.url);
+        self.onmessage = onmessage;
+      }
+      break;
+
     case 'configure':
       for (var i in msg.config) {
         openpgp.config[i] = msg.config[i];


### PR DESCRIPTION
This allows to use the worker when serving from `file://` to allow portable mini apps.

``` html
<script id='openpgp-worker' type='text/javascript-worker'>// openpgp.worker.js</script>
<script id='openpgp' type='text/javascript'>// openpgp.js</script>
<script>
  var worker = new Worker(
    window.URL.createObjectURL(
      new Blob([document.getElementById('openpgp-worker').innerHTML],
               { type: 'text/javascript' })));
  worker.postMessage({ event: 'openpgp-url', 
                       url: window.URL.createObjectURL(
                         new Blob([document.getElementById('openpgp').innerHTML],
                                  { type: 'text/javascript' })) });
  openpgp.initWorker({ worker: worker });
</script>
```
