### PR TITLE
Cleartext hashing fixes

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -29,7 +29,7 @@ import armor from './encoding/armor';
 import enums from './enums';
 import packet from './packet';
 import { Signature } from './signature';
-import { createVerificationObjects } from './message';
+import { createVerificationObjects, createSignaturePackets } from './message';
 import { getPreferredHashAlgo } from './key';
 
 /**
@@ -80,34 +80,10 @@ CleartextMessage.prototype.sign = async function(privateKeys) {
  * @return {module:signature~Signature}      new detached signature of message content
  */
 CleartextMessage.prototype.signDetached = async function(privateKeys) {
-  const packetlist = new packet.List();
   const literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
 
-  await Promise.all(privateKeys.map(async function(privateKey) {
-    if (privateKey.isPublic()) {
-      throw new Error('Need private key for signing');
-    }
-    await privateKey.verifyPrimaryUser();
-    const signingKeyPacket = privateKey.getSigningKeyPacket();
-    if (!signingKeyPacket) {
-      throw new Error('Could not find valid key packet for signing in key ' +
-                      privateKey.primaryKey.getKeyId().toHex());
-    }
-    const signaturePacket = new packet.Signature();
-    signaturePacket.signatureType = enums.signature.text;
-    signaturePacket.publicKeyAlgorithm = signingKeyPacket.algorithm;
-    signaturePacket.hashAlgorithm = getPreferredHashAlgo(privateKey);
-    if (!signingKeyPacket.isDecrypted) {
-      throw new Error('Private key is not decrypted.');
-    }
-    await signaturePacket.sign(signingKeyPacket, literalDataPacket);
-    return signaturePacket;
-  })).then(signatureList => {
-    signatureList.forEach(signaturePacket => packetlist.push(signaturePacket));
-  });
-
-  return new Signature(packetlist);
+  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys));
 };
 
 /**

--- a/src/message.js
+++ b/src/message.js
@@ -540,7 +540,7 @@ Message.prototype.verifyDetached = function(signature, keys) {
  * @param {Array<module:key~Key>} keys array of keys to verify signatures
  * @return {Array<({keyid: module:type/keyid, valid: Boolean})>} list of signer's keyid and validity of signature
  */
-async function createVerificationObjects(signatureList, literalDataList, keys) {
+export async function createVerificationObjects(signatureList, literalDataList, keys) {
   return Promise.all(signatureList.map(async function(signature) {
     let keyPacket = null;
     await Promise.all(keys.map(async function(key) {

--- a/src/message.js
+++ b/src/message.js
@@ -404,7 +404,6 @@ Message.prototype.sign = async function(privateKeys=[], signature=null) {
     }
     const onePassSig = new packet.OnePassSignature();
     onePassSig.type = signatureType;
-    //TODO get preferred hash algo from key signature
     onePassSig.hashAlgorithm = getPreferredHashAlgo(privateKey);
     onePassSig.publicKeyAlgorithm = signingKeyPacket.algorithm;
     onePassSig.signingKeyId = signingKeyPacket.getKeyId();

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1279,7 +1279,7 @@ describe('OpenPGP.js public api tests', function() {
               privateKeys: [privateKey.keys[0], privKeyDE]
             };
             const verifyOpt = {
-              publicKeys: publicKey.keys
+              publicKeys: [publicKey.keys[0], privKeyDE.toPublic()]
             };
             return openpgp.sign(signOpt).then(function (signed) {
               expect(signed.data).to.match(/-----BEGIN PGP SIGNED MESSAGE-----/);
@@ -1290,6 +1290,9 @@ describe('OpenPGP.js public api tests', function() {
               expect(verified.signatures[0].valid).to.be.true;
               expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
               expect(verified.signatures[0].signature.packets.length).to.equal(1);
+              expect(verified.signatures[1].valid).to.be.true;
+              expect(verified.signatures[1].keyid.toHex()).to.equal(privKeyDE.getSigningKeyPacket().getKeyId().toHex());
+              expect(verified.signatures[1].signature.packets.length).to.equal(1);
             });
           });
 


### PR DESCRIPTION
Fixes #643 

Updates cleartext signing to use the preferred hash algorithms from the private key and to correctly handle cases where no hashes are encoded in the header (in which case md5 should be assumed for all packets). 

Also combines some common signature and verification code from cleartext.js and message.js