### PR TITLE
Unit test fixes

### DIFF
--- a/test/general/hkp.js
+++ b/test/general/hkp.js
@@ -113,39 +113,34 @@ describe('HKP unit tests', function() {
   afterEach(function() {});
 
   describe('lookup', function() {
-    it('by email address should work', function(done) {
-      hkp.lookup({
+    it('by email address should work', () => {
+      return hkp.lookup({
         query: 'safewithme.testuser@gmail.com'
       }).then(function(key) {
         expect(key).to.exist;
-        done();
       });
     });
 
-    it('by email address should not find a key', function(done) {
-      hkp.lookup({
+    it('by email address should not find a key', () => {
+      return hkp.lookup({
         query: 'safewithme.testuse@gmail.com'
       }).then(function(key) {
         expect(key).to.be.undefined;
-        done();
       });
     });
 
-    it('by key id should work', function(done) {
-      hkp.lookup({
+    it('by key id should work', () => {
+      return hkp.lookup({
         keyId: 'D7FB93FCDFBFC23C'
       }).then(function(key) {
         expect(key).to.exist;
-        done();
       });
     });
   });
 
   describe('upload', function() {
-    it('should work', function(done) {
-      hkp.upload(pub_key).then(function() {
-        done();
-      });
+    it('should work', () => {
+      return hkp.upload(pub_key);
     });
   });
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -885,7 +885,7 @@ describe('Key', function() {
     expect(prefAlgo).to.equal(openpgp.config.encryption_cipher);
   });
 
-  it('Preferences of generated key', function(done) {
+  it('Preferences of generated key', () => {
     var testPref = function(key) {
       // key flags
       var keyFlags = openpgp.enums.keyFlags;
@@ -903,10 +903,9 @@ describe('Key', function() {
     };
     var opt = {numBits: 512, userIds: 'test <a@b.com>', passphrase: 'hello'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
+    return openpgp.generateKey(opt).then(function(key) {
       testPref(key.key);
       testPref(openpgp.key.readArmored(key.publicKeyArmored).keys[0]);
-      done();
     });
   });
 
@@ -924,54 +923,51 @@ describe('Key', function() {
     expect(primUser.selfCertificate).to.be.an.instanceof(openpgp.packet.Signature);
   });
 
-  it('Generated key is not unlocked by default', function(done) {
+  it('Generated key is not unlocked by default', () => {
     var opt = {numBits: 512, userIds: 'test <a@b.com>', passphrase: '123'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
     var key;
-    openpgp.generateKey(opt).then(function(newKey) {
+    return openpgp.generateKey(opt).then(function(newKey) {
       key = newKey;
       return openpgp.message.fromText('hello').encrypt([key.key]);
     }).then(function(msg) {
       return msg.decrypt(key.key);
     }).catch(function(err) {
       expect(err.message).to.equal('Private key is not decrypted.');
-      done();
     });
   });
 
-  it('Generate key - single userid', function(done) {
+  it('Generate key - single userid', () => {
     var userId = 'test <a@b.com>';
     var opt = {numBits: 512, userIds: userId, passphrase: '123'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
+    return openpgp.generateKey(opt).then(function(key) {
       key = key.key;
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userId.userid).to.equal(userId);
-      done();
-    }).catch(done);
+    });
   });
 
-  it('Generate key - multi userid', function(done) {
+  it('Generate key - multi userid', () => {
     var userId1 = 'test <a@b.com>';
     var userId2 = 'test <b@c.com>';
     var opt = {numBits: 512, userIds: [userId1, userId2], passphrase: '123'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
+    return openpgp.generateKey(opt).then(function(key) {
       key = key.key;
       expect(key.users.length).to.equal(2);
       expect(key.users[0].userId.userid).to.equal(userId1);
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
       expect(key.users[1].userId.userid).to.equal(userId2);
       expect(key.users[1].selfCertifications[0].isPrimaryUserID).to.be.null;
-      done();
-    }).catch(done);
+    });
   });
 
-  it('Encrypt key with new passphrase', function(done) {
+  it('Encrypt key with new passphrase', () => {
     var userId = 'test <a@b.com>';
     var opt = {numBits: 512, userIds: userId, passphrase: 'passphrase'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
+    return openpgp.generateKey(opt).then(function(key) {
       key = key.key;
       var armor1 = key.armor();
       var armor2 = key.armor();
@@ -986,15 +982,15 @@ describe('Key', function() {
       expect(key.primaryKey.isDecrypted).to.be.true;
       var armor3 = key.armor();
       expect(armor3).to.not.equal(armor1);
-      done();
-    }).catch(done);
+    });
   });
-  it('Generate key - ensure keyExpirationTime works', function(done) {
+
+  it('Generate key - ensure keyExpirationTime works', () => {
     var expect_delta = 365 * 24 * 60 * 60;
     var userId = 'test <a@b.com>';
     var opt = {numBits: 512, userIds: userId, passphrase: '123', keyExpirationTime: expect_delta};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
+    return openpgp.generateKey(opt).then(function(key) {
       key = key.key;
 
       var expiration = key.getExpirationTime();
@@ -1008,9 +1004,7 @@ describe('Key', function() {
 
       var actual_subKeyDelta = (new Date(subKeyExpiration) - new Date()) / 1000;
       expect(Math.abs(actual_subKeyDelta - expect_delta)).to.be.below(60);
-
-      done();
-    }).catch(done);
+    });
   });
 
   it('Sign and verify key - primary user', function(done) {
@@ -1086,80 +1080,78 @@ describe('Key', function() {
     expect(signatures[3].valid).to.be.null;
     done();
   });
-  it('Reformat key without passphrase', function(done) {
+  it('Reformat key without passphrase', () => {
     var userId1 = 'test1 <a@b.com>';
     var userId2 = 'test2 <b@a.com>';
     var opt = {numBits: 512, userIds: userId1};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
-      key = key.key
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userId.userid).to.equal(userId1);
       expect(key.primaryKey.isDecrypted).to.be.true;
       opt.privateKey = key;
       opt.userIds = userId2;
-      openpgp.reformatKey(opt).then(function(newKey) {
-        newKey = newKey.key
+      return openpgp.reformatKey(opt).then(function(newKey) {
+        newKey = newKey.key;
         expect(newKey.users.length).to.equal(1);
         expect(newKey.users[0].userId.userid).to.equal(userId2);
         expect(newKey.primaryKey.isDecrypted).to.be.true;
-        done();
-      }).catch(done);
-    }).catch(done);
+      });
+    });
   });
-  it('Reformat and encrypt key', function(done) {
+
+  it('Reformat and encrypt key', () => {
     var userId1 = 'test1 <a@b.com>';
     var userId2 = 'test2 <b@c.com>';
     var userId3 = 'test3 <c@d.com>';
     var opt = {numBits: 512, userIds: userId1};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
-      key = key.key
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
       opt.privateKey = key;
       opt.userIds = [userId2, userId3];
       opt.passphrase = '123';
-      openpgp.reformatKey(opt).then(function(newKey) {
-        newKey = newKey.key
+      return openpgp.reformatKey(opt).then(function(newKey) {
+        newKey = newKey.key;
         expect(newKey.users.length).to.equal(2);
         expect(newKey.users[0].userId.userid).to.equal(userId2);
         expect(newKey.primaryKey.isDecrypted).to.be.false;
         newKey.decrypt('123');
         expect(newKey.primaryKey.isDecrypted).to.be.true;
-        done();
-      }).catch(done);
-    }).catch(done);
+      });
+    });
   });
-  it('Sign and encrypt with reformatted key', function(done) {
+
+  it('Sign and encrypt with reformatted key', () => {
     var userId1 = 'test1 <a@b.com>';
     var userId2 = 'test2 <b@a.com>';
     var opt = {numBits: 512, userIds: userId1};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(key) {
-      key = key.key
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
       opt.privateKey = key;
       opt.userIds = userId2;
-      openpgp.reformatKey(opt).then(function(newKey) {
-        newKey = newKey.key
-        openpgp.encrypt({data: 'hello', publicKeys: newKey.toPublic(), privateKeys: newKey, armor: true}).then(function(encrypted) {
-          openpgp.decrypt({message: openpgp.message.readArmored(encrypted.data), privateKey: newKey, publicKeys: newKey.toPublic()}).then(function(decrypted) {
+      return openpgp.reformatKey(opt).then(function(newKey) {
+        newKey = newKey.key;
+        return openpgp.encrypt({data: 'hello', publicKeys: newKey.toPublic(), privateKeys: newKey, armor: true}).then(function(encrypted) {
+          return openpgp.decrypt({message: openpgp.message.readArmored(encrypted.data), privateKey: newKey, publicKeys: newKey.toPublic()}).then(function(decrypted) {
             expect(decrypted.data).to.equal('hello');
             expect(decrypted.signatures[0].valid).to.be.true;
-            done();
-          }).catch(done);
-        }).catch(done);
-      }).catch(done);
-    }).catch(done);
+          });
+        });
+      });
+    });
   });
-  it('Throw user friendly error when reformatting encrypted key', function(done) {
-    openpgp.generateKey({numBits: 1024, userIds: 'test1 <a@b.com>', passphrase: '1234'}).then(function(original) {
-      openpgp.reformatKey({privateKey: original.key, userIds: 'test2 <b@a.com>', passphrase: '1234'}).then(function(newKey) {
+
+  it('Throw user friendly error when reformatting encrypted key', () => {
+    return openpgp.generateKey({numBits: 1024, userIds: 'test1 <a@b.com>', passphrase: '1234'}).then(function(original) {
+      return openpgp.reformatKey({privateKey: original.key, userIds: 'test2 <b@a.com>', passphrase: '1234'}).then(function(newKey) {
         assert.fail('reformatKey should result in error when key not decrypted');
-        done();
       }).catch(function(error) {
         expect(error.message).to.equal('Error reformatting keypair: Key not decrypted');
-        done();
       });
-    }).catch(done);
+    });
   });
 
   it('Find a valid subkey binding signature among many invalid ones', function(done) {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1146,8 +1146,8 @@ describe('Key', function() {
 
   it('Throw user friendly error when reformatting encrypted key', () => {
     return openpgp.generateKey({numBits: 1024, userIds: 'test1 <a@b.com>', passphrase: '1234'}).then(function(original) {
-      return openpgp.reformatKey({privateKey: original.key, userIds: 'test2 <b@a.com>', passphrase: '1234'}).then(function(newKey) {
-        assert.fail('reformatKey should result in error when key not decrypted');
+      return openpgp.reformatKey({privateKey: original.key, userIds: 'test2 <b@a.com>', passphrase: '1234'}).then(function() {
+        throw new Error('reformatKey should result in error when key not decrypted');
       }).catch(function(error) {
         expect(error.message).to.equal('Error reformatting keypair: Key not decrypted');
       });

--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -287,10 +287,10 @@ describe("Keyring", function() {
 
     localstore.storePublic([key]);
     expect(localstore.storage.getItem('remove-prefix-public-keys')).to.be.not.null;
-    
+
     localstore.storePublic([]);
     expect(localstore.storage.getItem('remove-prefix-public-keys')).to.be.null;
-  })
+  });
 
   it('removeKeysForId() - unknown id', function() {
     keyring.publicKeys.importKey(pubkey);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -250,55 +250,55 @@ describe('OpenPGP.js public api tests', function() {
       expect(test).to.throw(/Invalid user id format/);
     });
 
-    it('should work for valid single string user id', function(done) {
+    it('should work for valid single string user id', () => {
       var opt = {
         userIds: 'Test User <text@example.com>'
       };
-      openpgp.generateKey(opt).then(function() { done(); });
+      return openpgp.generateKey(opt);
     });
 
-    it('should work for valid string user id', function(done) {
+    it('should work for valid string user id', () => {
       var opt = {
         userIds: ['Test User <text@example.com>']
       };
-      openpgp.generateKey(opt).then(function() { done(); });
+      return openpgp.generateKey(opt);
     });
 
-    it('should work for valid single user id hash', function(done) {
+    it('should work for valid single user id hash', () => {
       var opt = {
         userIds: { name: 'Test User', email: 'text@example.com' }
       };
-      openpgp.generateKey(opt).then(function() { done(); });
+      return openpgp.generateKey(opt);
     });
 
-    it('should work for valid single user id hash', function(done) {
+    it('should work for valid single user id hash', () => {
       var opt = {
         userIds: [{ name: 'Test User', email: 'text@example.com' }]
       };
-      openpgp.generateKey(opt).then(function() { done(); });
+      return openpgp.generateKey(opt);
     });
 
-    it('should work for an empty name', function(done) {
+    it('should work for an empty name', () => {
       var opt = {
         userIds: { email: 'text@example.com' }
       };
-      openpgp.generateKey(opt).then(function() { done(); });
+      return openpgp.generateKey(opt);
     });
 
-    it('should work for an empty email address', function(done) {
+    it('should work for an empty email address', () => {
       var opt = {
         userIds: { name: 'Test User' }
       };
-      openpgp.generateKey(opt).then(function() { done(); })
+      return openpgp.generateKey(opt);
     });
 
-    it('should have default params set', function(done) {
+    it('should have default params set', () => {
       var opt = {
         userIds: { name: 'Test User', email: 'text@example.com' },
         passphrase: 'secret',
         unlocked: true
       };
-      openpgp.generateKey(opt).then(function(newKey) {
+      return openpgp.generateKey(opt).then(function(newKey) {
         expect(keyGenStub.withArgs({
           userIds: ['Test User <text@example.com>'],
           passphrase: 'secret',
@@ -309,12 +309,11 @@ describe('OpenPGP.js public api tests', function() {
         expect(newKey.key).to.exist;
         expect(newKey.privateKeyArmored).to.exist;
         expect(newKey.publicKeyArmored).to.exist;
-        done();
-      })
+      });
     });
 
-    it('should work for no params', function(done) {
-      openpgp.generateKey().then(function(newKey) {
+    it('should work for no params', () => {
+      return openpgp.generateKey().then(function(newKey) {
         expect(keyGenStub.withArgs({
           userIds: [],
           passphrase: undefined,
@@ -323,7 +322,6 @@ describe('OpenPGP.js public api tests', function() {
           keyExpirationTime: 0
         }).calledOnce).to.be.true;
         expect(newKey.key).to.exist;
-        done();
       });
     });
 
@@ -355,7 +353,7 @@ describe('OpenPGP.js public api tests', function() {
       openpgp.destroyWorker();
     });
 
-    it('should work in JS (without worker)', function(done) {
+    it('should work in JS (without worker)', () => {
       openpgp.config.use_native = false;
       openpgp.destroyWorker();
       var opt = {
@@ -363,15 +361,14 @@ describe('OpenPGP.js public api tests', function() {
         numBits: 512
       };
 
-      openpgp.generateKey(opt).then(function(newKey) {
+      return openpgp.generateKey(opt).then(function(newKey) {
         expect(newKey.key.getUserIds()[0]).to.equal('Test User <text@example.com>');
         expect(newKey.publicKeyArmored).to.match(/^-----BEGIN PGP PUBLIC/);
         expect(newKey.privateKeyArmored).to.match(/^-----BEGIN PGP PRIVATE/);
-        done();
       });
     });
 
-    it('should work in JS (with worker)', function(done) {
+    it('should work in JS (with worker)', () => {
       openpgp.config.use_native = false;
       openpgp.initWorker({ path:'../dist/openpgp.worker.js' });
       var opt = {
@@ -379,15 +376,14 @@ describe('OpenPGP.js public api tests', function() {
         numBits: 512
       };
 
-      openpgp.generateKey(opt).then(function(newKey) {
+      return openpgp.generateKey(opt).then(function(newKey) {
         expect(newKey.key.getUserIds()[0]).to.equal('Test User <text@example.com>');
         expect(newKey.publicKeyArmored).to.match(/^-----BEGIN PGP PUBLIC/);
         expect(newKey.privateKeyArmored).to.match(/^-----BEGIN PGP PRIVATE/);
-        done();
       });
     });
 
-    it('should work in with native crypto', function(done) {
+    it('should work in with native crypto', () => {
       openpgp.config.use_native = true;
       var opt = {
         userIds: [{ name: 'Test User', email: 'text@example.com' }],
@@ -395,11 +391,10 @@ describe('OpenPGP.js public api tests', function() {
       };
       if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
 
-      openpgp.generateKey(opt).then(function(newKey) {
+      return openpgp.generateKey(opt).then(function(newKey) {
         expect(newKey.key.getUserIds()[0]).to.equal('Test User <text@example.com>');
         expect(newKey.publicKeyArmored).to.match(/^-----BEGIN PGP PUBLIC/);
         expect(newKey.privateKeyArmored).to.match(/^-----BEGIN PGP PRIVATE/);
-        done();
       });
     });
   });
@@ -464,21 +459,20 @@ describe('OpenPGP.js public api tests', function() {
     });
 
     function tests() {
-      it('Configuration', function(done){
+      it('Configuration', () => {
         openpgp.config.show_version = false;
         openpgp.config.commentstring = 'different';
         if (openpgp.getWorker()) { // init again to trigger config event
           openpgp.initWorker({ path:'../dist/openpgp.worker.js' });
         }
-        openpgp.encrypt({ publicKeys:publicKey.keys, data:plaintext }).then(function(encrypted) {
+        return openpgp.encrypt({ publicKeys:publicKey.keys, data:plaintext }).then(function(encrypted) {
           expect(encrypted.data).to.exist;
           expect(encrypted.data).not.to.match(/^Version:/);
           expect(encrypted.data).to.match(/Comment: different/);
-          done();
         });
       });
 
-      it('Calling decrypt with not decrypted key leads to exception', function (done) {
+      it('Calling decrypt with not decrypted key leads to exception', () => {
         var encOpt = {
           data: plaintext,
           publicKeys: publicKey.keys,
@@ -486,34 +480,31 @@ describe('OpenPGP.js public api tests', function() {
         var decOpt = {
           privateKey: privateKey.keys[0]
         };
-        openpgp.encrypt(encOpt).then(function(encrypted) {
+        return openpgp.encrypt(encOpt).then(function(encrypted) {
           decOpt.message = openpgp.message.readArmored(encrypted.data);
           return openpgp.decrypt(decOpt);
         }).catch(function(error) {
           expect(error.message).to.match(/not decrypted/);
-          done();
         });
       });
 
       describe('decryptKey', function() {
-        it('should work for correct passphrase', function(done) {
-          openpgp.decryptKey({
+        it('should work for correct passphrase', () => {
+          return openpgp.decryptKey({
             privateKey: privateKey.keys[0],
             passphrase: passphrase
           }).then(function(unlocked){
             expect(unlocked.key.primaryKey.getKeyId().toHex()).to.equal(privateKey.keys[0].primaryKey.getKeyId().toHex());
             expect(unlocked.key.primaryKey.isDecrypted).to.be.true;
-            done();
           });
         });
 
-        it('should fail for incorrect passphrase', function(done) {
-          openpgp.decryptKey({
+        it('should fail for incorrect passphrase', () => {
+          return openpgp.decryptKey({
             privateKey: privateKey.keys[0],
             passphrase: 'incorrect'
           }).catch(function(error){
             expect(error.message).to.match(/Invalid passphrase/);
-            done();
           });
         });
       });
@@ -525,8 +516,8 @@ describe('OpenPGP.js public api tests', function() {
           expect(privateKey.keys[0].decrypt(passphrase)).to.be.true;
         });
 
-        it('should encrypt with public key', function(done) {
-          openpgp.encryptSessionKey({
+        it('should encrypt with public key', () => {
+          return openpgp.encryptSessionKey({
             data: sk,
             algorithm: 'aes128',
             publicKeys: publicKey.keys
@@ -537,12 +528,11 @@ describe('OpenPGP.js public api tests', function() {
             });
           }).then(function(decrypted) {
             expect(decrypted.data).to.deep.equal(sk);
-            done();
           });
         });
 
-        it('should encrypt with password', function(done) {
-          openpgp.encryptSessionKey({
+        it('should encrypt with password', () => {
+          return openpgp.encryptSessionKey({
             data: sk,
             algorithm: 'aes128',
             passwords: password1
@@ -553,13 +543,12 @@ describe('OpenPGP.js public api tests', function() {
             });
           }).then(function(decrypted) {
             expect(decrypted.data).to.deep.equal(sk);
-            done();
           });
         });
 
-        it('roundtrip workflow: encrypt, decryptSessionKey, decrypt with pgp key pair', function(done) {
+        it('roundtrip workflow: encrypt, decryptSessionKey, decrypt with pgp key pair', () => {
           var msgAsciiArmored;
-          openpgp.encrypt({
+          return openpgp.encrypt({
             data: plaintext,
             publicKeys: publicKey.keys
           }).then(function(encrypted) {
@@ -577,13 +566,12 @@ describe('OpenPGP.js public api tests', function() {
 
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            done();
           });
         });
 
-        it('roundtrip workflow: encrypt, decryptSessionKey, decrypt with password', function(done) {
+        it('roundtrip workflow: encrypt, decryptSessionKey, decrypt with password', () => {
           var msgAsciiArmored;
-          openpgp.encrypt({
+          return openpgp.encrypt({
             data: plaintext,
             passwords: password1
           }).then(function(encrypted) {
@@ -601,7 +589,6 @@ describe('OpenPGP.js public api tests', function() {
 
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            done();
           });
         });
       });
@@ -623,7 +610,7 @@ describe('OpenPGP.js public api tests', function() {
           expect(privateKey.keys[0].decrypt(passphrase)).to.be.true;
         });
 
-        it('should encrypt then decrypt', function(done) {
+        it('should encrypt then decrypt', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -631,7 +618,7 @@ describe('OpenPGP.js public api tests', function() {
           var decOpt = {
             privateKey: privateKey.keys[0]
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             expect(encrypted.data).to.match(/^-----BEGIN PGP MESSAGE/);
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
@@ -639,11 +626,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures).to.exist;
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
 
-        it('should encrypt/sign and decrypt/verify', function(done) {
+        it('should encrypt/sign and decrypt/verify', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -653,7 +639,7 @@ describe('OpenPGP.js public api tests', function() {
             privateKey: privateKey.keys[0],
             publicKeys: publicKey.keys
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
@@ -661,11 +647,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.true;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should encrypt/sign and decrypt/verify with detached signatures', function(done) {
+        it('should encrypt/sign and decrypt/verify with detached signatures', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -676,7 +661,7 @@ describe('OpenPGP.js public api tests', function() {
             privateKey: privateKey.keys[0],
             publicKeys: publicKey.keys
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             decOpt.signature = openpgp.signature.readArmored(encrypted.signature);
             return openpgp.decrypt(decOpt);
@@ -685,11 +670,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.true;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should encrypt and decrypt/verify with detached signature input and detached flag set for encryption', function(done) {
+        it('should encrypt and decrypt/verify with detached signature input and detached flag set for encryption', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys[0],
@@ -707,7 +691,7 @@ describe('OpenPGP.js public api tests', function() {
             publicKeys: publicKey.keys[0]
           };
 
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
@@ -719,11 +703,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.true;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should encrypt and decrypt/verify with detached signature as input and detached flag not set for encryption', function(done) {
+        it('should encrypt and decrypt/verify with detached signature as input and detached flag not set for encryption', () => {
           var privKeyDE = openpgp.key.readArmored(priv_key_de).keys[0];
           privKeyDE.decrypt(passphrase);
 
@@ -746,7 +729,7 @@ describe('OpenPGP.js public api tests', function() {
             publicKeys: [publicKey.keys[0], pubKeyDE]
           };
 
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
@@ -760,11 +743,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[1].valid).to.be.true;
             expect(decrypted.signatures[1].keyid.toHex()).to.equal(privKeyDE.getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[1].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should fail to encrypt and decrypt/verify with detached signature input and detached flag set for encryption with wrong public key', function(done) {
+        it('should fail to encrypt and decrypt/verify with detached signature input and detached flag set for encryption with wrong public key', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -782,7 +764,7 @@ describe('OpenPGP.js public api tests', function() {
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
 
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
@@ -794,11 +776,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should fail to encrypt and decrypt/verify with detached signature as input and detached flag not set for encryption with wrong public key', function(done) {
+        it('should fail to encrypt and decrypt/verify with detached signature as input and detached flag not set for encryption with wrong public key', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -815,7 +796,7 @@ describe('OpenPGP.js public api tests', function() {
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
 
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             encOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.encrypt(encOpt);
           }).then(function(encrypted) {
@@ -826,11 +807,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should fail to verify decrypted data with wrong public pgp key', function(done) {
+        it('should fail to verify decrypted data with wrong public pgp key', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -840,7 +820,7 @@ describe('OpenPGP.js public api tests', function() {
             privateKey: privateKey.keys[0],
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
@@ -848,11 +828,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should successfully decrypt signed message without public keys to verify', function(done) {
+        it('should successfully decrypt signed message without public keys to verify', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -861,7 +840,7 @@ describe('OpenPGP.js public api tests', function() {
           var decOpt = {
             privateKey: privateKey.keys[0],
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
@@ -869,11 +848,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should fail to verify decrypted data with wrong public pgp key with detached signatures', function(done) {
+        it('should fail to verify decrypted data with wrong public pgp key with detached signatures', () => {
           var encOpt = {
             data: plaintext,
             publicKeys: publicKey.keys,
@@ -884,7 +862,7 @@ describe('OpenPGP.js public api tests', function() {
             privateKey: privateKey.keys[0],
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             decOpt.signature = openpgp.signature.readArmored(encrypted.signature);
             return openpgp.decrypt(decOpt);
@@ -893,11 +871,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(decrypted.signatures[0].valid).to.be.null;
             expect(decrypted.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and verify cleartext data', function(done) {
+        it('should sign and verify cleartext data', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys
@@ -905,7 +882,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: publicKey.keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             expect(signed.data).to.match(/-----BEGIN PGP SIGNED MESSAGE-----/);
             verifyOpt.message = openpgp.cleartext.readArmored(signed.data);
             return openpgp.verify(verifyOpt);
@@ -914,11 +891,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and verify cleartext data with detached signatures', function(done) {
+        it('should sign and verify cleartext data with detached signatures', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -927,7 +903,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: publicKey.keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             verifyOpt.message = openpgp.cleartext.readArmored(signed.data);
             verifyOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.verify(verifyOpt);
@@ -936,11 +912,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and fail to verify cleartext data with wrong public pgp key', function(done) {
+        it('should sign and fail to verify cleartext data with wrong public pgp key', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys
@@ -948,7 +923,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             verifyOpt.message = openpgp.cleartext.readArmored(signed.data);
             return openpgp.verify(verifyOpt);
           }).then(function(verified) {
@@ -956,11 +931,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.null;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and fail to verify cleartext data with wrong public pgp key with detached signature', function(done) {
+        it('should sign and fail to verify cleartext data with wrong public pgp key with detached signature', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -969,7 +943,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: openpgp.key.readArmored(wrong_pubkey).keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             verifyOpt.message = openpgp.cleartext.readArmored(signed.data);
             verifyOpt.signature = openpgp.signature.readArmored(signed.signature);
             return openpgp.verify(verifyOpt);
@@ -978,11 +952,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.null;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and verify cleartext data and not armor', function(done) {
+        it('should sign and verify cleartext data and not armor', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -991,7 +964,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: publicKey.keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             verifyOpt.message = signed.message;
             return openpgp.verify(verifyOpt);
           }).then(function(verified) {
@@ -999,11 +972,10 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
 
-        it('should sign and verify cleartext data and not armor with detached signatures', function(done) {
+        it('should sign and verify cleartext data and not armor with detached signatures', () => {
           var signOpt = {
             data: plaintext,
             privateKeys: privateKey.keys,
@@ -1013,7 +985,7 @@ describe('OpenPGP.js public api tests', function() {
           var verifyOpt = {
             publicKeys: publicKey.keys
           };
-          openpgp.sign(signOpt).then(function(signed) {
+          return openpgp.sign(signOpt).then(function(signed) {
             verifyOpt.message = signed.message;
             verifyOpt.signature = signed.signature;
             return openpgp.verify(verifyOpt);
@@ -1022,17 +994,16 @@ describe('OpenPGP.js public api tests', function() {
             expect(verified.signatures[0].valid).to.be.true;
             expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
             expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
       });
 
       describe('ELG / DSA encrypt, decrypt, sign, verify', function() {
-        it('round trip test', function (done) {
+        it('round trip test', () => {
           var pubKeyDE = openpgp.key.readArmored(pub_key_de).keys[0];
           var privKeyDE = openpgp.key.readArmored(priv_key_de).keys[0];
           privKeyDE.decrypt(passphrase);
-          openpgp.encrypt({
+          return openpgp.encrypt({
             publicKeys: pubKeyDE,
             privateKeys: privKeyDE,
             data: plaintext
@@ -1048,7 +1019,6 @@ describe('OpenPGP.js public api tests', function() {
             expect(encrypted.signatures[0].valid).to.be.true;
             expect(encrypted.signatures[0].keyid.toHex()).to.equal(privKeyDE.getSigningKeyPacket().getKeyId().toHex());
             expect(encrypted.signatures[0].signature.packets.length).to.equal(1);
-            done();
           });
         });
       });
@@ -1105,23 +1075,22 @@ describe('OpenPGP.js public api tests', function() {
             '=IkKW',
             '-----END PGP PRIVATE KEY BLOCK-----'].join('\n');
 
-        it('Decrypt message', function (done) {
+        it('Decrypt message', () => {
           var privKey, message;
 
           privKey = openpgp.key.readArmored(priv_key).keys[0];
           privKey.decrypt('1234');
           message = openpgp.message.readArmored(pgp_msg);
 
-          openpgp.decrypt({ privateKey:privKey, message:message }).then(function(decrypted) {
+          return openpgp.decrypt({ privateKey:privKey, message:message }).then(function(decrypted) {
             expect(decrypted.data).to.equal('hello 3des\n');
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
       });
 
       describe('AES encrypt, decrypt', function() {
-        it('should encrypt and decrypt with one password', function(done) {
+        it('should encrypt and decrypt with one password', () => {
           var encOpt = {
             data: plaintext,
             passwords: password1
@@ -1129,17 +1098,16 @@ describe('OpenPGP.js public api tests', function() {
           var decOpt = {
             password: password1
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
 
-        it('should encrypt and decrypt with two passwords', function(done) {
+        it('should encrypt and decrypt with two passwords', () => {
           var encOpt = {
             data: plaintext,
             passwords: [password1, password2]
@@ -1147,17 +1115,16 @@ describe('OpenPGP.js public api tests', function() {
           var decOpt = {
             password: password2
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = openpgp.message.readArmored(encrypted.data);
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
 
-        it('should encrypt and decrypt with password and not ascii armor', function(done) {
+        it('should encrypt and decrypt with password and not ascii armor', () => {
           var encOpt = {
             data: plaintext,
             passwords: password1,
@@ -1166,17 +1133,16 @@ describe('OpenPGP.js public api tests', function() {
           var decOpt = {
             password: password1
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = encrypted.message;
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
             expect(decrypted.data).to.equal(plaintext);
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
 
-        it('should encrypt and decrypt with binary data and transferable objects', function(done) {
+        it('should encrypt and decrypt with binary data and transferable objects', () => {
           openpgp.config.zero_copy = true; // activate transferable objects
           var encOpt = {
             data: new Uint8Array([0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01]),
@@ -1187,7 +1153,7 @@ describe('OpenPGP.js public api tests', function() {
             password: password1,
             format: 'binary'
           };
-          openpgp.encrypt(encOpt).then(function(encrypted) {
+          return openpgp.encrypt(encOpt).then(function(encrypted) {
             decOpt.message = encrypted.message;
             return openpgp.decrypt(decOpt);
           }).then(function(decrypted) {
@@ -1196,27 +1162,27 @@ describe('OpenPGP.js public api tests', function() {
             }
             expect(decrypted.data).to.deep.equal(new Uint8Array([0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01]));
             expect(decrypted.signatures.length).to.equal(0);
-            done();
           });
         });
       });
 
       describe('Errors', function() {
 
-        it('Error message should contain the original error message', function(done) {
+        it('Error message should contain the original error message', () => {
           return openpgp.encrypt({
             data: new Uint8Array([0x01, 0x01, 0x01]),
             passwords: null
           })
           .then(function() {
-            done(new Error('Error expected.'));
+            throw new Error('Error expected.');
           })
           .catch(function(error) {
             expect(error.message).to.match(/No keys or passwords/);
-            done();
-          })
+          });
         });
+
       });
+
     }
 
   });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -121,7 +121,7 @@ describe("Packet", function() {
     done();
   });
 
-  it('Sym. encrypted AEAD protected packet', function(done) {
+  it('Sym. encrypted AEAD protected packet', () => {
     var key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]),
         algo = 'aes256';
 
@@ -135,12 +135,11 @@ describe("Packet", function() {
 
     var msg2 = new openpgp.packet.List();
 
-    enc.encrypt(algo, key).then(function() {
+    return enc.encrypt(algo, key).then(function() {
       msg2.read(msg.write());
       return msg2[0].decrypt(algo, key);
     }).then(function() {
       expect(msg2[0].packets[0].data).to.deep.equal(literal.data);
-      done();
     });
   });
 
@@ -171,11 +170,11 @@ describe("Packet", function() {
     done();
   });
 
-  it('Public key encrypted symmetric key packet', function(done) {
+  it('Public key encrypted symmetric key packet', () => {
     var rsa = new openpgp.crypto.publicKey.rsa();
     var keySize = openpgp.util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
 
-    rsa.generate(keySize, "10001").then(function(mpiGen) {
+    return rsa.generate(keySize, "10001").then(function(mpiGen) {
 
       var mpi = [mpiGen.n, mpiGen.ee, mpiGen.d, mpiGen.p, mpiGen.q, mpiGen.u];
       mpi = mpi.map(function(k) {
@@ -202,7 +201,6 @@ describe("Packet", function() {
 
       expect(stringify(msg2[0].sessionKey)).to.equal(stringify(enc.sessionKey));
       expect(msg2[0].sessionKeyAlgorithm).to.equal(enc.sessionKeyAlgorithm);
-      done();
     });
   });
 
@@ -412,11 +410,11 @@ describe("Packet", function() {
         'UBGuHZzsGbTdyKvpVBuS3rnyHHBk6oCnsm1Nl7eLs64VkZUxjEUbq5pb4dlr1pw2\n' +
         'ztpmpAnRcmM=\n' +
         '=htrB\n' +
-        '-----END PGP MESSAGE-----'
+        '-----END PGP MESSAGE-----';
 
     var key = new openpgp.packet.List();
     key.read(openpgp.armor.decode(armored_key).data);
-    key[3].decrypt('test')
+    key[3].decrypt('test');
 
     var msg = new openpgp.packet.List();
     msg.read(openpgp.armor.decode(armored_msg).data);
@@ -424,7 +422,7 @@ describe("Packet", function() {
     msg[0].decrypt(key[3]);
     msg[1].decrypt(msg[0].sessionKeyAlgorithm, msg[0].sessionKey);
 
-    var payload = msg[1].packets[0].packets
+    var payload = msg[1].packets[0].packets;
 
     var verified = payload[2].verify(key[0], payload[1]);
 
@@ -432,15 +430,15 @@ describe("Packet", function() {
     done();
   });
 
-  it('Writing and encryption of a secret key packet.', function(done) {
+  it('Writing and encryption of a secret key packet.', () => {
     var key = new openpgp.packet.List();
     key.push(new openpgp.packet.SecretKey());
 
     var rsa = new openpgp.crypto.publicKey.rsa();
     var keySize = openpgp.util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
 
-    rsa.generate(keySize, "10001").then(function(mipGen) {
-      var mpi = [mipGen.n, mipGen.ee, mipGen.d, mipGen.p, mipGen.q, mipGen.u];
+    return rsa.generate(keySize, "10001").then(function(mpiGen) {
+      var mpi = [mpiGen.n, mpiGen.ee, mpiGen.d, mpiGen.p, mpiGen.q, mpiGen.u];
       mpi = mpi.map(function(k) {
         var mpi = new openpgp.MPI();
         mpi.fromBigInteger(k);
@@ -458,17 +456,16 @@ describe("Packet", function() {
       key2[0].decrypt('hello');
 
       expect(key[0].mpi.toString()).to.equal(key2[0].mpi.toString());
-      done();
     });
   });
 
-  it('Writing and verification of a signature packet.', function(done) {
+  it('Writing and verification of a signature packet.', () => {
     var key = new openpgp.packet.SecretKey();
 
     var rsa = new openpgp.crypto.publicKey.rsa();
     var keySize = openpgp.util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
 
-    rsa.generate(keySize, "10001").then(function(mpiGen) {
+    return rsa.generate(keySize, "10001").then(function(mpiGen) {
         var mpi = [mpiGen.n, mpiGen.ee, mpiGen.d, mpiGen.p, mpiGen.q, mpiGen.u];
         mpi = mpi.map(function(k) {
           var mpi = new openpgp.MPI();
@@ -501,7 +498,6 @@ describe("Packet", function() {
         var verified = signed2[1].verify(key, signed2[0]);
 
         expect(verified).to.be.true;
-        done();
     });
   });
 });

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -257,20 +257,19 @@ describe("Signature", function() {
       '-----END PGP PUBLIC KEY BLOCK-----'
     ].join('\n');
 
-  it('Testing signature checking on CAST5-enciphered message', function(done) {
+  it('Testing signature checking on CAST5-enciphered message', () => {
     var priv_key = openpgp.key.readArmored(priv_key_arm1).keys[0];
     var pub_key = openpgp.key.readArmored(pub_key_arm1).keys[0];
     var msg = openpgp.message.readArmored(msg_arm1);
     priv_key.decrypt("abcd");
-    openpgp.decrypt({ privateKey: priv_key, publicKeys:[pub_key], message:msg }).then(function(decrypted) {
+    return openpgp.decrypt({ privateKey: priv_key, publicKeys:[pub_key], message:msg }).then(function(decrypted) {
       expect(decrypted.data).to.exist;
       expect(decrypted.signatures[0].valid).to.be.true;
       expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
   });
 
-  it('Testing GnuPG stripped-key extensions', function(done) {
+  it('Testing GnuPG stripped-key extensions', () => {
     // exercises the GnuPG s2k type 1001 extension:
     // the secrets on the primary key have been stripped.
     var priv_key_gnupg_ext = openpgp.key.readArmored(
@@ -305,13 +304,12 @@ describe("Signature", function() {
     var msg = openpgp.message.readArmored(msg_arm1);
 
     priv_key_gnupg_ext.subKeys[0].subKey.decrypt("abcd");
-    msg.decrypt(priv_key_gnupg_ext).then(function(msg) {
+    return msg.decrypt(priv_key_gnupg_ext).then(function(msg) {
       var verified = msg.verify([pub_key]);
       expect(verified).to.exist;
       expect(verified).to.have.length(1);
       expect(verified[0].valid).to.be.true;
       expect(verified[0].signature.packets.length).to.equal(1);
-      done();
     });
   });
 
@@ -363,7 +361,7 @@ describe("Signature", function() {
     done();
   });
 
-  it('Verify signature of signed and encrypted message from GPG2 with openpgp.decrypt', function(done) {
+  it('Verify signature of signed and encrypted message from GPG2 with openpgp.decrypt', () => {
     var msg_armor =
       [ '-----BEGIN PGP MESSAGE-----',
         'Version: GnuPG v2.0.19 (GNU/Linux)',
@@ -389,17 +387,16 @@ describe("Signature", function() {
     var keyids = esMsg.getEncryptionKeyIds();
     privKey.decryptKeyPacket(keyids, 'hello world');
 
-    openpgp.decrypt({ privateKey: privKey, publicKeys:[pubKey], message:esMsg }).then(function(decrypted) {
+    return openpgp.decrypt({ privateKey: privKey, publicKeys:[pubKey], message:esMsg }).then(function(decrypted) {
       expect(decrypted.data).to.exist;
       expect(decrypted.data).to.equal(plaintext);
       expect(decrypted.signatures).to.have.length(1);
       expect(decrypted.signatures[0].valid).to.be.true;
       expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
   });
 
-  it('Verify signature of signed and encrypted message from PGP 10.3.0 with openpgp.decrypt', function(done) {
+  it('Verify signature of signed and encrypted message from PGP 10.3.0 with openpgp.decrypt', () => {
     var msg_armor =
       [ '-----BEGIN PGP MESSAGE-----',
         'Version: Encryption Desktop 10.3.0 (Build 9307)',
@@ -426,13 +423,12 @@ describe("Signature", function() {
     var keyids = esMsg.getEncryptionKeyIds();
     privKey.decryptKeyPacket(keyids, 'hello world');
 
-    openpgp.decrypt({ privateKey: privKey, publicKeys:[pubKey], message:esMsg }).then(function(decrypted) {
+    return openpgp.decrypt({ privateKey: privKey, publicKeys:[pubKey], message:esMsg }).then(function(decrypted) {
       expect(decrypted.data).to.exist;
       expect(decrypted.data).to.equal(plaintext);
       expect(decrypted.signatures).to.have.length(1);
       expect(decrypted.signatures[0].valid).to.be.true;
       expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
 
   });
@@ -480,7 +476,7 @@ describe("Signature", function() {
     done();
   });
 
-  it('Verify cleartext signed message with two signatures with openpgp.verify', function(done) {
+  it('Verify cleartext signed message with two signatures with openpgp.verify', () => {
     var msg_armor =
       [ '-----BEGIN PGP SIGNED MESSAGE-----',
         'Hash: SHA256',
@@ -515,7 +511,7 @@ describe("Signature", function() {
     expect(pubKey2.getKeyPacket(keyids)).to.exist;
     expect(pubKey3.getKeyPacket(keyids)).to.exist;
 
-    openpgp.verify({ publicKeys:[pubKey2, pubKey3], message:csMsg }).then(function(cleartextSig) {
+    return openpgp.verify({ publicKeys:[pubKey2, pubKey3], message:csMsg }).then(function(cleartextSig) {
       expect(cleartextSig).to.exist;
       expect(cleartextSig.data).to.equal(plaintext);
       expect(cleartextSig.signatures).to.have.length(2);
@@ -523,17 +519,16 @@ describe("Signature", function() {
       expect(cleartextSig.signatures[1].valid).to.be.true;
       expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
       expect(cleartextSig.signatures[1].signature.packets.length).to.equal(1);
-      done();
     });
   });
 
-  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same string cleartext and valid signatures', function(done) {
+  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same string cleartext and valid signatures', () => {
     var plaintext = 'short message\nnext line\n한국어/조선말';
     var pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
     var privKey = openpgp.key.readArmored(priv_key_arm2).keys[0];
     privKey.getSigningKeyPacket().decrypt('hello world');
 
-    openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
+    return openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
 
       var csMsg = openpgp.cleartext.readArmored(signed.data);
       return openpgp.verify({ publicKeys:[pubKey], message:csMsg });
@@ -544,18 +539,17 @@ describe("Signature", function() {
       expect(cleartextSig.signatures).to.have.length(1);
       expect(cleartextSig.signatures[0].valid).to.be.true;
       expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
 
   });
 
-  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same bytes cleartext and valid signatures - armored', function(done) {
+  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same bytes cleartext and valid signatures - armored', () => {
     var plaintext = openpgp.util.str2Uint8Array('short message\nnext line\n한국어/조선말');
     var pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
     var privKey = openpgp.key.readArmored(priv_key_arm2).keys[0];
     privKey.getSigningKeyPacket().decrypt('hello world');
 
-    openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
+    return openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
       var csMsg = openpgp.message.readArmored(signed.data);
       return openpgp.verify({ publicKeys:[pubKey], message:csMsg });
 
@@ -565,18 +559,17 @@ describe("Signature", function() {
       expect(cleartextSig.signatures).to.have.length(1);
       expect(cleartextSig.signatures[0].valid).to.be.true;
       expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
 
   });
 
-  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same bytes cleartext and valid signatures - not armored', function(done) {
+  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same bytes cleartext and valid signatures - not armored', () => {
     var plaintext = openpgp.util.str2Uint8Array('short message\nnext line\n한국어/조선말');
     var pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
     var privKey = openpgp.key.readArmored(priv_key_arm2).keys[0];
     privKey.getSigningKeyPacket().decrypt('hello world');
 
-    openpgp.sign({ privateKeys:[privKey], data:plaintext, armor:false }).then(function(signed) {
+    return openpgp.sign({ privateKeys:[privKey], data:plaintext, armor:false }).then(function(signed) {
       var csMsg = signed.message;
       return openpgp.verify({ publicKeys:[pubKey], message:csMsg });
 
@@ -586,7 +579,6 @@ describe("Signature", function() {
       expect(cleartextSig.signatures).to.have.length(1);
       expect(cleartextSig.signatures[0].valid).to.be.true;
       expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
-      done();
     });
 
   });
@@ -694,7 +686,7 @@ describe("Signature", function() {
     expect(result[0].valid).to.be.true;
   });
 
-  it('Detached signature signing and verification', function () {
+  it('Detached signature signing and verification', () => {
     var msg = openpgp.message.fromText('hello');
     var pubKey2 = openpgp.key.readArmored(pub_key_arm2).keys[0];
     var privKey2 = openpgp.key.readArmored(priv_key_arm2).keys[0];
@@ -702,7 +694,7 @@ describe("Signature", function() {
 
     var opt = {numBits: 512, userIds: { name:'test', email:'a@b.com' }, passphrase: null};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(gen) {
+    return openpgp.generateKey(opt).then(function(gen) {
       var generatedKey = gen.key;
       var detachedSig = msg.signDetached([generatedKey, privKey2]);
       var result = msg.verifyDetached(detachedSig, [generatedKey.toPublic(), pubKey2]);
@@ -711,17 +703,14 @@ describe("Signature", function() {
     });
   });
 
-  it('Sign message with key without password', function(done) {
+  it('Sign message with key without password', () => {
     var opt = {numBits: 512, userIds: { name:'test', email:'a@b.com' }, passphrase: null};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
-    openpgp.generateKey(opt).then(function(gen) {
+    return openpgp.generateKey(opt).then(function(gen) {
       var key = gen.key;
-
       var message = openpgp.message.fromText('hello world');
       message = message.sign([key]);
-
       expect(message).to.exist;
-      done();
     });
   });
 

--- a/test/worker/async_proxy.js
+++ b/test/worker/async_proxy.js
@@ -49,14 +49,13 @@ tryTests('Async Proxy', tests, {
 function tests() {
 
   describe('Error handling', function() {
-    it('Depleted random buffer in worker gives error', function (done) {
+    it('Depleted random buffer in worker gives error', () => {
       var wProxy = new openpgp.AsyncProxy({ path:'../dist/openpgp.worker.js' });
       wProxy.worker = new Worker('../dist/openpgp.worker.js');
       wProxy.worker.onmessage = wProxy.onMessage.bind(wProxy);
       wProxy.seedRandom(10);
-      wProxy.delegate('encrypt', { publicKeys:[pubKey], data:plaintext }).catch(function(err) {
+      return wProxy.delegate('encrypt', { publicKeys:[pubKey], data:plaintext }).catch(function(err) {
         expect(err.message).to.match(/Random number buffer depleted/);
-        done();
       });
     });
   });


### PR DESCRIPTION
Chai throws an error when an assertion fails, so when this happens within a promise the subsequent done() never gets executed. This causes the test to time out instead of failing immediately. 
To fix this, we can just return the promise instead of using the done callback.