### PR TITLE
Fix #607 - Add support for bzip2 de/compression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,6 +213,12 @@ module.exports = function(grunt) {
         cwd: 'node_modules/zlibjs/bin/',
         src: ['rawdeflate.min.js','rawinflate.min.js','zlib.min.js'],
         dest: 'src/compression/'
+      },
+      bzip2: {
+        expand: true,
+        cwd: 'node_modules/compressjs/bin/',
+        src: ['bzip2.build.js'],
+        dest: 'src/compression/'
       }
     },
     clean: ['dist/'],
@@ -310,7 +316,7 @@ module.exports = function(grunt) {
   // Build tasks
   grunt.registerTask('version', ['replace:openpgp', 'replace:openpgp_debug']);
   grunt.registerTask('replace_min', ['replace:openpgp_min', 'replace:worker_min']);
-  grunt.registerTask('default', ['clean', 'copy:zlib', 'browserify', 'version', 'uglify', 'replace_min']);
+  grunt.registerTask('default', ['clean', 'copy:zlib', 'copy:bzip2', 'browserify', 'version', 'uglify', 'replace_min']);
   grunt.registerTask('documentation', ['jsdoc']);
   // Test/Dev tasks
   grunt.registerTask('test', ['eslint', 'mochaTest']);

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ OpenPGP.js [![Build Status](https://travis-ci.org/openpgpjs/openpgpjs.svg?branch
         - [Set up](#set-up)
         - [Encrypt and decrypt *Uint8Array* data with a password](#encrypt-and-decrypt-uint8array-data-with-a-password)
         - [Encrypt and decrypt *String* data with PGP keys](#encrypt-and-decrypt-string-data-with-pgp-keys)
+        - [Encrypt with compression](#encrypt-with-compression)
         - [Generate new key pair](#generate-new-key-pair)
         - [Lookup public key on HKP server](#lookup-public-key-on-hkp-server)
         - [Upload public key to HKP server](#upload-public-key-to-hkp-server)
@@ -180,7 +181,10 @@ Or, override the config to enable compression:
 openpgp.config.compression = openpgp.enums.compression.zip
 ```
 
-Where `compression` can take the value of `openpgp.enums.compression.zlib` or `openpgp.enums.compression.zip`.
+Where the value can be any of:
+ * `openpgp.enums.compression.zip`
+ * `openpgp.enums.compression.zlib`
+ * `openpgp.enums.compression.bzip2`
 
 
 #### Generate new key pair

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node-fetch": "^1.7.3",
     "node-localstorage": "~1.3.0",
     "rusha": "^0.8.12",
-    "compressjs": "github:mmso/compressjs.git"
+    "compressjs": "github:openpgpjs/compressjs.git"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "jwk-to-pem": "^1.2.6",
     "node-fetch": "^1.7.3",
     "node-localstorage": "~1.3.0",
-    "rusha": "^0.8.12"
+    "rusha": "^0.8.12",
+    "compressjs": "github:mmso/compressjs.git"
   },
   "repository": {
     "type": "git",

--- a/src/packet/compressed.js
+++ b/src/packet/compressed.js
@@ -24,6 +24,7 @@
  * @requires compression/zlib
  * @requires compression/rawinflate
  * @requires compression/rawdeflate
+ * @requires compression/bzip2
  * @requires enums
  * @requires util
  * @module packet/compressed
@@ -34,6 +35,7 @@ import util from '../util.js';
 import Zlib from '../compression/zlib.min.js';
 import RawInflate from '../compression/rawinflate.min.js';
 import RawDeflate from '../compression/rawdeflate.min.js';
+import Bzip2 from '../compression/bzip2.build.js';
 
 /**
  * @constructor
@@ -114,8 +116,8 @@ Compressed.prototype.decompress = function () {
       break;
 
     case 'bzip2':
-      // TODO: need to implement this
-      throw new Error('Compression algorithm BZip2 [BZ2] is not implemented.');
+      decompressed = Bzip2.decompressFile(this.compressed);
+      break;
 
     default:
       throw new Error("Compression algorithm unknown :" + this.algorithm);
@@ -150,9 +152,8 @@ Compressed.prototype.compress = function () {
       break;
 
     case 'bzip2':
-      //  - BZip2 [BZ2]
-      // TODO: need to implement this
-      throw new Error("Compression algorithm BZip2 [BZ2] is not implemented.");
+      this.compressed = Bzip2.compressFile(uncompressed);
+      break;
 
     default:
       throw new Error("Compression algorithm unknown :" + this.type);

--- a/test/general/decompression.js
+++ b/test/general/decompression.js
@@ -1,0 +1,60 @@
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../../dist/openpgp');
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+const password = 'I am a password';
+
+const tests = {
+  zip: {
+    input: `-----BEGIN PGP MESSAGE-----
+
+jA0ECQMC5rhAA7l3jOzk0kwBTMc07y+1NME5RCUQ2EOlSofbh1KARLC5B1NMeBlq
+jS917VBeCW3R21xG+0ZJ6Z5iWwdQD7XBtg19doWOqExSmXBWWW/6vSaD81ox
+=Gw9+
+-----END PGP MESSAGE-----`,
+    output: 'Hello world! With zip.'
+  },
+  zlib: {
+    input: `-----BEGIN PGP MESSAGE-----
+
+jA0ECQMC8Qfig2+Tygnk0lMB++5JoyZUcpUy5EJqcxBuy93tXw+BSk7OhFhda1Uo
+JuQlKv27HlyUaA55tMJsFYPypGBLEXW3k0xi3Cs87RrLqmVGTZSqNhHOVNE28lVe
+W40mpQ==
+=z0we
+-----END PGP MESSAGE-----`,
+    output: 'Hello world! With zlib.'
+  },
+  bzip2: {
+    input: `-----BEGIN PGP MESSAGE-----
+
+jA0ECQMC97w+wp7u9/Xk0oABBfapJBuuxGBiHDfNmVgsRzbjLDBWTJ3LD4UtxEku
+qu6hwp5JXB0TgI/XQ3tKobSqHv1wSJ9SVxtWZq6WvWulu+j9GtzIVC3mbDA/qRA3
+41sUEMdAFC6I7BYLYGEiUAVNpjbvGOmJWptDyawjRgEuZeTzKyTI/UcMc/rLy9Pz
+Xg==
+=6ek1
+-----END PGP MESSAGE-----`,
+    output: 'Hello world! With bzip2.'
+  }
+};
+
+describe('Decrypt and decompress message tests', function () {
+
+  function runTest(key, test) {
+    it(`Decrypts message compressed with ${key}`, function () {
+      const message = openpgp.message.readArmored(test.input);
+      const options = {
+          passwords: password,
+          message
+        };
+      return openpgp.decrypt(options).then(function (encrypted) {
+        expect(encrypted.data).to.equal(test.output + '\n');
+      });
+    });
+  }
+
+  Object.keys(tests).forEach(key => runTest(key, tests[key]));
+
+});

--- a/test/general/index.js
+++ b/test/general/index.js
@@ -10,5 +10,6 @@ describe('General', function () {
   require('./oid.js');
   require('./ecc_nist.js');
   require('./x25519.js');
+  require('./decompression.js');
 });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -183,12 +183,6 @@ function withCompression(tests) {
     const compressionName = openpgp.enums.read(openpgp.enums.compression, compression);
     const group = `compression - ${compressionName}`;
 
-    // Compression bzip2 [BZ2] is yet to be implemented.
-    if (compression === openpgp.enums.compression.bzip2) {
-      describe.skip(`${group} (not implemented --> skipping tests)`, tests);
-      return;
-    }
-
     describe(group, function() {
       let compressSpy;
       let decompressSpy;


### PR DESCRIPTION
This pull request adds support for bzip2 compression and decompression.

For the bzip2 implementation I am using https://github.com/cscott/compressjs which was the fastest one I could find and it has support for typed arrays and both compression and decompression.

Since that module contains other compression algorithms, I had to fork it in order to generate a single build that only contains bzip2. That's why it's reading from my own repo at "github:mmso/compressjs.git".

With the bzip2 library this adds a footprint of about 48kB to the final build.

```
Before: >> 2 files created 1.28 MB → 576.36 kB
After: >> 2 files created 1.37 MB → 624.69 kB
```