### PR TITLE
account for non-cleartext sign/verify message parameters

### DIFF
--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -104,7 +104,7 @@ export function parseClonedPackets(options, method) {
   if (options.key) {
     options.key = packetlistCloneToKey(options.key);
   }
-  if (options.message && (method === 'sign' || method === 'verify')) { // sign and verify support only CleartextMessage
+  if (options.message && options.message.signature) {
     options.message = packetlistCloneToCleartextMessage(options.message);
   } else if (options.message) {
     options.message = packetlistCloneToMessage(options.message);


### PR DESCRIPTION
Now that we support signing/verifying of binary data, we cannot assume that all message parameters in sign/verify functions should be converted to CleartextMessage objects