### PR TITLE
Set keyExpirationTime for subkey binding signature

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -1247,6 +1247,10 @@ function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
   subkeySignaturePacket.publicKeyAlgorithm = options.keyType;
   subkeySignaturePacket.hashAlgorithm = config.prefer_hash_algorithm;
   subkeySignaturePacket.keyFlags = [enums.keyFlags.encrypt_communication | enums.keyFlags.encrypt_storage];
+  if (options.keyExpirationTime > 0) {
+    subkeySignaturePacket.keyExpirationTime = options.keyExpirationTime;
+    subkeySignaturePacket.keyNeverExpires = false;
+  }
   subkeySignaturePacket.sign(secretKeyPacket, dataToSign);
 
   packetlist.push(secretSubkeyPacket);

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1335,6 +1335,12 @@ describe('Key', function() {
       var actual_delta = (new Date(expiration) - new Date()) / 1000;
       expect(Math.abs(actual_delta - expect_delta)).to.be.below(60);
 
+      var subKeyExpiration = key.subKeys[0].getExpirationTime();
+      expect(subKeyExpiration).to.exist;
+
+      var actual_subKeyDelta = (new Date(subKeyExpiration) - new Date()) / 1000;
+      expect(Math.abs(actual_subKeyDelta - expect_delta)).to.be.below(60);
+
       done();
     }).catch(done);
   });


### PR DESCRIPTION
Currently when generating a key the keyExpirationTime is only added to the user id self signature but not to the subkey binding signature. Hence those subkeys are not displayed with an expiration time in PGP clients.
Keys generated with GPG set the expiration time also for subkeys.
This was already included in https://github.com/openpgpjs/openpgpjs/pull/458 but omitted in https://github.com/openpgpjs/openpgpjs/pull/514
