### PR TITLE
Invalidate expired primary keys

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -358,7 +358,7 @@ Key.prototype.getEncryptionKeyPacket = function() {
   }
   // if no valid subkey for encryption, evaluate primary key
   var primaryUser = this.getPrimaryUser();
-  if (primaryUser &&
+  if (primaryUser && primaryUser.selfCertificate && !primaryUser.selfCertificate.isExpired &&
       isValidEncryptionKeyPacket(this.primaryKey, primaryUser.selfCertificate)) {
     return this.primaryKey;
   }


### PR DESCRIPTION
Relates to #468 
Checks primary key's expiration time and invalidates the key if it has expired (this was already being done for subkeys)