### PR TITLE
Detached Signatures

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -48,7 +48,7 @@ export function CleartextMessage(text, signature) {
   if (signature && !(signature instanceof sigModule.Signature)) {
     throw new Error('Invalid signature input');
   }
-  this.signature = signature || new sigModule.Signature([]);
+  this.signature = signature || new sigModule.Signature(new packet.List());
 }
 
 /**

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -69,6 +69,15 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
  */
 CleartextMessage.prototype.sign = function(privateKeys) {
+  this.signature = this.signDetached(privateKeys);
+};
+
+/**
+ * Sign the cleartext message
+ * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
+ * @return {module:signature~Signature}      new detached signature of message content
+ */
+CleartextMessage.prototype.signDetached = function(privateKeys) {
   var packetlist = new packet.List();
   var literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
@@ -87,7 +96,7 @@ CleartextMessage.prototype.sign = function(privateKeys) {
     signaturePacket.sign(signingKeyPacket, literalDataPacket);
     packetlist.push(signaturePacket);
   }
-  this.signature = new sigModule.Signature(packetlist);
+  return new sigModule.Signature(packetlist);
 };
 
 /**
@@ -96,8 +105,17 @@ CleartextMessage.prototype.sign = function(privateKeys) {
  * @return {Array<{keyid: module:type/keyid, valid: Boolean}>} list of signer's keyid and validity of signature
  */
 CleartextMessage.prototype.verify = function(keys) {
+  return this.verifyDetached(this.signature, keys);
+};
+
+/**
+ * Verify signatures of cleartext signed message
+ * @param {Array<module:key~Key>} keys array of keys to verify signatures
+ * @return {Array<{keyid: module:type/keyid, valid: Boolean}>} list of signer's keyid and validity of signature
+ */
+CleartextMessage.prototype.verifyDetached = function(signature, keys) {
   var result = [];
-  var signatureList = this.signature.packets;
+  var signatureList = signature.packets;
   var literalDataPacket = new packet.Literal();
   // we assume that cleartext signature is generated based on UTF8 cleartext
   literalDataPacket.setText(this.text);

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -136,6 +136,8 @@ CleartextMessage.prototype.verifyDetached = function(signature, keys) {
       verifiedSig.keyid = signatureList[i].issuerKeyId;
       verifiedSig.valid = null;
     }
+    verifiedSig.signature = new sigModule.Signature([signatureList[i]]);
+
     result.push(verifiedSig);
   }
   return result;

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -62,10 +62,7 @@ function getType(text) {
     return enums.armor.multipart_last;
 
   } else
-  // BEGIN PGP SIGNATURE
-  // Used for detached signatures, OpenPGP/MIME signatures, and
-  // cleartext signatures. Note that PGP 2.x uses BEGIN PGP MESSAGE
-  // for detached signatures.
+  // BEGIN PGP SIGNED MESSAGE
   if (/SIGNED MESSAGE/.test(header[1])) {
     return enums.armor.signed;
 
@@ -86,6 +83,14 @@ function getType(text) {
   // Used for armoring private keys.
   if (/PRIVATE KEY BLOCK/.test(header[1])) {
     return enums.armor.private_key;
+
+  } else
+  // BEGIN PGP SIGNATURE
+  // Used for detached signatures, OpenPGP/MIME signatures, and
+  // cleartext signatures. Note that PGP 2.x uses BEGIN PGP MESSAGE
+  // for detached signatures.
+  if (/SIGNATURE/.test(header[1])) {
+    return enums.armor.signature;
   }
 }
 
@@ -396,6 +401,13 @@ function armor(messagetype, body, partindex, parttotal) {
       result.push(base64.encode(body));
       result.push("\r\n=" + getCheckSum(body) + "\r\n");
       result.push("-----END PGP PRIVATE KEY BLOCK-----\r\n");
+      break;
+    case enums.armor.signature:
+      result.push("-----BEGIN PGP SIGNATURE-----\r\n");
+      result.push(addheader());
+      result.push(base64.encode(body));
+      result.push("\r\n=" + getCheckSum(body) + "\r\n");
+      result.push("-----END PGP SIGNATURE-----\r\n");
       break;
   }
 

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -38,6 +38,7 @@ import config from '../config';
  *         3 = PGP MESSAGE
  *         4 = PUBLIC KEY BLOCK
  *         5 = PRIVATE KEY BLOCK
+ *         6 = SIGNATURE
  */
 function getType(text) {
   var reHeader = /^-----BEGIN PGP (MESSAGE, PART \d+\/\d+|MESSAGE, PART \d+|SIGNED MESSAGE|MESSAGE|PUBLIC KEY BLOCK|PRIVATE KEY BLOCK|SIGNATURE)-----$\n/m;

--- a/src/enums.js
+++ b/src/enums.js
@@ -297,7 +297,8 @@ export default {
     signed: 2,
     message: 3,
     public_key: 4,
-    private_key: 5
+    private_key: 5,
+    signature: 6
   },
 
   /** Asserts validity and converts from string/integer to integer. */

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,13 @@ import * as keyMod from './key';
 export const key = keyMod;
 
 /**
+ * @see module:signature
+ * @name module:openpgp.signature
+ */
+import * as signatureMod from './signature';
+export const signature = signatureMod;
+
+/**
  * @see module:message
  * @name module:openpgp.message
  */

--- a/src/message.js
+++ b/src/message.js
@@ -32,7 +32,7 @@ import enums from './enums.js';
 import armor from './encoding/armor.js';
 import config from './config';
 import crypto from './crypto';
-import signature from './signature.js';
+import * as sigModule from './signature.js';
 import * as keyModule from './key.js';
 
 /**
@@ -376,7 +376,7 @@ Message.prototype.signDetached = function(privateKeys) {
     packetlist.push(signaturePacket);
   }
 
-  return new signature.Signature(packetlist);
+  return new sigModule.Signature(packetlist);
 };
 
 

--- a/src/message.js
+++ b/src/message.js
@@ -431,12 +431,15 @@ function createVerificationObjects(signatureList, literalDataList, keys) {
 
     var verifiedSig = {};
     if (keyPacket) {
+      //found a key packet that matches keyId of signature
       verifiedSig.keyid = signatureList[i].issuerKeyId;
       verifiedSig.valid = signatureList[i].verify(keyPacket, literalDataList[0]);
     } else {
       verifiedSig.keyid = signatureList[i].issuerKeyId;
       verifiedSig.valid = null;
     }
+    verifiedSig.signature = new sigModule.Signature([signatureList[i]]);
+
     result.push(verifiedSig);
   }
   return result;

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -189,7 +189,7 @@ export function encrypt({ data, publicKeys, privateKeys, passwords, filename, ar
   checkData(data); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords);
 
   if (!nativeAEAD() && asyncProxy) { // use web worker if web crypto apis are not supported
-    return asyncProxy.delegate('encrypt', { data, publicKeys, privateKeys, passwords, filename, armor });
+    return asyncProxy.delegate('encrypt', { data, publicKeys, privateKeys, passwords, filename, armor, detached });
   }
   var result = {};
   return Promise.resolve().then(() => {
@@ -237,7 +237,7 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
   checkMessage(message); publicKeys = toArray(publicKeys);
 
   if (!nativeAEAD() && asyncProxy) { // use web worker if web crypto apis are not supported
-    return asyncProxy.delegate('decrypt', { message, privateKey, publicKeys, sessionKey, password, format });
+    return asyncProxy.delegate('decrypt', { message, privateKey, publicKeys, sessionKey, password, format, signature });
   }
 
   return message.decrypt(privateKey, sessionKey, password).then(message => {
@@ -279,7 +279,7 @@ export function sign({ data, privateKeys, armor=true, detached=false}) {
   privateKeys = toArray(privateKeys);
 
   if (asyncProxy) { // use web worker if available
-    return asyncProxy.delegate('sign', { data, privateKeys, armor });
+    return asyncProxy.delegate('sign', { data, privateKeys, armor, detached });
   }
 
   var result = {};
@@ -322,7 +322,7 @@ export function verify({ message, publicKeys, signature=null }) {
   publicKeys = toArray(publicKeys);
 
   if (asyncProxy) { // use web worker if available
-    return asyncProxy.delegate('verify', { message, publicKeys });
+    return asyncProxy.delegate('verify', { message, publicKeys, signature });
   }
 
   var result = {};

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -243,7 +243,7 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
   return message.decrypt(privateKey, sessionKey, password).then(message => {
 
     const result = parseMessage(message, format);
-    if (publicKeys && result.data) { // verify only if publicKeys are specified
+    if (result.data) { // verify
       if (signature) {
         //detached signature
         result.signatures = message.verifyDetached(signature, publicKeys);

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -178,36 +178,44 @@ export function decryptKey({ privateKey, passphrase }) {
  * @param  {Key|Array<Key>} privateKeys       (optional) private keys for signing. If omitted message will not be signed
  * @param  {String|Array<String>} passwords   (optional) array of passwords or a single password to encrypt the message
  * @param  {String} filename                  (optional) a filename for the literal data packet
- * @param  {Boolean} armor                    (optional) if the return value should be ascii armored or the message object
- * @return {Promise<String|Message>}          encrypted ASCII armored message, or the full Message object if 'armor' is false
+ * @param  {Boolean} armor                    (optional) if the return values should be ascii armored or the message/signature objects
+ * @param  {Boolean} detached                 (optional) if the signature should be detached (if true, signature will be added to returned object)
+ * @return {Promise<Object>}                  encrypted (and optionally signed message) in the form:
+ *                                              {data: ASCII armored message if 'armor' is true,
+ *                                                message: full Message object if 'armor' is false, signature: detached signature if 'detached' is true}
  * @static
  */
-export function encrypt({ data, publicKeys, privateKeys, passwords, filename, armor=true }) {
+export function encrypt({ data, publicKeys, privateKeys, passwords, filename, armor=true, detached=false }) {
   checkData(data); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords);
 
   if (!nativeAEAD() && asyncProxy) { // use web worker if web crypto apis are not supported
     return asyncProxy.delegate('encrypt', { data, publicKeys, privateKeys, passwords, filename, armor });
   }
-
+  var result = {};
   return Promise.resolve().then(() => {
 
     let message = createMessage(data, filename);
     if (privateKeys) { // sign the message only if private keys are specified
-      message = message.sign(privateKeys);
+      if (detached) {
+        var signature = message.signDetached(privateKeys);
+        if (armor) {
+          result.signature = signature.armor();
+        } else {
+          result.signature = signature;
+        }
+      } else {
+        message = message.sign(privateKeys);
+      }
     }
     return message.encrypt(publicKeys, passwords);
 
   }).then(message => {
-
-    if(armor) {
-      return {
-        data: message.armor()
-      };
+    if (armor) {
+      result.data = message.armor();
+    } else {
+      result.message = message;
     }
-    return {
-      message: message
-    };
-
+    return result;
   }).catch(onError.bind(null, 'Error encrypting message'));
 }
 
@@ -220,11 +228,12 @@ export function encrypt({ data, publicKeys, privateKeys, passwords, filename, ar
  * @param  {Object} sessionKey           (optional) session key in the form: { data:Uint8Array, algorithm:String }
  * @param  {String} password             (optional) single password to decrypt the message
  * @param  {String} format               (optional) return data format either as 'utf8' or 'binary'
+ * @param  {Signature} signature         (optional) detached signature for verification
  * @return {Promise<Object>}             decrypted and verified message in the form:
  *                                         { data:Uint8Array|String, filename:String, signatures:[{ keyid:String, valid:Boolean }] }
  * @static
  */
-export function decrypt({ message, privateKey, publicKeys, sessionKey, password, format='utf8' }) {
+export function decrypt({ message, privateKey, publicKeys, sessionKey, password, format='utf8', signature=null }) {
   checkMessage(message); publicKeys = toArray(publicKeys);
 
   if (!nativeAEAD() && asyncProxy) { // use web worker if web crypto apis are not supported
@@ -235,7 +244,12 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
 
     const result = parseMessage(message, format);
     if (publicKeys && result.data) { // verify only if publicKeys are specified
-      result.signatures = message.verify(publicKeys);
+      if (signature) {
+        //detached signature
+        result.signatures = message.verifyDetached(signature, publicKeys);
+      } else {
+        result.signatures = message.verify(publicKeys);
+      }
     }
     return result;
 
@@ -255,10 +269,12 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
  * @param  {String} data                        cleartext input to be signed
  * @param  {Key|Array<Key>} privateKeys         array of keys or single key with decrypted secret key data to sign cleartext
  * @param  {Boolean} armor                      (optional) if the return value should be ascii armored or the message object
- * @return {Promise<String|CleartextMessage>}   ASCII armored message or the message of type CleartextMessage
+ * @return {Promise<Object>}                    signed cleartext in the form:
+ *                                                {data: ASCII armored message if 'armor' is true,
+ *                                                message: full Message object if 'armor' is false, signature: detached signature if 'detached' is true}
  * @static
  */
-export function sign({ data, privateKeys, armor=true }) {
+export function sign({ data, privateKeys, armor=true, detached=false}) {
   checkString(data);
   privateKeys = toArray(privateKeys);
 
@@ -266,19 +282,28 @@ export function sign({ data, privateKeys, armor=true }) {
     return asyncProxy.delegate('sign', { data, privateKeys, armor });
   }
 
+  var result = {};
   return execute(() => {
 
     const cleartextMessage = new cleartext.CleartextMessage(data);
-    cleartextMessage.sign(privateKeys);
 
-    if(armor) {
-      return {
-        data: cleartextMessage.armor()
-      };
+    if (detached) {
+      var signature = cleartextMessage.signDetached(privateKeys);
+      if (armor) {
+        result.signature = signature.armor();
+      } else {
+        result.signature = signature;
+      }
+    } else {
+      cleartextMessage.sign(privateKeys);
     }
-    return {
-      message: cleartextMessage
-    };
+
+    if (armor) {
+      result.data = cleartextMessage.armor();
+    } else {
+      result.message = cleartextMessage;
+    }
+    return result;
 
   }, 'Error signing cleartext message');
 }
@@ -287,11 +312,12 @@ export function sign({ data, privateKeys, armor=true }) {
  * Verifies signatures of cleartext signed message
  * @param  {Key|Array<Key>} publicKeys   array of publicKeys or single key, to verify signatures
  * @param  {CleartextMessage} message    cleartext message object with signatures
+ * @param  {Signature} signature         (optional) detached signature for verification
  * @return {Promise<Object>}             cleartext with status of verified signatures in the form of:
  *                                         { data:String, signatures: [{ keyid:String, valid:Boolean }] }
  * @static
  */
-export function verify({ message, publicKeys }) {
+export function verify({ message, publicKeys, signature=null }) {
   checkCleartextMessage(message);
   publicKeys = toArray(publicKeys);
 
@@ -299,12 +325,19 @@ export function verify({ message, publicKeys }) {
     return asyncProxy.delegate('verify', { message, publicKeys });
   }
 
-  return execute(() => ({
+  var result = {};
+  return execute(() => {
+    result.data = message.getText();
 
-    data: message.getText(),
-    signatures: message.verify(publicKeys)
+    if (signature) {
+      //detached signature
+      result.signatures = message.verifyDetached(signature, publicKeys);
+    } else {
+      result.signatures = message.verify(publicKeys);
+    }
+    return result;
 
-  }), 'Error verifying cleartext signed message');
+  }, 'Error verifying cleartext signed message');
 }
 
 

--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -67,9 +67,16 @@ export function clonePackets(options) {
   if (options.signature && (options.signature instanceof signature.Signature)) {
     options.signature = options.signature.packets;
   }
+  if (options.signatures) {
+    options.signatures = options.signatures.map(sig => verificationObjectToClone(sig));
+  }
   return options;
 }
 
+function verificationObjectToClone(verObject) {
+  verObject.signature = verObject.signature.packets;
+  return verObject;
+}
 
 //////////////////////////////
 //                          //
@@ -129,6 +136,7 @@ function packetlistCloneToCleartextMessage(clone) {
 //verification objects
 function packetlistCloneToSignatures(clone) {
   clone.keyid = type_keyid.fromClone(clone.keyid);
+  clone.signature = new signature.Signature(clone.signature);
   return clone;
 }
 

--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -60,11 +60,11 @@ export function clonePackets(options) {
     //could be either a Message or CleartextMessage object
     if (options.message instanceof message.Message) {
       options.message = options.message.packets;
-    } else {
+    } else if (options.message instanceof cleartext.CleartextMessage) {
       options.message.signature = options.message.signature.packets;
     }
   }
-  if (options.signature) {
+  if (options.signature && (options.signature instanceof signature.Signature)) {
     options.signature = options.signature.packets;
   }
   return options;
@@ -133,6 +133,10 @@ function packetlistCloneToSignatures(clone) {
 }
 
 function packetlistCloneToSignature(clone) {
+  if (typeof clone === "string") {
+    //signature is armored
+    return clone;
+  }
   var packetlist = Packetlist.fromStructuredClone(clone);
   return new signature.Signature(packetlist);
 }

--- a/src/signature.js
+++ b/src/signature.js
@@ -33,9 +33,7 @@ import armor from './encoding/armor.js';
 /**
  * @class
  * @classdesc Class that represents an OpenPGP signature.
- * Can be an encrypted message, signed message, compressed message or literal message
- * @param  {module:packet/packetlist} packetlist The packets that form this message
- * See {@link http://tools.ietf.org/html/rfc4880#section-11.3}
+ * @param  {module:packet/packetlist} packetlist The signature packets
  */
 
 export function Signature(packetlist) {

--- a/src/signature.js
+++ b/src/signature.js
@@ -1,0 +1,78 @@
+// GPG4Browsers - An OpenPGP implementation in javascript
+// Copyright (C) 2011 Recurity Labs GmbH
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+/**
+ * @requires config
+ * @requires crypto
+ * @requires encoding/armor
+ * @requires enums
+ * @requires packet
+ * @module signature
+ */
+
+'use strict';
+
+import packet from './packet';
+import enums from './enums.js';
+import armor from './encoding/armor.js';
+
+/**
+ * @class
+ * @classdesc Class that represents an OpenPGP message.
+ * Can be an encrypted message, signed message, compressed message or literal message
+ * @param  {module:packet/packetlist} packetlist The packets that form this message
+ * See {@link http://tools.ietf.org/html/rfc4880#section-11.3}
+ */
+
+export function Signature(packetlist) {
+  if (!(this instanceof Signature)) {
+    return new Signature(packetlist);
+  }
+  this.packets = packetlist || new packet.List();
+}
+
+
+/**
+ * Returns ASCII armored text of signature
+ * @return {String} ASCII armor
+ */
+Signature.prototype.armor = function() {
+  return armor.encode(enums.armor.signature, this.packets.write());
+};
+
+/**
+ * reads an OpenPGP armored signature and returns a signature object
+ * @param {String} armoredText text to be parsed
+ * @return {module:signature~Signature} new signature object
+ * @static
+ */
+export function readArmored(armoredText) {
+  var input = armor.decode(armoredText).data;
+  return read(input);
+}
+
+/**
+ * reads an OpenPGP signature as byte array and returns a signature object
+ * @param {Uint8Array} input   binary signature
+ * @return {Signature}         new signature object
+ * @static
+ */
+export function read(input) {
+  var packetlist = new packet.List();
+  packetlist.read(input);
+  return new Signature(packetlist);
+}

--- a/src/signature.js
+++ b/src/signature.js
@@ -32,7 +32,7 @@ import armor from './encoding/armor.js';
 
 /**
  * @class
- * @classdesc Class that represents an OpenPGP message.
+ * @classdesc Class that represents an OpenPGP signature.
  * Can be an encrypted message, signed message, compressed message or literal message
  * @param  {module:packet/packetlist} packetlist The packets that form this message
  * See {@link http://tools.ietf.org/html/rfc4880#section-11.3}

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -637,7 +637,8 @@ describe('OpenPGP.js public api tests', function() {
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            expect(decrypted.signatures).to.not.exist;
+            expect(decrypted.signatures).to.exist;
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });
@@ -659,6 +660,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures[0].valid).to.be.true;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -682,6 +684,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures[0].valid).to.be.true;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -703,6 +706,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -726,6 +730,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -746,6 +751,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -767,6 +773,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -786,6 +793,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.null;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -807,6 +815,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.null;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -827,6 +836,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -849,6 +859,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.data).to.equal(plaintext);
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(verified.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -872,6 +883,9 @@ describe('OpenPGP.js public api tests', function() {
           }).then(function(encrypted) {
             expect(encrypted.data).to.exist;
             expect(encrypted.data).to.equal(plaintext);
+            expect(encrypted.signatures[0].valid).to.be.true;
+            expect(encrypted.signatures[0].keyid.toHex()).to.equal(privKeyDE.getSigningKeyPacket().getKeyId().toHex());
+            expect(encrypted.signatures[0].signature.packets.length).to.equal(1);
             done();
           });
         });
@@ -938,6 +952,7 @@ describe('OpenPGP.js public api tests', function() {
 
           openpgp.decrypt({ privateKey:privKey, message:message }).then(function(decrypted) {
             expect(decrypted.data).to.equal('hello 3des\n');
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });
@@ -957,6 +972,7 @@ describe('OpenPGP.js public api tests', function() {
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });
@@ -974,6 +990,7 @@ describe('OpenPGP.js public api tests', function() {
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });
@@ -992,6 +1009,7 @@ describe('OpenPGP.js public api tests', function() {
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });
@@ -1015,6 +1033,7 @@ describe('OpenPGP.js public api tests', function() {
               expect(encOpt.data.byteLength).to.equal(0); // transfered buffer should be empty
             }
             expect(decrypted.data).to.deep.equal(new Uint8Array([0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01]));
+            expect(decrypted.signatures.length).to.equal(0);
             done();
           });
         });

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -265,6 +265,7 @@ describe("Signature", function() {
     openpgp.decrypt({ privateKey: priv_key, publicKeys:[pub_key], message:msg }).then(function(decrypted) {
       expect(decrypted.data).to.exist;
       expect(decrypted.signatures[0].valid).to.be.true;
+      expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
       done();
     });
   });
@@ -309,6 +310,7 @@ describe("Signature", function() {
       expect(verified).to.exist;
       expect(verified).to.have.length(1);
       expect(verified[0].valid).to.be.true;
+      expect(verified[0].signature.packets.length).to.equal(1);
       done();
     });
   });
@@ -333,6 +335,7 @@ describe("Signature", function() {
     expect(verified).to.exist;
     expect(verified).to.have.length(1);
     expect(verified[0].valid).to.be.true;
+    expect(verified[0].signature.packets.length).to.equal(1);
     done();
   });
 
@@ -356,6 +359,7 @@ describe("Signature", function() {
     expect(verified).to.exist;
     expect(verified).to.have.length(1);
     expect(verified[0].valid).to.be.true;
+    expect(verified[0].signature.packets.length).to.equal(1);
     done();
   });
 
@@ -390,6 +394,7 @@ describe("Signature", function() {
       expect(decrypted.data).to.equal(plaintext);
       expect(decrypted.signatures).to.have.length(1);
       expect(decrypted.signatures[0].valid).to.be.true;
+      expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
       done();
     });
   });
@@ -426,6 +431,7 @@ describe("Signature", function() {
       expect(decrypted.data).to.equal(plaintext);
       expect(decrypted.signatures).to.have.length(1);
       expect(decrypted.signatures[0].valid).to.be.true;
+      expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
       done();
     });
 
@@ -469,6 +475,8 @@ describe("Signature", function() {
     expect(verifiedSig).to.have.length(2);
     expect(verifiedSig[0].valid).to.be.true;
     expect(verifiedSig[1].valid).to.be.true;
+    expect(verifiedSig[0].signature.packets.length).to.equal(1);
+    expect(verifiedSig[1].signature.packets.length).to.equal(1);
     done();
   });
 
@@ -513,6 +521,8 @@ describe("Signature", function() {
       expect(cleartextSig.signatures).to.have.length(2);
       expect(cleartextSig.signatures[0].valid).to.be.true;
       expect(cleartextSig.signatures[1].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
+      expect(cleartextSig.signatures[1].signature.packets.length).to.equal(1);
       done();
     });
   });
@@ -533,6 +543,7 @@ describe("Signature", function() {
       expect(cleartextSig.data).to.equal(plaintext.replace(/\r/g,''));
       expect(cleartextSig.signatures).to.have.length(1);
       expect(cleartextSig.signatures[0].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
       done();
     });
 

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -595,7 +595,7 @@ describe("Signature", function() {
     expect(pubKey.users[0].selfCertifications).to.eql(pubKey2.users[0].selfCertifications);
   });
 
-  it('Verify a detached signature', function() {
+  it('Verify a detached signature using readSignedContent', function() {
     var detachedSig = ['-----BEGIN PGP SIGNATURE-----',
       'Version: GnuPG v1.4.13 (Darwin)',
       'Comment: GPGTools - https://gpgtools.org',
@@ -638,6 +638,30 @@ describe("Signature", function() {
 
     var msg = openpgp.message.readSignedContent(content, detachedSig);
     var result = msg.verify(publicKeys);
+    expect(result[0].valid).to.be.true;
+  });
+
+  it('Detached signature signing and verification cleartext', function () {
+    var msg = openpgp.message.fromText('hello');
+    var pubKey2 = openpgp.key.readArmored(pub_key_arm2).keys[0];
+    var privKey2 = openpgp.key.readArmored(priv_key_arm2).keys[0];
+    privKey2.decrypt('hello world');
+
+    var detachedSig = msg.signDetached([privKey2]);
+
+    var result = msg.verifyDetached(detachedSig, [pubKey2]);
+    expect(result[0].valid).to.be.true;
+  });
+
+  it('Detached signature signing and verification encrypted', function () {
+    var msg = openpgp.message.fromText('hello');
+    var pubKey2 = openpgp.key.readArmored(pub_key_arm2).keys[0];
+    var privKey2 = openpgp.key.readArmored(priv_key_arm2).keys[0];
+    privKey2.decrypt('hello world');
+    msg.encrypt({keys: [pubKey2] });
+
+    var detachedSig = msg.signDetached([privKey2]);
+    var result = msg.verifyDetached(detachedSig, [pubKey2]);
     expect(result[0].valid).to.be.true;
   });
 


### PR DESCRIPTION
Fixes #452 (adds support for detached signatures)

Creates a new Signature class, which represents a list of signature packets. 
Creates new signDetached and verifyDetached functions for both the Message and CleartextMessage classes. The "packets" field of the CleartextMessage class is replaced by a Signature object "signature". 

Detached signing is also possible in the high-level encrypt/decrypt/sign/verify functions:

1) encrypt/sign: an additional boolean input "detached" (which defaults to false) can be passed into the encrypt and sign functions. If "detached" is true, then the output will have an additional "signature" field containing a Signature object or armored signature (depending on the value of the armor input). 

2) decrypt/verify: an additional Signature input "signature" can be passed into the decrypt and verify functions. If both a signature and publicKeys are present, the detached signature will be verified with the public keys. 
