### PR TITLE
Fix for issue 573: Don't throw with unknown Armor Headers

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -224,7 +224,7 @@ function splitHeaders(text) {
  */
 function verifyHeaders(headers) {
   for (var i = 0; i < headers.length; i++) {
-    if (!/^(Version|Comment|MessageID|Hash|Charset): .+$/.test(headers[i])) {
+    if (!/^[^: ]+: .+$/.test(headers[i])) {
       throw new Error('Improperly formatted armor header: ' + headers[i]);
     }
   }

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -104,7 +104,7 @@ describe("ASCII armor", function() {
     var msg = getArmor(['Hash:SHA256']);
     msg = openpgp.cleartext.readArmored.bind(null, msg);
     expect(msg).to.throw(Error, /Improperly formatted armor header/);
-    msg = getArmor(['<script>: SHA256']);
+    msg = getArmor(['Ha sh: SHA256']);
     msg = openpgp.cleartext.readArmored.bind(null, msg);
     expect(msg).to.throw(Error, /Improperly formatted armor header/);
     msg = getArmor(['Hash SHA256']);


### PR DESCRIPTION
Don't throw with unknown Armor Headers but just with invalid headers