### PR TITLE
Iterate `signingKeyPacket` for signaturePackets

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -334,6 +334,7 @@ Message.prototype.sign = function(privateKeys) {
     if (!signingKeyPacket.isDecrypted) {
       throw new Error('Private key is not decrypted.');
     }
+    signingKeyPacket = privateKeys[i].getSigningKeyPacket();
     signaturePacket.sign(signingKeyPacket, literalDataPacket);
     packetlist.push(signaturePacket);
   }


### PR DESCRIPTION
For each generated `signaturePacket`, the corresponding `signingKeyPacket`
has to be used. Fixed https://github.com/openpgpjs/openpgpjs/issues/451.

This fix is quick but not so efficient since `getSigningKeyPacket` is called
twice for each private key. But in most cases message may not be signed
with too many private keys.

Also some test cases should be added in the future for validating such
signing scenarios.
