### PR TITLE
Implement feature #443

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -377,6 +377,7 @@ Key.prototype.encrypt = function(passphrase) {
   var keys = this.getAllKeyPackets();
   for (var i = 0; i < keys.length; i++) {
     keys[i].encrypt(passphrase);
+    keys[i].clearPrivateMPIs();
   }
 };
 

--- a/src/key.js
+++ b/src/key.js
@@ -374,16 +374,11 @@ Key.prototype.encrypt = function(passphrase) {
   if (this.isPrivate()) {
     var keys = this.getAllKeyPackets();
     for (var i = 0; i < keys.length; i++) {
-      try {
-        keys[i].encrypt(passphrase);
-      } catch (e) {
-        return false;
-      }
+      keys[i].encrypt(passphrase);
     }
   } else {
     throw new Error("Nothing to encrypt in a public key");
   }
-  return true;
 };
 
 /**

--- a/src/key.js
+++ b/src/key.js
@@ -366,6 +366,27 @@ Key.prototype.getEncryptionKeyPacket = function() {
 };
 
 /**
+ * Encrypts all secret key and subkey packets
+ * @param  {String} passphrase
+ * @return {Boolean} true if all key and subkey packets encrypted successfully
+ */
+Key.prototype.encrypt = function(passphrase) {
+  if (this.isPrivate()) {
+    var keys = this.getAllKeyPackets();
+    for (var i = 0; i < keys.length; i++) {
+      try {
+        keys[i].encrypt(passphrase);
+      } catch (e) {
+        return false;
+      }
+    }
+  } else {
+    throw new Error("Nothing to encrypt in a public key");
+  }
+  return true;
+};
+
+/**
  * Decrypts all secret key and subkey packets
  * @param  {String} passphrase
  * @return {Boolean} true if all key and subkey packets decrypted successfully

--- a/src/key.js
+++ b/src/key.js
@@ -368,7 +368,6 @@ Key.prototype.getEncryptionKeyPacket = function() {
 /**
  * Encrypts all secret key and subkey packets
  * @param  {String} passphrase
- * @return {Boolean} true if all key and subkey packets encrypted successfully
  */
 Key.prototype.encrypt = function(passphrase) {
   if (this.isPrivate()) {
@@ -376,8 +375,6 @@ Key.prototype.encrypt = function(passphrase) {
     for (var i = 0; i < keys.length; i++) {
       keys[i].encrypt(passphrase);
     }
-  } else {
-    throw new Error("Nothing to encrypt in a public key");
   }
 };
 

--- a/src/key.js
+++ b/src/key.js
@@ -370,11 +370,13 @@ Key.prototype.getEncryptionKeyPacket = function() {
  * @param  {String} passphrase
  */
 Key.prototype.encrypt = function(passphrase) {
-  if (this.isPrivate()) {
-    var keys = this.getAllKeyPackets();
-    for (var i = 0; i < keys.length; i++) {
-      keys[i].encrypt(passphrase);
-    }
+  if (!this.isPrivate()) {
+    throw new Error("Nothing to encrypt in a public key");
+  }
+
+  var keys = this.getAllKeyPackets();
+  for (var i = 0; i < keys.length; i++) {
+    keys[i].encrypt(passphrase);
   }
 };
 

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -199,7 +199,6 @@ SecretKey.prototype.encrypt = function (passphrase) {
   arr.push(crypto.cfb.normalEncrypt(symmetric, key, cleartext, iv));
 
   this.encrypted = util.concatUint8Array(arr);
-  this.isDecrypted = false;
 };
 
 function produceEncryptionKey(s2k, passphrase, algorithm) {

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -199,6 +199,7 @@ SecretKey.prototype.encrypt = function (passphrase) {
   arr.push(crypto.cfb.normalEncrypt(symmetric, key, cleartext, iv));
 
   this.encrypted = util.concatUint8Array(arr);
+  this.isDecrypted = false;
 };
 
 function produceEncryptionKey(s2k, passphrase, algorithm) {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -716,9 +716,13 @@ var pgp_desktop_priv =
       var armor2 = key.armor();
       expect(armor1).to.equal(armor2);
       expect(key.decrypt('passphrase')).to.be.true;
+      expect(key.primaryKey.isDecrypted).to.be.true;
       expect(key.encrypt('new_passphrase')).to.be.true;
+      expect(key.primaryKey.isDecrypted).to.be.false;
       expect(key.decrypt('passphrase')).to.be.false;
+      expect(key.primaryKey.isDecrypted).to.be.false;
       expect(key.decrypt('new_passphrase')).to.be.true;
+      expect(key.primaryKey.isDecrypted).to.be.true;
       var armor3 = key.armor();
       expect(armor3).to.not.equal(armor1);
       done();

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -717,7 +717,7 @@ var pgp_desktop_priv =
       expect(armor1).to.equal(armor2);
       expect(key.decrypt('passphrase')).to.be.true;
       expect(key.primaryKey.isDecrypted).to.be.true;
-      expect(key.encrypt('new_passphrase')).to.be.true;
+      key.encrypt('new_passphrase');
       expect(key.primaryKey.isDecrypted).to.be.false;
       expect(key.decrypt('passphrase')).to.be.false;
       expect(key.primaryKey.isDecrypted).to.be.false;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -706,5 +706,24 @@ var pgp_desktop_priv =
     }).catch(done);
   });
 
+  it('Encrypt key with new passphrase', function(done) {
+    var userId = 'test <a@b.com>';
+    var opt = {numBits: 512, userIds: userId, passphrase: 'passphrase'};
+    if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
+    openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
+      var armor1 = key.armor();
+      var armor2 = key.armor();
+      expect(armor1).to.equal(armor2);
+      expect(key.decrypt('passphrase')).to.be.true;
+      expect(key.encrypt('new_passphrase')).to.be.true;
+      expect(key.decrypt('passphrase')).to.be.false;
+      expect(key.decrypt('new_passphrase')).to.be.true;
+      var armor3 = key.armor();
+      expect(armor3).to.not.equal(armor1);
+      done();
+    }).catch(done);
+  });
+
 });
 


### PR DESCRIPTION
This pull request implement a Key API to the key with a passphrased following the same encrypt API.

This way combining `decrypt``+ `encrypt` one could easily and securely change the passphrase.

The pull request include the unit tests.


@tanx could you take care of review this and eventually push this out in the next useful release?