### PR TITLE
Add grunt 'concurrent' target, can be used with --watch to watchify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,10 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     browserify: {
+      options: grunt.option('watch') ? {
+            watch: true,
+            keepAlive: true,
+          } : {},
       openpgp: {
         files: {
           'dist/openpgp.js': [ './src/index.js' ]
@@ -244,6 +248,14 @@ module.exports = function(grunt) {
         tasks: ['browserify:unittests']
       }
     },
+    concurrent: {
+      all: {
+        tasks: ['browserify:openpgp', 'browserify:openpgp_debug', 'browserify:worker'],
+        options: {
+          logConcurrentOutput: true
+        }
+      }
+    }
   });
 
   // Load the plugin(s)
@@ -261,6 +273,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-saucelabs');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-concurrent');
 
   grunt.registerTask('set_version', function() {
     if (!version) {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "grunt-mocha-test": "~0.12.7",
     "grunt-saucelabs": "8.6.2",
     "grunt-text-replace": "~0.4.0",
+    "grunt-concurrent": "^2.3.1",
     "istanbul": "~0.4.1",
     "mocha": "~2.5.3",
     "rusha": "^0.8.3",


### PR DESCRIPTION
Related to #524 

I discovered that grunt-browserify can use watchify instead of browserify just by using an option (see: https://github.com/jmreidy/grunt-browserify#watch) so the changes are quite simple

Watchify is blocking so I used grunt-concurrent in order to run 1 watchify instance per target (openpgp, openpgp_debug, worker)

Usage:

    $ grunt concurrent --watch

Leave running
In other shell:

    $ touch src/message.js
    $ touch src/worker/worker.js