### PR TITLE
Tolerant flag for suppressing packet read errors

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -44,6 +44,7 @@ export default {
   use_native: true, // use native node.js crypto and Web Crypto apis (if available)
   zero_copy: false, // use transferable objects between the Web Worker and main thread
   debug: false,
+  tolerant: false, // ignore unsupported/unrecognizable packets instead of throwing an error
   show_version: true,
   show_comment: true,
   versionstring: "OpenPGP.js VERSION",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -44,7 +44,7 @@ export default {
   use_native: true, // use native node.js crypto and Web Crypto apis (if available)
   zero_copy: false, // use transferable objects between the Web Worker and main thread
   debug: false,
-  tolerant: false, // ignore unsupported/unrecognizable packets instead of throwing an error
+  tolerant: true, // ignore unsupported/unrecognizable packets instead of throwing an error
   show_version: true,
   show_comment: true,
   versionstring: "OpenPGP.js VERSION",

--- a/src/packet/compressed.js
+++ b/src/packet/compressed.js
@@ -120,7 +120,7 @@ Compressed.prototype.decompress = function () {
       throw new Error('Compression algorithm BZip2 [BZ2] is not implemented.');
 
     default:
-      throw new Error("Compression algorithm unknown :" + this.alogrithm);
+      throw new Error("Compression algorithm unknown :" + this.algorithm);
   }
 
   this.packets.read(decompressed);

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -15,6 +15,7 @@ import util from '../util';
 import packetParser from './packet.js';
 import * as packets from './all_packets.js';
 import enums from '../enums.js';
+import config from '../config';
 
 /**
  * @constructor
@@ -44,6 +45,9 @@ Packetlist.prototype.read = function (bytes) {
       pushed = true;
       packet.read(parsed.packet);
     } catch(e) {
+      if (!config.tolerant || parsed.tag == enums.packet.symmetricallyEncrypted || parsed.tag == enums.packet.literal || parsed.tag == enums.packet.compressed) {
+        throw e;
+      }
       if (pushed) {
         this.pop(); // drop unsupported packet
       }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -527,7 +527,8 @@ describe('Key', function() {
     '=Q/kB',
     '-----END PGP PUBLIC KEY BLOCK-----'].join('\n');
 
-  it('Parsing armored text with RSA key and ECC subkey', function(done) {
+  it('Parsing armored text with RSA key and ECC subkey in tolerant mode', function(done) {
+    openpgp.config.tolerant = true;
     var pubKeys = openpgp.key.readArmored(rsa_ecc_pub);
     expect(pubKeys).to.exist;
     expect(pubKeys.err).to.not.exist;
@@ -535,6 +536,15 @@ describe('Key', function() {
     expect(pubKeys.keys[0].primaryKey.getKeyId().toHex()).to.equal('b8e4105cc9dedc77');
     done();
   });
+
+  it('Parsing armored text with RSA key and ECC subkey in non-tolerant mode', function(done) {
+    openpgp.config.tolerant = false;
+    var pubKeys = openpgp.key.readArmored(rsa_ecc_pub);
+    expect(pubKeys).to.exist;
+    expect(pubKeys.err).to.exist;
+    done();
+  });
+
 
   var multi_uid_key =
     ['-----BEGIN PGP PUBLIC KEY BLOCK-----',


### PR DESCRIPTION
Fixes #539 

Added a config flag "tolerant". 
When tolerant is true, errors thrown when reading packets other than literal/compressed/symmetrically encrypted will be suppressed and just be left out of the resulting packetlist. When tolerant is false (default), all packet read errors are thrown. 