### PR TITLE
Add support for binary data in v1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   fast_finish: true
   include:
     - node_js: "0.12"
-      env: OPENPGPJSTEST='coverage' OPENPGP_NODE_JS='0.12'
+      env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='0.12'
     - node_js: "4.2"
       env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='4.2'
     - node_js: "5"

--- a/src/message.js
+++ b/src/message.js
@@ -128,6 +128,15 @@ Message.prototype.getLiteralData = function() {
 };
 
 /**
+ * Get filename from literal data packet
+ * @return {(String|null)} filename of literal data packet as string
+ */
+Message.prototype.getFilename = function() {
+  var literal = this.packets.findPacket(enums.packet.literal);
+  return literal && literal.getFilename() || null;
+};
+
+/**
  * Get literal data as text
  * @return {(String|null)} literal body of the message interpreted as text
  */

--- a/src/worker/async_proxy.js
+++ b/src/worker/async_proxy.js
@@ -133,8 +133,10 @@ AsyncProxy.prototype.terminate = function() {
  * Encrypts message text with keys
  * @param  {(Array<module:key~Key>|module:key~Key)}  keys array of keys or single key, used to encrypt the message
  * @param  {String} text message as native JavaScript string
+ * @param  {String} format     (optional) The input format either 'utf8' or 'binary'.
+ * @param  {String} filename   (optional) The filename of the encrypted data
  */
-AsyncProxy.prototype.encryptMessage = function(keys, text) {
+AsyncProxy.prototype.encryptMessage = function(keys, text, format, filename) {
   var self = this;
 
   return self.execute(function() {
@@ -147,7 +149,9 @@ AsyncProxy.prototype.encryptMessage = function(keys, text) {
     self.worker.postMessage({
       event: 'encrypt-message',
       keys: keys,
-      text: text
+      text: text,
+      format: format,
+      filename: filename
     });
   });
 };
@@ -157,8 +161,10 @@ AsyncProxy.prototype.encryptMessage = function(keys, text) {
  * @param  {(Array<module:key~Key>|module:key~Key)}  publicKeys array of keys or single key, used to encrypt the message
  * @param  {module:key~Key}    privateKey private key with decrypted secret key data for signing
  * @param  {String} text       message as native JavaScript string
+ * @param  {String} format     (optional) The input format either 'utf8' or 'binary'.
+ * @param  {String} filename   (optional) The filename of the encrypted data
  */
-AsyncProxy.prototype.signAndEncryptMessage = function(publicKeys, privateKey, text) {
+AsyncProxy.prototype.signAndEncryptMessage = function(publicKeys, privateKey, text, format, filename) {
   var self = this;
 
   return self.execute(function() {
@@ -173,7 +179,9 @@ AsyncProxy.prototype.signAndEncryptMessage = function(publicKeys, privateKey, te
       event: 'sign-and-encrypt-message',
       publicKeys: publicKeys,
       privateKey: privateKey,
-      text: text
+      text: text,
+      format: format,
+      filename: filename
     });
   });
 };
@@ -182,8 +190,9 @@ AsyncProxy.prototype.signAndEncryptMessage = function(publicKeys, privateKey, te
  * Decrypts message
  * @param  {module:key~Key}     privateKey private key with decrypted secret key data
  * @param  {module:message~Message} message    the message object with the encrypted data
+ * @param  {String} format     (optional) The input format either 'utf8' or 'binary'.
  */
-AsyncProxy.prototype.decryptMessage = function(privateKey, message) {
+AsyncProxy.prototype.decryptMessage = function(privateKey, message, format) {
   var self = this;
 
   return self.execute(function() {
@@ -191,7 +200,8 @@ AsyncProxy.prototype.decryptMessage = function(privateKey, message) {
     self.worker.postMessage({
       event: 'decrypt-message',
       privateKey: privateKey,
-      message: message
+      message: message,
+      format: format
     });
   });
 };
@@ -201,8 +211,9 @@ AsyncProxy.prototype.decryptMessage = function(privateKey, message) {
  * @param  {module:key~Key}     privateKey private key with decrypted secret key data
  * @param  {(Array<module:key~Key>|module:key~Key)}  publicKeys array of keys or single key to verify signatures
  * @param  {module:message~Message} message    the message object with signed and encrypted data
+ * @param  {String} format     (optional) The input format either 'utf8' or 'binary'.
  */
-AsyncProxy.prototype.decryptAndVerifyMessage = function(privateKey, publicKeys, message) {
+AsyncProxy.prototype.decryptAndVerifyMessage = function(privateKey, publicKeys, message, format) {
   var self = this;
 
   var promise = new Promise(function(resolve, reject) {
@@ -217,7 +228,8 @@ AsyncProxy.prototype.decryptAndVerifyMessage = function(privateKey, publicKeys, 
       event: 'decrypt-and-verify-message',
       privateKey: privateKey,
       publicKeys: publicKeys,
-      message: message
+      message: message,
+      format: format
     });
 
     self.tasks.push({ resolve:function(data) {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -69,7 +69,7 @@ self.onmessage = function (event) {
         msg.keys = [msg.keys];
       }
       msg.keys = msg.keys.map(packetlistCloneToKey);
-      window.openpgp.encryptMessage(msg.keys, msg.text).then(function(data) {
+      window.openpgp.encryptMessage(msg.keys, msg.text, msg.format, msg.filename).then(function(data) {
         response({event: 'method-return', data: data});
       }).catch(function(e) {
         response({event: 'method-return', err: e.message});
@@ -81,7 +81,7 @@ self.onmessage = function (event) {
       }
       msg.publicKeys = msg.publicKeys.map(packetlistCloneToKey);
       msg.privateKey = packetlistCloneToKey(msg.privateKey);
-      window.openpgp.signAndEncryptMessage(msg.publicKeys, msg.privateKey, msg.text).then(function(data) {
+      window.openpgp.signAndEncryptMessage(msg.publicKeys, msg.privateKey, msg.text, msg.format, msg.filename).then(function(data) {
         response({event: 'method-return', data: data});
       }).catch(function(e) {
         response({event: 'method-return', err: e.message});
@@ -90,7 +90,7 @@ self.onmessage = function (event) {
     case 'decrypt-message':
       msg.privateKey = packetlistCloneToKey(msg.privateKey);
       msg.message = packetlistCloneToMessage(msg.message.packets);
-      window.openpgp.decryptMessage(msg.privateKey, msg.message).then(function(data) {
+      window.openpgp.decryptMessage(msg.privateKey, msg.message, msg.format).then(function(data) {
         response({event: 'method-return', data: data});
       }).catch(function(e) {
         response({event: 'method-return', err: e.message});
@@ -103,7 +103,7 @@ self.onmessage = function (event) {
       }
       msg.publicKeys = msg.publicKeys.map(packetlistCloneToKey);
       msg.message = packetlistCloneToMessage(msg.message.packets);
-      window.openpgp.decryptAndVerifyMessage(msg.privateKey, msg.publicKeys, msg.message).then(function(data) {
+      window.openpgp.decryptAndVerifyMessage(msg.privateKey, msg.publicKeys, msg.message, msg.format).then(function(data) {
         response({event: 'method-return', data: data});
       }).catch(function(e) {
         response({event: 'method-return', err: e.message});

--- a/test/worker/api.js
+++ b/test/worker/api.js
@@ -333,6 +333,42 @@ describe('High level API', function() {
 
   });
 
+
+  describe('Sign and Encrypt binary data', function() {
+
+    var pt = 'binary_string';
+    var format = 'binary';
+    var filename = 'foo.txt';
+
+    before(function() {
+      privKeyRSA.decrypt('hello world');
+    });
+
+    it('Encrypt/Decrypt binary data with filename', function (done) {
+      openpgp.encryptMessage([pubKeyRSA], pt, format, filename).then(function(encrypted) {
+        var msg = openpgp.message.readArmored(encrypted);
+        return openpgp.decryptMessage(privKeyRSA, msg, format);
+      }).then(function(decrypted) {
+        expect(decrypted.text).to.equal(pt);
+        expect(decrypted.filename).to.equal(filename);
+        done();
+      });
+    });
+
+    it('EncryptAndSign/DecryptAndVerify binary data with filename', function (done) {
+      openpgp.signAndEncryptMessage([pubKeyRSA], privKeyRSA, pt, format, filename).then(function(encrypted) {
+        var msg = openpgp.message.readArmored(encrypted);
+        return openpgp.decryptAndVerifyMessage(privKeyRSA, [pubKeyRSA], msg, format);
+      }).then(function(decrypted) {
+        expect(decrypted.text).to.equal(pt);
+        expect(decrypted.filename).to.equal(filename);
+        expect(decrypted.signatures[0].valid).to.be.true;
+        done();
+      });
+    });
+
+  });
+
   describe('Signing', function() {
 
     before(function() {


### PR DESCRIPTION
We backported support for binary data to the v1.x branch, because v2.x has not undergone a security audit yet, but Mailvelope needs to ship file encryption.

@toberndo please review and test if this patch implements all your requirements. After we merge, I'll release v1.6.0

Thanks