### PR TITLE
Only polyfill ES6 Promises when required

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -39,7 +39,10 @@ import config from './config/config.js';
 import util from './util';
 import AsyncProxy from './worker/async_proxy.js';
 import es6Promise from 'es6-promise';
-es6Promise.polyfill(); // load ES6 Promises polyfill
+
+if (typeof Promise === 'undefined') {
+  es6Promise.polyfill(); // load ES6 Promises
+}
 
 
 //////////////////////////


### PR DESCRIPTION
I thought the module `es6-promise` already did this check internally. But it seems to cause problems under node.js v4.x.
Resolves openpgpjs/openpgpjs#455