### PR TITLE
Fix/590 preserve error stack

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -552,7 +552,6 @@ function onError(message, error) {
   if (config.debug) { console.error(error.stack); }
   // rethrow new high level error for api users
   const newError = new Error(message + ': ' + error.message);
-  newError.stack += '\n' + error.stack;
   newError.innerError = error;
   throw newError;
 }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -551,7 +551,10 @@ function onError(message, error) {
   // log the stack trace
   if (config.debug) { console.error(error.stack); }
   // rethrow new high level error for api users
-  throw new Error(message + ': ' + error.message);
+  const newError = new Error(message + ': ' + error.message);
+  newError.stack += '\n' + error.stack;
+  newError.innerError = error;
+  throw newError;
 }
 
 /**

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -553,6 +553,7 @@ function onError(message, error) {
   // rethrow new high level error for api users
   const newError = new Error(message + ': ' + error.message);
   newError.innerError = error;
+  newError.stack += '\n' + error.stack;
   throw newError;
 }
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1202,6 +1202,19 @@ describe('OpenPGP.js public api tests', function() {
       });
 
       describe('Errors', function() {
+        it('Errors stack should contain the stack of innerError', function(done) {
+          openpgp.encrypt({
+            data: new Uint8Array([0x01, 0x01, 0x01]),
+            passwords: null
+          })
+          .then(function() {
+            done(new Error('Error expected.'));
+          })
+          .catch(function(error) {
+            expect(error.stack).to.match(/\nError: No keys or passwords/);
+            done();
+          });
+        });
         it('Errors should contain innerError', function(done) {
           openpgp.encrypt({
             data: new Uint8Array([0x01, 0x01, 0x01]),

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1207,7 +1207,9 @@ describe('OpenPGP.js public api tests', function() {
             data: new Uint8Array([0x01, 0x01, 0x01]),
             passwords: null
           })
-          .then(() => done(new Error('Error expected.')))
+          .then(function () {
+            done(new Error('Error expected.'));
+          })
           .catch(function(error){
             expect(error.innerError).to.exist;
             done();

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1207,10 +1207,10 @@ describe('OpenPGP.js public api tests', function() {
             data: new Uint8Array([0x01, 0x01, 0x01]),
             passwords: null
           })
-          .then(function () {
+          .then(function() {
             done(new Error('Error expected.'));
           })
-          .catch(function(error){
+          .catch(function(error) {
             expect(error.innerError).to.exist;
             done();
           });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1200,6 +1200,20 @@ describe('OpenPGP.js public api tests', function() {
           });
         });
       });
+
+      describe('Errors', function() {
+        it('Errors should contain innerError', function(done) {
+          openpgp.encrypt({
+            data: new Uint8Array([0x01, 0x01, 0x01]),
+            passwords: null
+          })
+          .then(() => done(new Error('Error expected.')))
+          .catch(function(error){
+            expect(error.innerError).to.exist;
+            done();
+          });
+        });
+      })
     }
 
   });


### PR DESCRIPTION
Adds innerError to re-thrown Error for slightly better debugging experience.

Based on this issue:
https://github.com/openpgpjs/openpgpjs/issues/590

I found that there wasn't a need to concat the stacks if you just embedded the error onto a property on the thrown error. It prints out find and it also preserves any other fields that may have been on that error beyond just the stack and message. It looks like this when printed out:
![capture](https://user-images.githubusercontent.com/10974/33224864-b26c4ef4-d133-11e7-9c56-5e5eabd1bdbc.PNG)
