### PR TITLE
S2K - Only generate what is needed

### DIFF
--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -189,7 +189,7 @@ S2K.prototype.produce_key = function (passphrase, numBytes) {
   }
   i = 0;
 
-  while (rlength <= numBytes) {
+  while (rlength < numBytes) {
     var result = round(prefix.subarray(0,i), this);
     arr.push(result);
     rlength += result.length;


### PR DESCRIPTION
In a typical scenario 32 bytes is needed(numBytes), and `round` generates 32 bytes via SHA256.

However `round` is currently called twice in this scenario, generating 64 bytes, and the last 32 bytes is then thrown away in the return.