### PR TITLE
Accept signature object as an input to encrypt function

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -104,12 +104,12 @@ Message.prototype.decrypt = function(privateKey, sessionKey, password) {
       enums.packet.symEncryptedIntegrityProtected,
       enums.packet.symEncryptedAEADProtected
     );
+
     if (symEncryptedPacketlist.length === 0) {
       return;
     }
 
     const symEncryptedPacket = symEncryptedPacketlist[0];
-
     return symEncryptedPacket.decrypt(keyObj.algorithm, keyObj.data).then(() => {
       const resultMsg = new Message(symEncryptedPacket.packets);
       symEncryptedPacket.packets = new packet.List(); // remove packets after decryption
@@ -360,9 +360,11 @@ Message.prototype.sign = function(privateKeys=[], signature=null) {
     signaturePacket.sign(signingKeyPacket, literalDataPacket);
     packetlist.push(signaturePacket);
   }
+
   if (signature) {
     packetlist.concat(existingSigPacketlist);
   }
+
   return new Message(packetlist);
 };
 

--- a/src/message.js
+++ b/src/message.js
@@ -104,12 +104,12 @@ Message.prototype.decrypt = function(privateKey, sessionKey, password) {
       enums.packet.symEncryptedIntegrityProtected,
       enums.packet.symEncryptedAEADProtected
     );
-
     if (symEncryptedPacketlist.length === 0) {
       return;
     }
 
     const symEncryptedPacket = symEncryptedPacketlist[0];
+
     return symEncryptedPacket.decrypt(keyObj.algorithm, keyObj.data).then(() => {
       const resultMsg = new Message(symEncryptedPacket.packets);
       symEncryptedPacket.packets = new packet.List(); // remove packets after decryption
@@ -292,10 +292,11 @@ export function encryptSessionKey(sessionKey, symAlgo, publicKeys, passwords) {
 
 /**
  * Sign the message (the literal data packet of the message)
- * @param  {Array<module:key~Key>} privateKey private keys with decrypted secret key data for signing
- * @return {module:message~Message}      new message with signed content
+ * @param  {Array<module:key~Key>}        privateKey private keys with decrypted secret key data for signing
+ * @param  {Signature} signature          (optional) any existing detached signature to add to the message
+ * @return {module:message~Message}       new message with signed content
  */
-Message.prototype.sign = function(privateKeys) {
+Message.prototype.sign = function(privateKeys=[], signature=null) {
 
   var packetlist = new packet.List();
 
@@ -307,12 +308,27 @@ Message.prototype.sign = function(privateKeys) {
   var literalFormat = enums.write(enums.literal, literalDataPacket.format);
   var signatureType = literalFormat === enums.literal.binary ?
                       enums.signature.binary : enums.signature.text;
-  var i, signingKeyPacket;
+  var i, signingKeyPacket, existingSigPacketlist, onePassSig;
+
+  if (signature) {
+    existingSigPacketlist = signature.packets.filterByTag(enums.packet.signature);
+    if (existingSigPacketlist.length) {
+      for (i = existingSigPacketlist.length - 1; i >= 0; i--) {
+        var sigPacket = existingSigPacketlist[i];
+        onePassSig = new packet.OnePassSignature();
+        onePassSig.type = signatureType;
+        onePassSig.hashAlgorithm = config.prefer_hash_algorithm;
+        onePassSig.publicKeyAlgorithm = sigPacket.publicKeyAlgorithm;
+        onePassSig.signingKeyId = sigPacket.issuerKeyId;
+        packetlist.push(onePassSig);
+      }
+    }
+  }
   for (i = 0; i < privateKeys.length; i++) {
     if (privateKeys[i].isPublic()) {
       throw new Error('Need private key for signing');
     }
-    var onePassSig = new packet.OnePassSignature();
+    onePassSig = new packet.OnePassSignature();
     onePassSig.type = signatureType;
     //TODO get preferred hashg algo from key signature
     onePassSig.hashAlgorithm = config.prefer_hash_algorithm;
@@ -341,16 +357,19 @@ Message.prototype.sign = function(privateKeys) {
     signaturePacket.sign(signingKeyPacket, literalDataPacket);
     packetlist.push(signaturePacket);
   }
-
+  if (signature) {
+    packetlist.concat(existingSigPacketlist);
+  }
   return new Message(packetlist);
 };
 
 /**
  * Create a detached signature for the message (the literal data packet of the message)
- * @param  {Array<module:key~Key>} privateKey private keys with decrypted secret key data for signing
+ * @param  {Array<module:key~Key>}           privateKey private keys with decrypted secret key data for signing
+ * @param  {Signature} signature             (optional) any existing detached signature
  * @return {module:signature~Signature}      new detached signature of message content
  */
-Message.prototype.signDetached = function(privateKeys) {
+Message.prototype.signDetached = function(privateKeys=[], signature=null) {
 
   var packetlist = new packet.List();
 
@@ -374,6 +393,10 @@ Message.prototype.signDetached = function(privateKeys) {
     }
     signaturePacket.sign(signingKeyPacket, literalDataPacket);
     packetlist.push(signaturePacket);
+  }
+  if (signature) {
+    var existingSigPacketlist = signature.packets.filterByTag(enums.packet.signature);
+    packetlist.concat(existingSigPacketlist);
   }
 
   return new sigModule.Signature(packetlist);

--- a/src/message.js
+++ b/src/message.js
@@ -320,6 +320,9 @@ Message.prototype.sign = function(privateKeys=[], signature=null) {
         onePassSig.hashAlgorithm = config.prefer_hash_algorithm;
         onePassSig.publicKeyAlgorithm = sigPacket.publicKeyAlgorithm;
         onePassSig.signingKeyId = sigPacket.issuerKeyId;
+        if (!privateKeys.length && i === 0) {
+          onePassSig.flags = 1;
+        }
         packetlist.push(onePassSig);
       }
     }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -247,7 +247,6 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
   return message.decrypt(privateKey, sessionKey, password).then(message => {
 
     const result = parseMessage(message, format);
-
     if (result.data) { // verify
       if (!publicKeys) {
         publicKeys = [];
@@ -286,6 +285,7 @@ export function decrypt({ message, privateKey, publicKeys, sessionKey, password,
 export function sign({ data, privateKeys, armor=true, detached=false}) {
   checkString(data);
   privateKeys = toArray(privateKeys);
+
   if (asyncProxy) { // use web worker if available
     return asyncProxy.delegate('sign', { data, privateKeys, armor, detached });
   }

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -724,9 +724,14 @@ describe('OpenPGP.js public api tests', function() {
         });
 
         it('should encrypt and decrypt/verify with detached signature as input and detached flag not set for encryption', function(done) {
+          var privKeyDE = openpgp.key.readArmored(priv_key_de).keys[0];
+          privKeyDE.decrypt(passphrase);
+
+          var pubKeyDE = openpgp.key.readArmored(pub_key_de).keys[0];
+
           var signOpt = {
             data: plaintext,
-            privateKeys: privateKey.keys[0],
+            privateKeys: privKeyDE,
             detached: true
           };
 
@@ -738,7 +743,7 @@ describe('OpenPGP.js public api tests', function() {
 
           var decOpt = {
             privateKey: privateKey.keys[0],
-            publicKeys: publicKey.keys
+            publicKeys: [publicKey.keys[0], pubKeyDE]
           };
 
           openpgp.sign(signOpt).then(function(signed) {
@@ -753,7 +758,7 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
             expect(decrypted.signatures[1].valid).to.be.true;
-            expect(decrypted.signatures[1].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+            expect(decrypted.signatures[1].keyid.toHex()).to.equal(privKeyDE.getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[1].signature.packets.length).to.equal(1);
             done();
           });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -708,7 +708,7 @@ describe('OpenPGP.js public api tests', function() {
           };
 
           openpgp.sign(signOpt).then(function(signed) {
-            encOpt.signatureInput = openpgp.signature.readArmored(signed.signature);
+            encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
@@ -747,7 +747,7 @@ describe('OpenPGP.js public api tests', function() {
           };
 
           openpgp.sign(signOpt).then(function(signed) {
-            encOpt.signatureInput = openpgp.signature.readArmored(signed.signature);
+            encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
@@ -783,7 +783,7 @@ describe('OpenPGP.js public api tests', function() {
           };
 
           openpgp.sign(signOpt).then(function(signed) {
-            encOpt.signatureInput = openpgp.signature.readArmored(signed.signature);
+            encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
@@ -816,7 +816,7 @@ describe('OpenPGP.js public api tests', function() {
           };
 
           openpgp.sign(signOpt).then(function(signed) {
-            encOpt.signatureInput = openpgp.signature.readArmored(signed.signature);
+            encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);


### PR DESCRIPTION
Allows a detached signature object to be passed in as an input ("signatureInput") to openpgp.encrypt instead of or in addition to private keys for signing.
If detached=true, then the signature packets in this object will be included in the returned detached signature.
If detached=false, then the signature packets will be added to the message object and encrypted. 