### PR TITLE
Add a date parameter to the sign/verify/encrypt/decrypt functions

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -24,7 +24,6 @@
  * @module cleartext
  */
 
-import util from './util.js';
 import config from './config';
 import armor from './encoding/armor';
 import enums from './enums';
@@ -72,7 +71,7 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
  * @param  {Date} date                       (optional) The creation time of the signature that should be created
  * @return {module:message~CleartextMessage} new cleartext message with signed content
  */
-CleartextMessage.prototype.sign = async function(privateKeys, signature = null, date=new Date()) {
+CleartextMessage.prototype.sign = async function(privateKeys, signature=null, date=new Date()) {
   return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, date));
 };
 

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -69,25 +69,25 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
- * @param  {Date} creationDate     The creation time of the signature that should be created
+ * @param  {Date} date     The creation time of the signature that should be created
  * @return {module:message~CleartextMessage} new cleartext message with signed content
  */
-CleartextMessage.prototype.sign = async function(privateKeys, signature = null, creationDate = new Date()) {
-  return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, creationDate));
+CleartextMessage.prototype.sign = async function(privateKeys, signature = null, date = new Date()) {
+  return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, date));
 };
 
 /**
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
- * @param  {Date} creationDate     The creation time of the signature that should be created
+ * @param  {Date} date     The creation time of the signature that should be created
  * @return {module:signature~Signature}      new detached signature of message content
  */
-CleartextMessage.prototype.signDetached = async function(privateKeys, signature = null, creationDate = new Date()) {
+CleartextMessage.prototype.signDetached = async function(privateKeys, signature = null, date = new Date()) {
   const literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
 
-  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, creationDate));
+  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, date));
 };
 
 /**

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -24,13 +24,13 @@
  * @module cleartext
  */
 
+import util from './util.js';
 import config from './config';
 import armor from './encoding/armor';
 import enums from './enums';
 import packet from './packet';
 import { Signature } from './signature';
 import { createVerificationObjects, createSignaturePackets } from './message';
-import { getPreferredHashAlgo } from './key';
 
 /**
  * @class
@@ -69,10 +69,10 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
- * @param  {Date} date     The creation time of the signature that should be created
+ * @param  {Date} date                       (optional) The creation time of the signature that should be created
  * @return {module:message~CleartextMessage} new cleartext message with signed content
  */
-CleartextMessage.prototype.sign = async function(privateKeys, signature = null, date = new Date()) {
+CleartextMessage.prototype.sign = async function(privateKeys, signature = null, date=new Date()) {
   return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, date));
 };
 
@@ -80,10 +80,10 @@ CleartextMessage.prototype.sign = async function(privateKeys, signature = null, 
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
- * @param  {Date} date     The creation time of the signature that should be created
+ * @param  {Date} date                       (optional) The creation time of the signature that should be created
  * @return {module:signature~Signature}      new detached signature of message content
  */
-CleartextMessage.prototype.signDetached = async function(privateKeys, signature = null, date = new Date()) {
+CleartextMessage.prototype.signDetached = async function(privateKeys, signature=null, date=new Date()) {
   const literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
 
@@ -93,23 +93,25 @@ CleartextMessage.prototype.signDetached = async function(privateKeys, signature 
 /**
  * Verify signatures of cleartext signed message
  * @param {Array<module:key~Key>} keys array of keys to verify signatures
+ * @param {Date} date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
  * @return {Array<{keyid: module:type/keyid, valid: Boolean}>} list of signer's keyid and validity of signature
  */
-CleartextMessage.prototype.verify = function(keys) {
-  return this.verifyDetached(this.signature, keys);
+CleartextMessage.prototype.verify = function(keys, date=new Date()) {
+  return this.verifyDetached(this.signature, keys, date);
 };
 
 /**
  * Verify signatures of cleartext signed message
  * @param {Array<module:key~Key>} keys array of keys to verify signatures
+ * @param {Date} date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
  * @return {Array<{keyid: module:type/keyid, valid: Boolean}>} list of signer's keyid and validity of signature
  */
-CleartextMessage.prototype.verifyDetached = function(signature, keys) {
+CleartextMessage.prototype.verifyDetached = function(signature, keys, date=new Date()) {
   const signatureList = signature.packets;
   const literalDataPacket = new packet.Literal();
   // we assume that cleartext signature is generated based on UTF8 cleartext
   literalDataPacket.setText(this.text);
-  return createVerificationObjects(signatureList, [literalDataPacket], keys);
+  return createVerificationObjects(signatureList, [literalDataPacket], keys, date);
 };
 
 /**

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -68,22 +68,26 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
 /**
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
+ * @param  {Signature} signature             (optional) any existing detached signature
+ * @param  {Date} creationDate     The creation time of the signature that should be created
  * @return {module:message~CleartextMessage} new cleartext message with signed content
  */
-CleartextMessage.prototype.sign = async function(privateKeys) {
-  return new CleartextMessage(this.text, await this.signDetached(privateKeys));
+CleartextMessage.prototype.sign = async function(privateKeys, signature = null, creationDate = new Date()) {
+  return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, creationDate));
 };
 
 /**
  * Sign the cleartext message
  * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
+ * @param  {Signature} signature             (optional) any existing detached signature
+ * @param  {Date} creationDate     The creation time of the signature that should be created
  * @return {module:signature~Signature}      new detached signature of message content
  */
-CleartextMessage.prototype.signDetached = async function(privateKeys) {
+CleartextMessage.prototype.signDetached = async function(privateKeys, signature = null, creationDate = new Date()) {
   const literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
 
-  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys));
+  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, creationDate));
 };
 
 /**

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -46,8 +46,6 @@ export default {
   ignore_mdc_error:         false,
   /** @property {Boolean} checksum_required Do not throw error when armor is missing a checksum */
   checksum_required:        false,
-  /** @property {Boolean} verify_expired_keys Allow signature verification with expired keys */
-  verify_expired_keys:      true,
   /** @property {Boolean} rsa_blinding */
   rsa_blinding:             true,
   /** Work-around for rare GPG decryption bug when encrypting with multiple passwords

--- a/src/key.js
+++ b/src/key.js
@@ -677,7 +677,6 @@ Key.prototype.signAllUsers = async function(privateKeys) {
  * - if no arguments are given, verifies the self certificates;
  * - otherwise, verifies all certificates signed with given keys.
  * @param  {Array<module:key~Key>} keys array of keys to verify certificate signatures
- * @param {Date} date (optional) use the given date for verification instead of the current time
  * @return {Array<({keyid: module:type/keyid, valid: Boolean})>} list of signer's keyid and validity of signature
  */
 Key.prototype.verifyPrimaryUser = async function(keys) {
@@ -957,7 +956,7 @@ SubKey.prototype.toPacketlist = function() {
  * @return {Boolean}
  */
 SubKey.prototype.isValidEncryptionKey = async function(primaryKey, date=new Date()) {
-  if (await this.verify(primaryKey) !== enums.keyStatus.valid) {
+  if (await this.verify(primaryKey, date) !== enums.keyStatus.valid) {
     return false;
   }
   for (let i = 0; i < this.bindingSignatures.length; i++) {
@@ -975,7 +974,7 @@ SubKey.prototype.isValidEncryptionKey = async function(primaryKey, date=new Date
  * @return {Boolean}
  */
 SubKey.prototype.isValidSigningKey = async function(primaryKey, date=new Date()) {
-  if (await this.verify(primaryKey) !== enums.keyStatus.valid) {
+  if (await this.verify(primaryKey, date) !== enums.keyStatus.valid) {
     return false;
   }
   for (let i = 0; i < this.bindingSignatures.length; i++) {
@@ -1290,7 +1289,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
     const dataToSign = {};
     dataToSign.userid = userIdPacket;
     dataToSign.key = secretKeyPacket;
-    const signaturePacket = new packet.Signature(new Date(1000));
+    const signaturePacket = new packet.Signature();
     signaturePacket.signatureType = enums.signature.cert_generic;
     signaturePacket.publicKeyAlgorithm = options.keyType;
     signaturePacket.hashAlgorithm = getPreferredHashAlgo(secretKeyPacket);

--- a/src/message.js
+++ b/src/message.js
@@ -452,8 +452,6 @@ Message.prototype.compress = function(compression) {
  * @return {module:signature~Signature}      new detached signature of message content
  */
 Message.prototype.signDetached = async function(privateKeys=[], signature=null, date=new Date()) {
-  const packetlist = new packet.List();
-
   const literalDataPacket = this.packets.findPacket(enums.packet.literal);
   if (!literalDataPacket) {
     throw new Error('No literal data packet to sign.');

--- a/src/message.js
+++ b/src/message.js
@@ -360,7 +360,7 @@ export function encryptSessionKey(sessionKey, symAlgo, publicKeys, passwords, wi
 
 /**
  * Sign the message (the literal data packet of the message)
- * @param  {Array<module:key~Key>} privateKeys private keys with decrypted secret key data for signing
+ * @param  {Array<module:key~Key>}        privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature          (optional) any existing detached signature to add to the message
  * @param  {Date} date}                   (optional) override the creation time of the signature
  * @return {module:message~Message}       new message with signed content

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -345,7 +345,7 @@ export function verify({ message, publicKeys, signature=null, date=new Date() })
   publicKeys = toArray(publicKeys);
 
   if (asyncProxy) { // use web worker if available
-    return asyncProxy.delegate('verify', { message, publicKeys, signature });
+    return asyncProxy.delegate('verify', { message, publicKeys, signature, date });
   }
 
   return Promise.resolve().then(async function() {

--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -60,7 +60,7 @@ export function clonePackets(options) {
     if (options.message instanceof Message) {
       options.message = options.message.packets;
     } else if (options.message instanceof CleartextMessage) {
-      options.message.signature = options.message.signature.packets;
+      options.message = { text: options.message.text, signature: options.message.signature.packets };
     }
   }
   if (options.signature && (options.signature instanceof Signature)) {

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -31,10 +31,10 @@ import enums from '../enums.js';
 /**
  * @constructor
  */
-export default function Literal(creationDate = new Date()) {
+export default function Literal(date = new Date()) {
   this.tag = enums.packet.literal;
   this.format = 'utf8'; // default format for literal data packets
-  this.date = creationDate;
+  this.date = date;
   this.data = new Uint8Array(0); // literal data representation
   this.filename = 'msg.txt';
 }

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -29,12 +29,13 @@ import util from '../util.js';
 import enums from '../enums.js';
 
 /**
+ * @param {Date} date the creation date of the literal package
  * @constructor
  */
-export default function Literal(date = new Date()) {
+export default function Literal(date=new Date()) {
   this.tag = enums.packet.literal;
   this.format = 'utf8'; // default format for literal data packets
-  this.date = date;
+  this.date = util.normalizeDate(date);
   this.data = new Uint8Array(0); // literal data representation
   this.filename = 'msg.txt';
 }

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -31,10 +31,10 @@ import enums from '../enums.js';
 /**
  * @constructor
  */
-export default function Literal() {
+export default function Literal(creationDate = new Date()) {
   this.tag = enums.packet.literal;
   this.format = 'utf8'; // default format for literal data packets
-  this.date = new Date();
+  this.date = creationDate;
   this.data = new Uint8Array(0); // literal data representation
   this.filename = 'msg.txt';
 }

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -43,7 +43,7 @@ export default function PublicKey() {
   this.version = 4;
   /** Key creation date.
    * @type {Date} */
-  this.created = new Date();
+  this.created = util.normalizeDate();
   /* Algorithm specific params */
   this.params = [];
   // time in days (V3 only)

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -666,8 +666,8 @@ Signature.prototype.verify = async function (key, data) {
  * @return {Boolean} true if expired
  */
 Signature.prototype.isExpired = function (date=new Date()) {
-  if (!this.signatureNeverExpires && date !== null) {
-    const expirationTime = this.created.getTime() + this.signatureExpirationTime*1000;
+  if (date !== null) {
+    const expirationTime = !this.signatureNeverExpires ? this.created.getTime() + this.signatureExpirationTime*1000 : Infinity;
     const normDate = util.normalizeDate(date);
     return !(this.created <= normDate && normDate < expirationTime);
   }

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -40,8 +40,9 @@ import type_keyid from '../type/keyid.js';
 
 /**
  * @constructor
+ * @param {Date} date the creation date of the signature
  */
-export default function Signature(date = new Date()) {
+export default function Signature(date=new Date()) {
   this.tag = enums.packet.signature;
   this.version = 4;
   this.signatureType = null;
@@ -52,7 +53,7 @@ export default function Signature(date = new Date()) {
   this.unhashedSubpackets = null;
   this.signedHashValue = null;
 
-  this.created = date;
+  this.created = util.normalizeDate(date);
   this.signatureExpirationTime = null;
   this.signatureNeverExpires = true;
   this.exportable = null;
@@ -661,11 +662,14 @@ Signature.prototype.verify = async function (key, data) {
 
 /**
  * Verifies signature expiration date
+ * @param {Date} date (optional) use the given date for verification instead of the current time
  * @return {Boolean} true if expired
  */
-Signature.prototype.isExpired = function (date = new Date()) {
-  if (!this.signatureNeverExpires) {
-    return +date > (this.created.getTime() + this.signatureExpirationTime*1000);
+Signature.prototype.isExpired = function (date=new Date()) {
+  if (!this.signatureNeverExpires && date !== null) {
+    const expirationTime = this.created.getTime() + this.signatureExpirationTime*1000;
+    const normDate = util.normalizeDate(date);
+    return !(this.created <= normDate && normDate < expirationTime);
   }
   return false;
 };

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -41,7 +41,7 @@ import type_keyid from '../type/keyid.js';
 /**
  * @constructor
  */
-export default function Signature(creationDate = new Date()) {
+export default function Signature(date = new Date()) {
   this.tag = enums.packet.signature;
   this.version = 4;
   this.signatureType = null;
@@ -52,7 +52,7 @@ export default function Signature(creationDate = new Date()) {
   this.unhashedSubpackets = null;
   this.signedHashValue = null;
 
-  this.created = creationDate;
+  this.created = date;
   this.signatureExpirationTime = null;
   this.signatureNeverExpires = true;
   this.exportable = null;
@@ -663,9 +663,9 @@ Signature.prototype.verify = async function (key, data) {
  * Verifies signature expiration date
  * @return {Boolean} true if expired
  */
-Signature.prototype.isExpired = function (currentDate = new Date()) {
+Signature.prototype.isExpired = function (date = new Date()) {
   if (!this.signatureNeverExpires) {
-    return +currentDate > (this.created.getTime() + this.signatureExpirationTime*1000);
+    return +date > (this.created.getTime() + this.signatureExpirationTime*1000);
   }
   return false;
 };

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -41,7 +41,7 @@ import type_keyid from '../type/keyid.js';
 /**
  * @constructor
  */
-export default function Signature() {
+export default function Signature(creationDate = new Date()) {
   this.tag = enums.packet.signature;
   this.version = 4;
   this.signatureType = null;
@@ -52,7 +52,7 @@ export default function Signature() {
   this.unhashedSubpackets = null;
   this.signedHashValue = null;
 
-  this.created = new Date();
+  this.created = creationDate;
   this.signatureExpirationTime = null;
   this.signatureNeverExpires = true;
   this.exportable = null;
@@ -663,9 +663,9 @@ Signature.prototype.verify = async function (key, data) {
  * Verifies signature expiration date
  * @return {Boolean} true if expired
  */
-Signature.prototype.isExpired = function () {
+Signature.prototype.isExpired = function (currentDate = new Date()) {
   if (!this.signatureNeverExpires) {
-    return Date.now() > (this.created.getTime() + this.signatureExpirationTime*1000);
+    return +currentDate > (this.created.getTime() + this.signatureExpirationTime*1000);
   }
   return false;
 };

--- a/src/util.js
+++ b/src/util.js
@@ -100,15 +100,18 @@ export default {
 
   readDate: function (bytes) {
     const n = this.readNumber(bytes);
-    const d = new Date();
-    d.setTime(n * 1000);
+    const d = new Date(n * 1000);
     return d;
   },
 
   writeDate: function (time) {
-    const numeric = Math.round(time.getTime() / 1000);
+    const numeric = Math.floor(time.getTime() / 1000);
 
     return this.writeNumber(numeric, 4);
+  },
+
+  normalizeDate: function (time = Date.now()) {
+      return time === null ? time : new Date(Math.floor(+time / 1000) * 1000);
   },
 
   hexdump: function (str) {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1577,7 +1577,7 @@ describe('OpenPGP.js public api tests', function() {
               return openpgp.verify(verifyOpt);
             }).then(function (verified) {
               expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
-              expect(Array.from(verified.data)).to.deep.equal(Array.from(data));
+              expect([].slice.call(verified.data)).to.deep.equal([].slice.call(data));
               expect(verified.signatures[0].valid).to.be.true;
               expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, future))
                   .to.be.not.null;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1583,7 +1583,7 @@ describe('OpenPGP.js public api tests', function() {
                   expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(verified.data).to.equal(plaintext);
                   expect(verified.signatures[0].valid).to.be.true;
-                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, past))
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, past))
                       .to.be.not.a('null');
                   expect(verified.signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1611,7 +1611,7 @@ describe('OpenPGP.js public api tests', function() {
                   expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
                   expect(verified.data).to.equal(data);
                   expect(verified.signatures[0].valid).to.be.true;
-                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, future))
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, future))
                       .to.be.not.a('null');
                   expect(verified.signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1686,7 +1686,7 @@ describe('OpenPGP.js public api tests', function() {
               }).then(function (signatures) {
                   expect(+signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, past))
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, past))
                       .to.be.not.a('null');
                   expect(signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1715,7 +1715,7 @@ describe('OpenPGP.js public api tests', function() {
               }).then(function (signatures) {
                   expect(+signatures[0].signature.packets[0].created).to.equal(+future);
                   expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, future))
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, future))
                       .to.be.not.a('null');
                   expect(signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1741,7 +1741,7 @@ describe('OpenPGP.js public api tests', function() {
                   expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(verified.data).to.equal(plaintext);
                   expect(verified.signatures[0].valid).to.be.true;
-                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, past))
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, past))
                       .to.be.not.a('null');
                   expect(verified.signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1816,7 +1816,7 @@ describe('OpenPGP.js public api tests', function() {
               }).then(function (signatures) {
                   expect(+signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, past))
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, past))
                       .to.be.not.a('null');
                   expect(signatures[0].signature.packets.length).to.equal(1);
               });
@@ -1845,7 +1845,7 @@ describe('OpenPGP.js public api tests', function() {
               }).then(function (signatures) {
                   expect(+signatures[0].signature.packets[0].created).to.equal(+future);
                   expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, future))
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, future))
                       .to.be.not.a('null');
                   expect(signatures[0].signature.packets.length).to.equal(1);
               });
@@ -2072,7 +2072,6 @@ describe('OpenPGP.js public api tests', function() {
         });
 
       });
-
     }
 
   });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -214,38 +214,6 @@ t/ia1kMpSEiOVLlX5dfHZzhR3WNtBqU=
 =C0fJ
 -----END PGP PRIVATE KEY BLOCK-----`;
 
-const pub_key_2000_2008 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-xo0EOKg3aAEEALLlUS7z92VAc53Xa/y01jYCJz4L6TrLIp7t4dF/U+rB3R050yT7
-QS8yLVn6LTH9xCPz217zUXtMKZV36qshZHqspz/pZDOD0VDSHVZArENiLMQjKJrR
-k0S5h3sXUfrJzHfna3KZ6kC2HTmLq3UvEjmMTEUOr53zPwvl7Or7/oFlABEBAAHN
-E3Rlc3QgPHRlc3RAZXhhbXBsZT7CrQQTAQoAFwUCOKg3aAIbLwMLCQcDFQoIAh4B
-AheAAAoJEFzwINOIu4R09q8EAIqd3AAl3W0oacbyhLELNKATdR+TwMdQQBl2p8Po
-8QxVJKw5NQzkq2RZzGqIbqCa2MqBP0ZC89OtYPLRXPyhE5p8iQHFy/zz4nN7Twgr
-NXKYVQLAIxC7GMDy+FEKRZ0VNnvqYYM1/TPxu/ML6ojhnDPytEmU58kb2GgBx7ix
-RNsZzo0EOKg3aAEEALOt5AUdDf7fz0DwOkIokGj4zeiFuphsTPwpRAS6c1o9xAzS
-/C8hLFShhTKL4Z9znYkdaMHuFIs7AJ3P5tKlvG0/cZAl3u286lz0aTtQluHMCKNy
-UyhuZ0K1VgZOj+HcDKo8jQ+aejcwjHDg02yPvfzrXHBjWAJMjglV4W+YPFYjABEB
-AAHCwIMEGAEKAA8FAjioN2gFCQ8JnAACGy4AqAkQXPAg04i7hHSdIAQZAQoABgUC
-OKg3aAAKCRDh8+Pj74TEoHURA/4+mbmGa/ZzTjzfrAxceOMIhfV+wGEk1J5Y1mWP
-E85w+BvSQB3aFjVL9Wf1kOiB5iYMFRD8kePjYR11rYhhrH/vh0DBRNXYqcOx0FPx
-Nv2WMedjcYzsmoQqL+7T27tl/Crdq5EMfxFb+FEdDTnx1+RKiiuk3mIJR/Ngl6Yz
-hmYDs08LA/4+xDre4g+YMHj0zaxDBXUawFz5gH5oPeGCCxG/tQeHiC+vYYJy6RGU
-cOL+k4Q79lNqjJK6febtvYziffVsSPWWSdkG0xkujS5bDDpikBATAUVeFVwA5hCo
-5vYp8XWskYHrDXS2ald01abkk8A27pGppcjOS4xxFSqVhw0t/PpJQc6NBDioN2gB
-BAC30PxDScc8m4HSi0AYRfETd8W9VfA4mBbX4A5G6Gr44kg+z1RAzTtvOnC6Hv7g
-JBPg4JtqBBZmfyCUoV/gS9SZB63jSrlk1tBs9I5KmGxOOCrLMucsAl3NCLVuMqzL
-Wm1zyOc6l83j3fRcKe2TrfEDf41Pk1HxlDMBL9rQyqv/uwARAQABwsCDBBgBCgAP
-BQI4qDdoBQkPCZwAAhsuAKgJEFzwINOIu4R0nSAEGQEKAAYFAjioN2gACgkQJVG+
-vfNJQKhK6gP+LB5qXTJKCduuqZm7VhFvPeOu4W0pyORo29zZI0owKZnD2ZKZrZhK
-XZC/1+xKXi8aX4V2ygRth2P1tGFLJRqRiA3C20NVewdI4tQtEqWWSlfNFDz4EsbN
-spyodQ4jPsKPk2R8pFjAwmpXLizPg2UyPKUJ/2GnNWjleP0UNyUXgD1MkgP+IkxX
-TYgDF5/LrOlrq7ThWqFqQ/prQCBy7xxNLjpVKLDxGYbXVER6p0pkD6DXlaOgSB3i
-32dQJnU96l44TlUyaUK/dJP7JPbVUOFq/awSxJiCxFxF6Oarc10qQ+OG5ESdJAjp
-CMHGCzlbt/ia1kMpSEiOVLlX5dfHZzhR3WNtBqU=
-=kwK1
------END PGP PUBLIC KEY BLOCK-----`;
-
 const priv_key_2038_2045 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
 xcEYBH/oGU8BBACilkYen6vxr1LAhqWc0HaS+zMkjeND/P9ENePoNRVo3Bq8
@@ -302,37 +270,19 @@ J4wE4f3U5NnR+W6uranaXA2ghVyUsk0lJtnM400nA/45gAq9EBZUSL+DWdYZ
 =WLIN
 -----END PGP PRIVATE KEY BLOCK-----`;
 
-const pub_key_2038_2045 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+const priv_key_expires_1337 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
-xo0Ef+gZTwEEAKKWRh6fq/GvUsCGpZzQdpL7MySN40P8/0Q14+g1FWjcGrwotpyr
-WlAWK0lVxRrPoPmWTTC2KNJZv+5RKHohbqV1Vi+yMd1OkZiofe8smylhfMHNPqxe
-qG35x5A+Lmkikv9fnbjRZ5pBC0PRqt5xUC2a2Cs3nAn/dKjyWWqZ/yrRABEBAAHN
-FmV4YW1wbGUgPHRlc3RAZXhhbXBsZT7CrQQTAQoAFwUCf+gZTwIbLwMLCQcDFQoI
-Ah4BAheAAAoJEHSimBgePDrrKzoD/2e/hfwT+K59Ag8j4F5l74/hAGBdm0VhW8Vh
-j7PCjrmvV77gDtVyUAguzIMfw/Lf+y3y2J+JE8xGyhU/92bTc5e+D5f0JQ2aqHZk
-/IBREg3dNS7C+fZiNDvc8O4D+0WZH7Yhb3jhr0+DrP0rzs3aVxhlgH8rR7aMZsQ6
-uuoM7mVDzo0Ef+gZTwEEAK0pLhDM5pDxWVfuVFssIdbWhClxlN9ZGhjGM27vf5QE
-0YAluhlv5BTtLU3pYtQYScJksNAFYmENtufWU+c4fv4HHSTGXsW5baw8Ix1vFasr
-Aa9atZWBZklQVt3Bsxu9+jOYxGJDjkzyhpLOZgJSYFK36l8dATPF5t1eGy405i0n
-ABEBAAHCwIMEGAEKAA8FAn/oGU8FCQ8JnAACGy4AqAkQdKKYGB48OuudIAQZAQoA
-BgUCf+gZTwAKCRDuSkIwkyAjaKEqA/9XS9AgN4nV9on6GsuK1ZpQpqcKAf4SZaF3
-rDXqpYfM+LDpqaIl8LZKzK7EyW2pVNV9PwnYtMXwQ7A3KAu2audWxSawHNyvgez1
-Ujl0J7TfKwJyVBrCDjZCJrr+joPU0To95jJivSrnCYC3l1ngoMIZycfaU6FhYwHd
-2XJe2kbzc8JPA/9aCPIahfTEDEH/giKdtzlLbkri2UYGCJqcoNl0Maz6LVUI3NCo
-3O77zi2v7gLtu+9hgfWa8dTxCOszDbNTknb8XXCK74FxwIBgr4gHlvK+xh38RI+8
-eC2y0qONraQ/qACJ+UGh1/4smKasSlBi7hZOvNmOxqm4iQ5hve4uWsSlIs6NBH/o
-GU8BBADDinuE+B31B2hCxsRcNiruHEF9Q65vWUC0w32a9ScsyiiESqhwIgs0L/Ey
-ejnn4jAQVlmgfJJLUIggGjLXGBGF7Q7v4uzxH97JeC+OCFV2b0RIyUf37Sn3i/+B
-/BLp250RbLfN5jOJAtVpnbBJSLDjpWzzC6YBXiUXMRrSdEEwWwARAQABwsCDBBgB
-CgAPBQJ/6BlPBQkPCZwAAhsuAKgJEHSimBgePDrrnSAEGQEKAAYFAn/oGU8ACgkQ
-KMGvjkoZ3acysgP9FoulZYO+rmQwjyYE7hZ97v/gdzWb6ScO+m8Jm30Q0J9uKNTK
-wOlTOh6Nrb0q0t1U2apJ//SQV0zxmQmWf1a5pNR0KdhiD3J02+3hwLl5dSoYzkNz
-A9Xzgg1cCbSDF/dgLH+x1ieMBOH91OTZ0flurq2p2lwNoIVclLJNJSbZzONNJwP+
-OYAKvRAWVEi/g1nWGfv0YF6cOP+6cA26vxuJPuGFp/7bwlJ8ALAk6NsQ+qjfonGO
-VsAU6YXQP9Dt1PvLo7pOtZZ/W9NbuPRaFW7sB6EtYFcko9kckYJXZcIOpffTCPHm
-Jrh3+G2j19Lsnomz3YCU4wETLkMwxQPG3WzOeNLwX+U=
-=yV+n
------END PGP PUBLIC KEY BLOCK-----`;
+xcA4BAAAAAEBAgCgONc0J8rfO6cJw5YTP38x1ze2tAYIO7EcmRCNYwMkXngb
+0Qdzg34Q5RW0rNiR56VB6KElPUhePRPVklLFiIvHABEBAAEAAf9qabYMzsz/
+/LeRVZSsTgTljmJTdzd2ambUbpi+vt8MXJsbaWh71vjoLMWSXajaKSPDjVU5
+waFNt9kLqwGGGLqpAQD5ZdMH2XzTq6GU9Ka69iZs6Pbnzwdz59Vc3i8hXlUj
+zQEApHargCTsrtvSrm+hK/pN51/BHAy9lxCAw9f2etx+AeMA/RGrijkFZtYt
+jeWdv/usXL3mgHvEcJv63N5zcEvDX5X4W1bND3Rlc3QxIDxhQGIuY29tPsJ7
+BBABCAAvBQIAAAABBQMAAAU5BgsJBwgDAgkQzcF99nGrkAkEFQgKAgMWAgEC
+GQECGwMCHgEAABAlAfwPehmLZs+gOhOTTaSslqQ50bl/REjmv42Nyr1ZBlQS
+DECl1Qu4QyeXin29uEXWiekMpNlZVsEuc8icCw6ABhIZ
+=/7PI
+-----END PGP PRIVATE KEY BLOCK-----`;
 
 const passphrase = 'hello world';
 const plaintext = 'short message\nnext line\n한국어/조선말';
@@ -645,6 +595,8 @@ describe('OpenPGP.js public api tests', function() {
     let publicKey_2000_2008;
     let privateKey_2038_2045;
     let publicKey_2038_2045;
+    let privateKey_1337;
+    let publicKey_1337;
     let privateKey;
     let publicKey;
     let zero_copyVal;
@@ -658,18 +610,18 @@ describe('OpenPGP.js public api tests', function() {
       privateKey = openpgp.key.readArmored(priv_key);
       expect(privateKey.keys).to.have.length(1);
       expect(privateKey.err).to.not.exist;
-      publicKey_2000_2008 = openpgp.key.readArmored(pub_key_2000_2008);
-      expect(publicKey_2000_2008.keys).to.have.length(1);
-      expect(publicKey_2000_2008.err).to.not.exist;
       privateKey_2000_2008 = openpgp.key.readArmored(priv_key_2000_2008);
       expect(privateKey_2000_2008.keys).to.have.length(1);
       expect(privateKey_2000_2008.err).to.not.exist;
-      publicKey_2038_2045 = openpgp.key.readArmored(pub_key_2038_2045);
-      expect(publicKey_2038_2045.keys).to.have.length(1);
-      expect(publicKey_2038_2045.err).to.not.exist;
+      publicKey_2000_2008 = { keys: [ privateKey_2000_2008.keys[0].toPublic() ] };
       privateKey_2038_2045 = openpgp.key.readArmored(priv_key_2038_2045);
       expect(privateKey_2038_2045.keys).to.have.length(1);
       expect(privateKey_2038_2045.err).to.not.exist;
+      publicKey_2038_2045 = { keys: [ privateKey_2038_2045.keys[0].toPublic() ] };
+      privateKey_1337 = openpgp.key.readArmored(priv_key_expires_1337);
+      expect(privateKey_1337.keys).to.have.length(1);
+      expect(privateKey_1337.err).to.not.exist;
+      publicKey_1337 = { keys: [ privateKey_1337.keys[0].toPublic() ] };
       zero_copyVal = openpgp.config.zero_copy;
       use_nativeVal = openpgp.config.use_native;
       aead_protectVal = openpgp.config.aead_protect;
@@ -1539,7 +1491,7 @@ describe('OpenPGP.js public api tests', function() {
         });
 
         it('should sign and verify cleartext data and not armor with detached signatures', function () {
-            const start = Date.now();
+            const start = openpgp.util.normalizeDate();
             const signOpt = {
                 data: plaintext,
                 privateKeys: privateKey.keys,
@@ -1555,301 +1507,182 @@ describe('OpenPGP.js public api tests', function() {
                 return openpgp.verify(verifyOpt);
             }).then(function (verified) {
                 expect(verified.data).to.equal(plaintext);
-                expect(+verified.signatures[0].signature.packets[0].created).to.be.lte(Date.now());
-                expect(+verified.signatures[0].signature.packets[0].created).to.be.gte(start);
+                expect(+verified.signatures[0].signature.packets[0].created).to.be.lte(+openpgp.util.normalizeDate());
+                expect(+verified.signatures[0].signature.packets[0].created).to.be.gte(+start);
                 expect(verified.signatures[0].valid).to.be.true;
                 expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
                 expect(verified.signatures[0].signature.packets.length).to.equal(1);
             });
         });
 
-          it('should sign and verify cleartext data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const signOpt = {
-                  data: plaintext,
-                  privateKeys: privateKey_2000_2008.keys,
-                  detached: true,
-                  creationDate: past,
-                  armor: false
-              };
-              const verifyOpt = {
-                  publicKeys: publicKey_2000_2008.keys
-              };
-              return openpgp.sign(signOpt).then(function (signed) {
-                  verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
-                  verifyOpt.signature = signed.signature;
-                  return openpgp.verify(verifyOpt);
-              }).then(function (verified) {
+        it('should sign and verify cleartext data with a date in the past', function () {
+            const past = new Date(2000);
+            const signOpt = {
+                data: plaintext,
+                privateKeys: privateKey_1337.keys,
+                detached: true,
+                date: past,
+                armor: false
+            };
+            const verifyOpt = {
+                publicKeys: publicKey_1337.keys,
+                date: past
+            };
+            return openpgp.sign(signOpt).then(function (signed) {
+                verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
+                verifyOpt.signature = signed.signature;
+                return openpgp.verify(verifyOpt).then(function (verified) {
                   expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(verified.data).to.equal(plaintext);
                   expect(verified.signatures[0].valid).to.be.true;
                   expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, past))
-                      .to.be.not.a('null');
+                      .to.be.not.null;
                   expect(verified.signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
-
-
-          it('should sign and verify binary data with a date in the future', function () {
-              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
-              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
-              const signOpt = {
-                  data,
-                  privateKeys: privateKey_2038_2045.keys,
-                  detached: true,
-                  creationDate: future,
-                  armor: false
-              };
-              const verifyOpt = {
-                  publicKeys: publicKey_2038_2045.keys
-              };
-              return openpgp.sign(signOpt).then(function (signed) {
-                  verifyOpt.message = openpgp.message.fromBinary(data);
-                  verifyOpt.signature = signed.signature;
+                  // now check with expiration checking disabled
+                  verifyOpt.date = null;
                   return openpgp.verify(verifyOpt);
-              }).then(function (verified) {
-                  expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
-                  expect(verified.data).to.equal(data);
-                  expect(verified.signatures[0].valid).to.be.true;
-                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, future))
-                      .to.be.not.a('null');
-                  expect(verified.signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
-
-          it('should encrypt and decrypt cleartext data with a date in the future', function () {
-              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
-              const encryptOpt = {
-                  data: plaintext,
-                  publicKeys: publicKey_2038_2045.keys,
-                  creationDate: future,
-                  armor: false
-              };
-              const decryptOpt = {
-                  privateKeys: privateKey_2038_2045.keys
-              };
-
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  decryptOpt.message = encrypted.message;
-                  return encrypted.message.decrypt(decryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+future);
-                  expect(packets.getText()).to.equal(plaintext);
-              });
-          });
-
-
-          it('should encrypt and decrypt binary data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
-              const encryptOpt = {
-                  data,
-                  publicKeys: publicKey_2000_2008.keys,
-                  creationDate: past,
-                  armor: false
-              };
-              const decryptOpt = {
-                  privateKeys: privateKey_2000_2008.keys
-              };
-
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  decryptOpt.message = encrypted.message;
-                  return encrypted.message.decrypt(decryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+past);
-                  expect(packets.getLiteralData()).to.deep.equal(data);
-              });
-          });
-
-          it('should sign, encrypt and decrypt, verify cleartext data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const encryptOpt = {
-                  data: plaintext,
-                  publicKeys: publicKey_2000_2008.keys,
-                  privateKeys: privateKey_2000_2008.keys,
-                  creationDate: past,
-                  armor: false
-              };
-
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  return encrypted.message.decrypt(encryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+past);
-                  expect(packets.getText()).to.equal(plaintext);
-                  return packets.verify(encryptOpt.publicKeys);
-              }).then(function (signatures) {
-                  expect(+signatures[0].signature.packets[0].created).to.equal(+past);
-                  expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, past))
-                      .to.be.not.a('null');
-                  expect(signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
-
-
-          it('should sign, encrypt and decrypt, verify binary data with a date in the future', function () {
-              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
-              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
-              const encryptOpt = {
-                  data,
-                  publicKeys: publicKey_2038_2045.keys,
-                  privateKeys: privateKey_2038_2045.keys,
-                  creationDate: future,
-                  armor: false
-              };
-
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  return encrypted.message.decrypt(encryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+future);
-                  expect(packets.getLiteralData()).to.deep.equal(data);
-                  return packets.verify(encryptOpt.publicKeys);
-              }).then(function (signatures) {
-                  expect(+signatures[0].signature.packets[0].created).to.equal(+future);
-                  expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, future))
-                      .to.be.not.a('null');
-                  expect(signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
-
-          it('should sign and verify cleartext data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const signOpt = {
-                  data: plaintext,
-                  privateKeys: privateKey_2000_2008.keys,
-                  detached: true,
-                  creationDate: past,
-                  armor: false
-              };
-              const verifyOpt = {
-                  publicKeys: publicKey_2000_2008.keys
-              };
-              return openpgp.sign(signOpt).then(function (signed) {
-                  verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
-                  verifyOpt.signature = signed.signature;
-                  return openpgp.verify(verifyOpt);
-              }).then(function (verified) {
+                }).then(function (verified) {
                   expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
                   expect(verified.data).to.equal(plaintext);
                   expect(verified.signatures[0].valid).to.be.true;
-                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, past))
-                      .to.be.not.a('null');
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, null))
+                      .to.be.not.null;
                   expect(verified.signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
+                });
+            });
+        });
 
-          it('should encrypt and decrypt cleartext data with a date in the future', function () {
-              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
-              const encryptOpt = {
-                  data: plaintext,
-                  publicKeys: publicKey_2038_2045.keys,
-                  creationDate: future,
-                  armor: false
-              };
-              const decryptOpt = {
-                  privateKeys: privateKey_2038_2045.keys
-              };
+        it('should sign and verify binary data with a date in the future', function () {
+            const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+            const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+            const signOpt = {
+                data,
+                privateKeys: privateKey_2038_2045.keys,
+                detached: true,
+                date: future,
+                armor: false
+            };
+            const verifyOpt = {
+                publicKeys: publicKey_2038_2045.keys,
+                date: future
+            };
+            return openpgp.sign(signOpt).then(function (signed) {
+                verifyOpt.message = openpgp.message.fromBinary(data);
+                verifyOpt.signature = signed.signature;
+                return openpgp.verify(verifyOpt);
+            }).then(function (verified) {
+                expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
+                expect(verified.data).to.equal(data);
+                expect(verified.signatures[0].valid).to.be.true;
+                expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, future))
+                    .to.be.not.null;
+                expect(verified.signatures[0].signature.packets.length).to.equal(1);
+            });
+        });
 
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  decryptOpt.message = encrypted.message;
-                  return encrypted.message.decrypt(decryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+future);
-                  expect(packets.getText()).to.equal(plaintext);
-              });
-          });
+        it('should encrypt and decrypt cleartext data with a date in the future', function () {
+            const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+            const encryptOpt = {
+                data: plaintext,
+                publicKeys: publicKey_2038_2045.keys,
+                date: future,
+                armor: false
+            };
+            const decryptOpt = {
+                privateKeys: privateKey_2038_2045.keys,
+                date: future
+            };
 
+            return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                decryptOpt.message = encrypted.message;
+                return encrypted.message.decrypt(decryptOpt.privateKeys);
+            }).then(function (packets) {
+                const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                expect(literals.length).to.equal(1);
+                expect(+literals[0].date).to.equal(+future);
+                expect(packets.getText()).to.equal(plaintext);
+            });
+        });
 
-          it('should encrypt and decrypt binary data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
-              const encryptOpt = {
-                  data,
-                  publicKeys: publicKey_2000_2008.keys,
-                  creationDate: past,
-                  armor: false
-              };
-              const decryptOpt = {
-                  privateKeys: privateKey_2000_2008.keys
-              };
+        it('should encrypt and decrypt binary data with a date in the past', function () {
+            const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+            const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+            const encryptOpt = {
+                data,
+                publicKeys: publicKey_2000_2008.keys,
+                date: past,
+                armor: false
+            };
+            const decryptOpt = {
+                privateKeys: privateKey_2000_2008.keys,
+                date: past
+            };
 
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  decryptOpt.message = encrypted.message;
-                  return encrypted.message.decrypt(decryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+past);
-                  expect(packets.getLiteralData()).to.deep.equal(data);
-              });
-          });
+            return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                decryptOpt.message = encrypted.message;
+                return encrypted.message.decrypt(decryptOpt.privateKeys);
+            }).then(function (packets) {
+                const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                expect(literals.length).to.equal(1);
+                expect(+literals[0].date).to.equal(+past);
+                expect(packets.getLiteralData()).to.deep.equal(data);
+            });
+        });
 
-          it('should sign, encrypt and decrypt, verify cleartext data with a date in the past', function () {
-              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
-              const encryptOpt = {
-                  data: plaintext,
-                  publicKeys: publicKey_2000_2008.keys,
-                  privateKeys: privateKey_2000_2008.keys,
-                  creationDate: past,
-                  armor: false
-              };
+        it('should sign, encrypt and decrypt, verify cleartext data with a date in the past', function () {
+            const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+            const encryptOpt = {
+                data: plaintext,
+                publicKeys: publicKey_2000_2008.keys,
+                privateKeys: privateKey_2000_2008.keys,
+                date: past,
+                armor: false
+            };
 
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  return encrypted.message.decrypt(encryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+past);
-                  expect(packets.getText()).to.equal(plaintext);
-                  return packets.verify(encryptOpt.publicKeys);
-              }).then(function (signatures) {
-                  expect(+signatures[0].signature.packets[0].created).to.equal(+past);
-                  expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, past))
-                      .to.be.not.a('null');
-                  expect(signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
+            return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                return encrypted.message.decrypt(encryptOpt.privateKeys);
+            }).then(function (packets) {
+                const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                expect(literals.length).to.equal(1);
+                expect(+literals[0].date).to.equal(+past);
+                expect(packets.getText()).to.equal(plaintext);
+                return packets.verify(encryptOpt.publicKeys, past);
+            }).then(function (signatures) {
+                expect(+signatures[0].signature.packets[0].created).to.equal(+past);
+                expect(signatures[0].valid).to.be.true;
+                expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, past))
+                    .to.be.not.null;
+                expect(signatures[0].signature.packets.length).to.equal(1);
+            });
+        });
 
+        it('should sign, encrypt and decrypt, verify binary data with a date in the future', function () {
+            const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+            const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+            const encryptOpt = {
+                data,
+                publicKeys: publicKey_2038_2045.keys,
+                privateKeys: privateKey_2038_2045.keys,
+                date: future,
+                armor: false
+            };
 
-          it('should sign, encrypt and decrypt, verify binary data with a date in the future', function () {
-              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
-              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
-              const encryptOpt = {
-                  data,
-                  publicKeys: publicKey_2038_2045.keys,
-                  privateKeys: privateKey_2038_2045.keys,
-                  creationDate: future,
-                  armor: false
-              };
-
-              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
-                  return encrypted.message.decrypt(encryptOpt.privateKeys);
-              }).then(function (packets) {
-                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
-                  expect(literals.length).to.equal(1);
-                  expect(+literals[0].date).to.equal(+future);
-                  expect(packets.getLiteralData()).to.deep.equal(data);
-                  return packets.verify(encryptOpt.publicKeys);
-              }).then(function (signatures) {
-                  expect(+signatures[0].signature.packets[0].created).to.equal(+future);
-                  expect(signatures[0].valid).to.be.true;
-                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, future))
-                      .to.be.not.a('null');
-                  expect(signatures[0].signature.packets.length).to.equal(1);
-              });
-          });
+            return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                return encrypted.message.decrypt(encryptOpt.privateKeys);
+            }).then(function (packets) {
+                const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                expect(literals.length).to.equal(1);
+                expect(+literals[0].date).to.equal(+future);
+                expect(packets.getLiteralData()).to.deep.equal(data);
+                return packets.verify(encryptOpt.publicKeys, future);
+            }).then(function (signatures) {
+                expect(+signatures[0].signature.packets[0].created).to.equal(+future);
+                expect(signatures[0].valid).to.be.true;
+                expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, future))
+                    .to.be.not.null;
+                expect(signatures[0].signature.packets.length).to.equal(1);
+            });
+        });
       });
 
       describe('ELG / DSA encrypt, decrypt, sign, verify', function() {
@@ -2072,6 +1905,7 @@ describe('OpenPGP.js public api tests', function() {
         });
 
       });
+
     }
 
   });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -158,6 +158,182 @@ const priv_key_de =
   '=kyeP',
   '-----END PGP PRIVATE KEY BLOCK-----'].join('\n');
 
+const priv_key_2000_2008 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xcEYBDioN2gBBACy5VEu8/dlQHOd12v8tNY2Aic+C+k6yyKe7eHRf1Pqwd0d
+OdMk+0EvMi1Z+i0x/cQj89te81F7TCmVd+qrIWR6rKc/6WQzg9FQ0h1WQKxD
+YizEIyia0ZNEuYd7F1H6ycx352tymepAth05i6t1LxI5jExFDq+d8z8L5ezq
++/6BZQARAQABAAP5AY01ySGNEQKq2LY0WyaqCqG1+5azW72aIS+WKztpO9VE
+HhuGXmD+gFK1VtKHFKgAjOucc2RKszYmey56ftL6kdvBs404GEFGCtZOkr4a
+PcnSBM7SNZrUlOIBN9u6U4McnNYdEhyARIf+Qm9NGTbzZCoZ13f40/QjX2TG
+2T6cTwECAOeTJBaIinz+OInqPzWbEndnbWKIXbPhPtpvU/D2OyLquwMmma8r
+khX78V9ZduLVwtzP2DyGnQ+yHBmLCgjxEQECAMXDxAlcx3LbAGew6OA2u938
+Cf+O0fJWid3/e0gNppvnbayTtisXF0uENX4pJv82S02QgqxFL3FYrdON5KVW
+zGUB/3rtIzMQJaSYZAJFc4SDOn1RNkl4nUroPf1IbB17nDX/GcB6acquJxQq
+0q5FtJCrnNR2K25u6t2AGDcZLleSaFSamc0TdGVzdCA8dGVzdEBleGFtcGxl
+PsKtBBMBCgAXBQI4qDdoAhsvAwsJBwMVCggCHgECF4AACgkQXPAg04i7hHT2
+rwQAip3cACXdbShpxvKEsQs0oBN1H5PAx1BAGXanw+jxDFUkrDk1DOSrZFnM
+aohuoJrYyoE/RkLz061g8tFc/KETmnyJAcXL/PPic3tPCCs1cphVAsAjELsY
+wPL4UQpFnRU2e+phgzX9M/G78wvqiOGcM/K0SZTnyRvYaAHHuLFE2xnHwRgE
+OKg3aAEEALOt5AUdDf7fz0DwOkIokGj4zeiFuphsTPwpRAS6c1o9xAzS/C8h
+LFShhTKL4Z9znYkdaMHuFIs7AJ3P5tKlvG0/cZAl3u286lz0aTtQluHMCKNy
+UyhuZ0K1VgZOj+HcDKo8jQ+aejcwjHDg02yPvfzrXHBjWAJMjglV4W+YPFYj
+ABEBAAEAA/9FbqPXagPXgssG8A3DNQOg3MxM1yhk8CzLoHKdVSNwMsAIqJs0
+5x/HUGc1QiKcyEOPEaNClWqw5sr1MLqkmdD2y9xU6Ys1VyJY92GKQyVAgLej
+tAvgeUb7NoHKU7b8F/oDfZezY8rs5fBRNVO5hHd+aAD4gcAAfIeAmy7AHRU9
+wQIA7UPEpAI/lil5fDByHz7wyo1k/7yLqY18tHEAcUbPwUWvYCuvv3ASts78
+0kQETsqn0bZZuuiR+IRdFxZzsElLAwIAwd4M85ewucF2tsyJYWJq4A+dETJC
+WJfcSboagENXUYjOsLgtU/H8b9JD9CWpsd0DkcPshKAjuum6c3cUaTROYQIA
+lp2kWrnzdLZxXELA2RDTaqsp/M+XhwKhChuG53FH+AKMVrwDImG7qVVL07gI
+Rv+gGkG79PGvej7YZLZvHIq/+qTWwsCDBBgBCgAPBQI4qDdoBQkPCZwAAhsu
+AKgJEFzwINOIu4R0nSAEGQEKAAYFAjioN2gACgkQ4fPj4++ExKB1EQP+Ppm5
+hmv2c04836wMXHjjCIX1fsBhJNSeWNZljxPOcPgb0kAd2hY1S/Vn9ZDogeYm
+DBUQ/JHj42Edda2IYax/74dAwUTV2KnDsdBT8Tb9ljHnY3GM7JqEKi/u09u7
+Zfwq3auRDH8RW/hRHQ058dfkSoorpN5iCUfzYJemM4ZmA7NPCwP+PsQ63uIP
+mDB49M2sQwV1GsBc+YB+aD3hggsRv7UHh4gvr2GCcukRlHDi/pOEO/ZTaoyS
+un3m7b2M4n31bEj1lknZBtMZLo0uWww6YpAQEwFFXhVcAOYQqOb2KfF1rJGB
+6w10tmpXdNWm5JPANu6RqaXIzkuMcRUqlYcNLfz6SUHHwRgEOKg3aAEEALfQ
+/ENJxzybgdKLQBhF8RN3xb1V8DiYFtfgDkboavjiSD7PVEDNO286cLoe/uAk
+E+Dgm2oEFmZ/IJShX+BL1JkHreNKuWTW0Gz0jkqYbE44Kssy5ywCXc0ItW4y
+rMtabXPI5zqXzePd9Fwp7ZOt8QN/jU+TUfGUMwEv2tDKq/+7ABEBAAEAA/4l
+tAGSQbdSqKj7ySE3+Vyl/Bq8p7xyt0t0Mxpqk/ChJTThYUBsXExVF70YiBQK
+YIwNQ7TNDZKUqn3BzsnuJU+xTHKx8/mg7cGo+EzBstLMz7tGQJ9GN2LwrTZj
+/yA2JZk3t54Ip/eNCkg7j5OaJG9l3RaW3DKPskRFY63gnitC8QIA745VRJmw
+FwmHQ0H4ZoggO26+Q77ViYn84s8gio7AWkrFlt5sWhSdkrGcy/IIeSqzq0ZU
+2p7zsXR8qz85+RyTcQIAxG8mwRGHkboHVa6qKt+lAxpqCuxe/buniw0LZuzu
+wJQU+E6Y0oybSAcOjleIMkxULljc3Us7a5/HDKdQi4mX6wH/bVPlW8koygus
+mDVIPSP2rmjBA9YVLn5CBPG+u0oGAMY9tfJ848V22S/ZPYNZe9ksFSjEuFDL
+Xnmz/O1jI3Xht6IGwsCDBBgBCgAPBQI4qDdoBQkPCZwAAhsuAKgJEFzwINOI
+u4R0nSAEGQEKAAYFAjioN2gACgkQJVG+vfNJQKhK6gP+LB5qXTJKCduuqZm7
+VhFvPeOu4W0pyORo29zZI0owKZnD2ZKZrZhKXZC/1+xKXi8aX4V2ygRth2P1
+tGFLJRqRiA3C20NVewdI4tQtEqWWSlfNFDz4EsbNspyodQ4jPsKPk2R8pFjA
+wmpXLizPg2UyPKUJ/2GnNWjleP0UNyUXgD1MkgP+IkxXTYgDF5/LrOlrq7Th
+WqFqQ/prQCBy7xxNLjpVKLDxGYbXVER6p0pkD6DXlaOgSB3i32dQJnU96l44
+TlUyaUK/dJP7JPbVUOFq/awSxJiCxFxF6Oarc10qQ+OG5ESdJAjpCMHGCzlb
+t/ia1kMpSEiOVLlX5dfHZzhR3WNtBqU=
+=C0fJ
+-----END PGP PRIVATE KEY BLOCK-----`;
+
+const pub_key_2000_2008 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xo0EOKg3aAEEALLlUS7z92VAc53Xa/y01jYCJz4L6TrLIp7t4dF/U+rB3R050yT7
+QS8yLVn6LTH9xCPz217zUXtMKZV36qshZHqspz/pZDOD0VDSHVZArENiLMQjKJrR
+k0S5h3sXUfrJzHfna3KZ6kC2HTmLq3UvEjmMTEUOr53zPwvl7Or7/oFlABEBAAHN
+E3Rlc3QgPHRlc3RAZXhhbXBsZT7CrQQTAQoAFwUCOKg3aAIbLwMLCQcDFQoIAh4B
+AheAAAoJEFzwINOIu4R09q8EAIqd3AAl3W0oacbyhLELNKATdR+TwMdQQBl2p8Po
+8QxVJKw5NQzkq2RZzGqIbqCa2MqBP0ZC89OtYPLRXPyhE5p8iQHFy/zz4nN7Twgr
+NXKYVQLAIxC7GMDy+FEKRZ0VNnvqYYM1/TPxu/ML6ojhnDPytEmU58kb2GgBx7ix
+RNsZzo0EOKg3aAEEALOt5AUdDf7fz0DwOkIokGj4zeiFuphsTPwpRAS6c1o9xAzS
+/C8hLFShhTKL4Z9znYkdaMHuFIs7AJ3P5tKlvG0/cZAl3u286lz0aTtQluHMCKNy
+UyhuZ0K1VgZOj+HcDKo8jQ+aejcwjHDg02yPvfzrXHBjWAJMjglV4W+YPFYjABEB
+AAHCwIMEGAEKAA8FAjioN2gFCQ8JnAACGy4AqAkQXPAg04i7hHSdIAQZAQoABgUC
+OKg3aAAKCRDh8+Pj74TEoHURA/4+mbmGa/ZzTjzfrAxceOMIhfV+wGEk1J5Y1mWP
+E85w+BvSQB3aFjVL9Wf1kOiB5iYMFRD8kePjYR11rYhhrH/vh0DBRNXYqcOx0FPx
+Nv2WMedjcYzsmoQqL+7T27tl/Crdq5EMfxFb+FEdDTnx1+RKiiuk3mIJR/Ngl6Yz
+hmYDs08LA/4+xDre4g+YMHj0zaxDBXUawFz5gH5oPeGCCxG/tQeHiC+vYYJy6RGU
+cOL+k4Q79lNqjJK6febtvYziffVsSPWWSdkG0xkujS5bDDpikBATAUVeFVwA5hCo
+5vYp8XWskYHrDXS2ald01abkk8A27pGppcjOS4xxFSqVhw0t/PpJQc6NBDioN2gB
+BAC30PxDScc8m4HSi0AYRfETd8W9VfA4mBbX4A5G6Gr44kg+z1RAzTtvOnC6Hv7g
+JBPg4JtqBBZmfyCUoV/gS9SZB63jSrlk1tBs9I5KmGxOOCrLMucsAl3NCLVuMqzL
+Wm1zyOc6l83j3fRcKe2TrfEDf41Pk1HxlDMBL9rQyqv/uwARAQABwsCDBBgBCgAP
+BQI4qDdoBQkPCZwAAhsuAKgJEFzwINOIu4R0nSAEGQEKAAYFAjioN2gACgkQJVG+
+vfNJQKhK6gP+LB5qXTJKCduuqZm7VhFvPeOu4W0pyORo29zZI0owKZnD2ZKZrZhK
+XZC/1+xKXi8aX4V2ygRth2P1tGFLJRqRiA3C20NVewdI4tQtEqWWSlfNFDz4EsbN
+spyodQ4jPsKPk2R8pFjAwmpXLizPg2UyPKUJ/2GnNWjleP0UNyUXgD1MkgP+IkxX
+TYgDF5/LrOlrq7ThWqFqQ/prQCBy7xxNLjpVKLDxGYbXVER6p0pkD6DXlaOgSB3i
+32dQJnU96l44TlUyaUK/dJP7JPbVUOFq/awSxJiCxFxF6Oarc10qQ+OG5ESdJAjp
+CMHGCzlbt/ia1kMpSEiOVLlX5dfHZzhR3WNtBqU=
+=kwK1
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+const priv_key_2038_2045 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xcEYBH/oGU8BBACilkYen6vxr1LAhqWc0HaS+zMkjeND/P9ENePoNRVo3Bq8
+KLacq1pQFitJVcUaz6D5lk0wtijSWb/uUSh6IW6ldVYvsjHdTpGYqH3vLJsp
+YXzBzT6sXqht+ceQPi5pIpL/X5240WeaQQtD0arecVAtmtgrN5wJ/3So8llq
+mf8q0QARAQABAAP9FZXBxWW0BtLHN7bTMdhzMDGX/phfvbJO6W1beS6Noxg6
+7Gld+mVoCLiIvU8HwKF5YOlVYiGCQJBDF46VbcbBJjwUMCmLBF7eCO1tls6G
+JPhG0EcVenx2f/V12cq9O+mKIXkfqnc9n9Wd8uVwav6HQsBFcPcmqj/Y5EAw
+Yv8D6qkCANL1ABYZoXn/Bo1SfkOGWFGMS0xb/ISEIgEaQuAt7RFThx3BR7TG
+cIkUfG10tm0aRz4LJ74jgfEf+34RZVAzlJsCAMVNWQaSQ2zGmMB+CM73BCXb
+JPIh0mB6W0XFWl/a0tex+VkmdnCtvnbtA9MjDs1v3WR2+8SRvDe+k/Yx1w2H
+lwMB/2pxnIOH7yrCMPDK14Yfay3EOWzTs17FF1sm8HUSR17qwpBEcH2a6TRd
+msr2TvmaCI/uSVtX+h7swnBlhC/+p5ugUc0WZXhhbXBsZSA8dGVzdEBleGFt
+cGxlPsKtBBMBCgAXBQJ/6BlPAhsvAwsJBwMVCggCHgECF4AACgkQdKKYGB48
+OusrOgP/Z7+F/BP4rn0CDyPgXmXvj+EAYF2bRWFbxWGPs8KOua9XvuAO1XJQ
+CC7Mgx/D8t/7LfLYn4kTzEbKFT/3ZtNzl74Pl/QlDZqodmT8gFESDd01LsL5
+9mI0O9zw7gP7RZkftiFveOGvT4Os/SvOzdpXGGWAfytHtoxmxDq66gzuZUPH
+wRcEf+gZTwEEAK0pLhDM5pDxWVfuVFssIdbWhClxlN9ZGhjGM27vf5QE0YAl
+uhlv5BTtLU3pYtQYScJksNAFYmENtufWU+c4fv4HHSTGXsW5baw8Ix1vFasr
+Aa9atZWBZklQVt3Bsxu9+jOYxGJDjkzyhpLOZgJSYFK36l8dATPF5t1eGy40
+5i0nABEBAAEAA/dvmxsVuPricKwlAHdeTBODZL/J9mr9iXBIh3afCb4wqOpe
+rfJEctmOo0+P59zK1tyzbjKH4PCHnU9GHd32KXOvNtmFs4BeuJTFMnQd5YdE
+45/7UD29fYtv6cqnn4oigIijuwDFL6qBzEfAjgxl9+MbZz2Gkh6zOtwwDlxv
+hOjJAgDhktuQCWfZ8oLoHAHYMR2Fn8n16qUhAqZEDOCF4vjiCOp3za/whtMl
+bQMngnA9MioHRQ5vsI5ksUgvzE+9hSzlAgDEhH0b68DTJRDZHFeOIltZhcgC
+s5VA6rspabCQ2ETthgLmj4UJbloNCr5z/5IOiAeoWWaw98oSw6yVaHta6p0b
+Af4mD95MipQfWvHldxAKeTZRkB9wG68KfzJOmmWoQS+JqYGGwjYZV97KG6ai
+7N4xGRiiwfaU0oSIcoDhO0kn5VPMokXCwIMEGAEKAA8FAn/oGU8FCQ8JnAAC
+Gy4AqAkQdKKYGB48OuudIAQZAQoABgUCf+gZTwAKCRDuSkIwkyAjaKEqA/9X
+S9AgN4nV9on6GsuK1ZpQpqcKAf4SZaF3rDXqpYfM+LDpqaIl8LZKzK7EyW2p
+VNV9PwnYtMXwQ7A3KAu2audWxSawHNyvgez1Ujl0J7TfKwJyVBrCDjZCJrr+
+joPU0To95jJivSrnCYC3l1ngoMIZycfaU6FhYwHd2XJe2kbzc8JPA/9aCPIa
+hfTEDEH/giKdtzlLbkri2UYGCJqcoNl0Maz6LVUI3NCo3O77zi2v7gLtu+9h
+gfWa8dTxCOszDbNTknb8XXCK74FxwIBgr4gHlvK+xh38RI+8eC2y0qONraQ/
+qACJ+UGh1/4smKasSlBi7hZOvNmOxqm4iQ5hve4uWsSlIsfBGAR/6BlPAQQA
+w4p7hPgd9QdoQsbEXDYq7hxBfUOub1lAtMN9mvUnLMoohEqocCILNC/xMno5
+5+IwEFZZoHySS1CIIBoy1xgRhe0O7+Ls8R/eyXgvjghVdm9ESMlH9+0p94v/
+gfwS6dudEWy3zeYziQLVaZ2wSUiw46Vs8wumAV4lFzEa0nRBMFsAEQEAAQAD
++gOnmEdpRm0sMO+Okief8OLNEp4NoHM34LhjvTN4OmiL5dX2ss87DIxWCtTo
+d3dDXaYpaMb8cJv7Tjqu7VYbYmMXwnPxD6XxOtqAmmL89KmtNAY77B3OQ+dD
+LHzkFDjzB4Lzh9/WHwGeDKAlsuYO7KhVwqZ+J67QeQpXBH4ddgwBAgD9xDfI
+r+JQzQEsfThwiPt/+XXd3HvpUOubhkGrNTNjy3J0RKOOIz4WVLWL83Y8he31
+ghF6DA2QXEf9zz5aMQS7AgDFQxJmBzSGFCkbHbSphT37SnohLONdxyvmZqj5
+sKIA01fs5gO/+AK2/qpLb1BAXFhi8H6RPVNyOho98VVFx5jhAfwIoivqrLBK
+GzFJxS+KxUZgAUwj2ifZ2G3xTAmzZK6ZCPf4giwn4KsC1jVF0TO6zp02RcmZ
+wavObOiYwaRyhz9bnvvCwIMEGAEKAA8FAn/oGU8FCQ8JnAACGy4AqAkQdKKY
+GB48OuudIAQZAQoABgUCf+gZTwAKCRAowa+OShndpzKyA/0Wi6Vlg76uZDCP
+JgTuFn3u/+B3NZvpJw76bwmbfRDQn24o1MrA6VM6Ho2tvSrS3VTZqkn/9JBX
+TPGZCZZ/Vrmk1HQp2GIPcnTb7eHAuXl1KhjOQ3MD1fOCDVwJtIMX92Asf7HW
+J4wE4f3U5NnR+W6uranaXA2ghVyUsk0lJtnM400nA/45gAq9EBZUSL+DWdYZ
++/RgXpw4/7pwDbq/G4k+4YWn/tvCUnwAsCTo2xD6qN+icY5WwBTphdA/0O3U
++8ujuk61ln9b01u49FoVbuwHoS1gVySj2RyRgldlwg6l99MI8eYmuHf4baPX
+0uyeibPdgJTjARMuQzDFA8bdbM540vBf5Q==
+=WLIN
+-----END PGP PRIVATE KEY BLOCK-----`;
+
+const pub_key_2038_2045 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xo0Ef+gZTwEEAKKWRh6fq/GvUsCGpZzQdpL7MySN40P8/0Q14+g1FWjcGrwotpyr
+WlAWK0lVxRrPoPmWTTC2KNJZv+5RKHohbqV1Vi+yMd1OkZiofe8smylhfMHNPqxe
+qG35x5A+Lmkikv9fnbjRZ5pBC0PRqt5xUC2a2Cs3nAn/dKjyWWqZ/yrRABEBAAHN
+FmV4YW1wbGUgPHRlc3RAZXhhbXBsZT7CrQQTAQoAFwUCf+gZTwIbLwMLCQcDFQoI
+Ah4BAheAAAoJEHSimBgePDrrKzoD/2e/hfwT+K59Ag8j4F5l74/hAGBdm0VhW8Vh
+j7PCjrmvV77gDtVyUAguzIMfw/Lf+y3y2J+JE8xGyhU/92bTc5e+D5f0JQ2aqHZk
+/IBREg3dNS7C+fZiNDvc8O4D+0WZH7Yhb3jhr0+DrP0rzs3aVxhlgH8rR7aMZsQ6
+uuoM7mVDzo0Ef+gZTwEEAK0pLhDM5pDxWVfuVFssIdbWhClxlN9ZGhjGM27vf5QE
+0YAluhlv5BTtLU3pYtQYScJksNAFYmENtufWU+c4fv4HHSTGXsW5baw8Ix1vFasr
+Aa9atZWBZklQVt3Bsxu9+jOYxGJDjkzyhpLOZgJSYFK36l8dATPF5t1eGy405i0n
+ABEBAAHCwIMEGAEKAA8FAn/oGU8FCQ8JnAACGy4AqAkQdKKYGB48OuudIAQZAQoA
+BgUCf+gZTwAKCRDuSkIwkyAjaKEqA/9XS9AgN4nV9on6GsuK1ZpQpqcKAf4SZaF3
+rDXqpYfM+LDpqaIl8LZKzK7EyW2pVNV9PwnYtMXwQ7A3KAu2audWxSawHNyvgez1
+Ujl0J7TfKwJyVBrCDjZCJrr+joPU0To95jJivSrnCYC3l1ngoMIZycfaU6FhYwHd
+2XJe2kbzc8JPA/9aCPIahfTEDEH/giKdtzlLbkri2UYGCJqcoNl0Maz6LVUI3NCo
+3O77zi2v7gLtu+9hgfWa8dTxCOszDbNTknb8XXCK74FxwIBgr4gHlvK+xh38RI+8
+eC2y0qONraQ/qACJ+UGh1/4smKasSlBi7hZOvNmOxqm4iQ5hve4uWsSlIs6NBH/o
+GU8BBADDinuE+B31B2hCxsRcNiruHEF9Q65vWUC0w32a9ScsyiiESqhwIgs0L/Ey
+ejnn4jAQVlmgfJJLUIggGjLXGBGF7Q7v4uzxH97JeC+OCFV2b0RIyUf37Sn3i/+B
+/BLp250RbLfN5jOJAtVpnbBJSLDjpWzzC6YBXiUXMRrSdEEwWwARAQABwsCDBBgB
+CgAPBQJ/6BlPBQkPCZwAAhsuAKgJEHSimBgePDrrnSAEGQEKAAYFAn/oGU8ACgkQ
+KMGvjkoZ3acysgP9FoulZYO+rmQwjyYE7hZ97v/gdzWb6ScO+m8Jm30Q0J9uKNTK
+wOlTOh6Nrb0q0t1U2apJ//SQV0zxmQmWf1a5pNR0KdhiD3J02+3hwLl5dSoYzkNz
+A9Xzgg1cCbSDF/dgLH+x1ieMBOH91OTZ0flurq2p2lwNoIVclLJNJSbZzONNJwP+
+OYAKvRAWVEi/g1nWGfv0YF6cOP+6cA26vxuJPuGFp/7bwlJ8ALAk6NsQ+qjfonGO
+VsAU6YXQP9Dt1PvLo7pOtZZ/W9NbuPRaFW7sB6EtYFcko9kckYJXZcIOpffTCPHm
+Jrh3+G2j19Lsnomz3YCU4wETLkMwxQPG3WzOeNLwX+U=
+=yV+n
+-----END PGP PUBLIC KEY BLOCK-----`;
+
 const passphrase = 'hello world';
 const plaintext = 'short message\nnext line\n한국어/조선말';
 const password1 = 'I am a password';
@@ -465,6 +641,10 @@ describe('OpenPGP.js public api tests', function() {
   });
 
   describe('encrypt, decrypt, sign, verify - integration tests', function() {
+    let privateKey_2000_2008;
+    let publicKey_2000_2008;
+    let privateKey_2038_2045;
+    let publicKey_2038_2045;
     let privateKey;
     let publicKey;
     let zero_copyVal;
@@ -478,6 +658,18 @@ describe('OpenPGP.js public api tests', function() {
       privateKey = openpgp.key.readArmored(priv_key);
       expect(privateKey.keys).to.have.length(1);
       expect(privateKey.err).to.not.exist;
+      publicKey_2000_2008 = openpgp.key.readArmored(pub_key_2000_2008);
+      expect(publicKey_2000_2008.keys).to.have.length(1);
+      expect(publicKey_2000_2008.err).to.not.exist;
+      privateKey_2000_2008 = openpgp.key.readArmored(priv_key_2000_2008);
+      expect(privateKey_2000_2008.keys).to.have.length(1);
+      expect(privateKey_2000_2008.err).to.not.exist;
+      publicKey_2038_2045 = openpgp.key.readArmored(pub_key_2038_2045);
+      expect(publicKey_2038_2045.keys).to.have.length(1);
+      expect(publicKey_2038_2045.err).to.not.exist;
+      privateKey_2038_2045 = openpgp.key.readArmored(priv_key_2038_2045);
+      expect(privateKey_2038_2045.keys).to.have.length(1);
+      expect(privateKey_2038_2045.err).to.not.exist;
       zero_copyVal = openpgp.config.zero_copy;
       use_nativeVal = openpgp.config.use_native;
       aead_protectVal = openpgp.config.aead_protect;
@@ -1347,26 +1539,317 @@ describe('OpenPGP.js public api tests', function() {
         });
 
         it('should sign and verify cleartext data and not armor with detached signatures', function () {
-          const signOpt = {
-            data: plaintext,
-            privateKeys: privateKey.keys,
-            detached: true,
-            armor: false
-          };
-          const verifyOpt = {
-            publicKeys: publicKey.keys
-          };
-          return openpgp.sign(signOpt).then(function (signed) {
-            verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
-            verifyOpt.signature = signed.signature;
-            return openpgp.verify(verifyOpt);
-          }).then(function (verified) {
-            expect(verified.data).to.equal(plaintext);
-            expect(verified.signatures[0].valid).to.be.true;
-            expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
-            expect(verified.signatures[0].signature.packets.length).to.equal(1);
-          });
+            const start = Date.now();
+            const signOpt = {
+                data: plaintext,
+                privateKeys: privateKey.keys,
+                detached: true,
+                armor: false
+            };
+            const verifyOpt = {
+                publicKeys: publicKey.keys
+            };
+            return openpgp.sign(signOpt).then(function (signed) {
+                verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
+                verifyOpt.signature = signed.signature;
+                return openpgp.verify(verifyOpt);
+            }).then(function (verified) {
+                expect(verified.data).to.equal(plaintext);
+                expect(+verified.signatures[0].signature.packets[0].created).to.be.lte(Date.now());
+                expect(+verified.signatures[0].signature.packets[0].created).to.be.gte(start);
+                expect(verified.signatures[0].valid).to.be.true;
+                expect(verified.signatures[0].keyid.toHex()).to.equal(privateKey.keys[0].getSigningKeyPacket().getKeyId().toHex());
+                expect(verified.signatures[0].signature.packets.length).to.equal(1);
+            });
         });
+
+          it('should sign and verify cleartext data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const signOpt = {
+                  data: plaintext,
+                  privateKeys: privateKey_2000_2008.keys,
+                  detached: true,
+                  creationDate: past,
+                  armor: false
+              };
+              const verifyOpt = {
+                  publicKeys: publicKey_2000_2008.keys
+              };
+              return openpgp.sign(signOpt).then(function (signed) {
+                  verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
+                  verifyOpt.signature = signed.signature;
+                  return openpgp.verify(verifyOpt);
+              }).then(function (verified) {
+                  expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
+                  expect(verified.data).to.equal(plaintext);
+                  expect(verified.signatures[0].valid).to.be.true;
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, past))
+                      .to.be.not.a('null');
+                  expect(verified.signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+
+          it('should sign and verify binary data with a date in the future', function () {
+              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+              const signOpt = {
+                  data,
+                  privateKeys: privateKey_2038_2045.keys,
+                  detached: true,
+                  creationDate: future,
+                  armor: false
+              };
+              const verifyOpt = {
+                  publicKeys: publicKey_2038_2045.keys
+              };
+              return openpgp.sign(signOpt).then(function (signed) {
+                  verifyOpt.message = openpgp.message.fromBinary(data);
+                  verifyOpt.signature = signed.signature;
+                  return openpgp.verify(verifyOpt);
+              }).then(function (verified) {
+                  expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
+                  expect(verified.data).to.equal(data);
+                  expect(verified.signatures[0].valid).to.be.true;
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, future))
+                      .to.be.not.a('null');
+                  expect(verified.signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+          it('should encrypt and decrypt cleartext data with a date in the future', function () {
+              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+              const encryptOpt = {
+                  data: plaintext,
+                  publicKeys: publicKey_2038_2045.keys,
+                  creationDate: future,
+                  armor: false
+              };
+              const decryptOpt = {
+                  privateKeys: privateKey_2038_2045.keys
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  decryptOpt.message = encrypted.message;
+                  return encrypted.message.decrypt(decryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+future);
+                  expect(packets.getText()).to.equal(plaintext);
+              });
+          });
+
+
+          it('should encrypt and decrypt binary data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+              const encryptOpt = {
+                  data,
+                  publicKeys: publicKey_2000_2008.keys,
+                  creationDate: past,
+                  armor: false
+              };
+              const decryptOpt = {
+                  privateKeys: privateKey_2000_2008.keys
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  decryptOpt.message = encrypted.message;
+                  return encrypted.message.decrypt(decryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+past);
+                  expect(packets.getLiteralData()).to.deep.equal(data);
+              });
+          });
+
+          it('should sign, encrypt and decrypt, verify cleartext data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const encryptOpt = {
+                  data: plaintext,
+                  publicKeys: publicKey_2000_2008.keys,
+                  privateKeys: privateKey_2000_2008.keys,
+                  creationDate: past,
+                  armor: false
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  return encrypted.message.decrypt(encryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+past);
+                  expect(packets.getText()).to.equal(plaintext);
+                  return packets.verify(encryptOpt.publicKeys);
+              }).then(function (signatures) {
+                  expect(+signatures[0].signature.packets[0].created).to.equal(+past);
+                  expect(signatures[0].valid).to.be.true;
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, past))
+                      .to.be.not.a('null');
+                  expect(signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+
+          it('should sign, encrypt and decrypt, verify binary data with a date in the future', function () {
+              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+              const encryptOpt = {
+                  data,
+                  publicKeys: publicKey_2038_2045.keys,
+                  privateKeys: privateKey_2038_2045.keys,
+                  creationDate: future,
+                  armor: false
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  return encrypted.message.decrypt(encryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+future);
+                  expect(packets.getLiteralData()).to.deep.equal(data);
+                  return packets.verify(encryptOpt.publicKeys);
+              }).then(function (signatures) {
+                  expect(+signatures[0].signature.packets[0].created).to.equal(+future);
+                  expect(signatures[0].valid).to.be.true;
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, future))
+                      .to.be.not.a('null');
+                  expect(signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+          it('should sign and verify cleartext data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const signOpt = {
+                  data: plaintext,
+                  privateKeys: privateKey_2000_2008.keys,
+                  detached: true,
+                  creationDate: past,
+                  armor: false
+              };
+              const verifyOpt = {
+                  publicKeys: publicKey_2000_2008.keys
+              };
+              return openpgp.sign(signOpt).then(function (signed) {
+                  verifyOpt.message = new openpgp.cleartext.CleartextMessage(plaintext);
+                  verifyOpt.signature = signed.signature;
+                  return openpgp.verify(verifyOpt);
+              }).then(function (verified) {
+                  expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
+                  expect(verified.data).to.equal(plaintext);
+                  expect(verified.signatures[0].valid).to.be.true;
+                  expect(signOpt.privateKeys[0].getSigningKeyPacket(verified.signatures[0].keyid, undefined, past))
+                      .to.be.not.a('null');
+                  expect(verified.signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+          it('should encrypt and decrypt cleartext data with a date in the future', function () {
+              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+              const encryptOpt = {
+                  data: plaintext,
+                  publicKeys: publicKey_2038_2045.keys,
+                  creationDate: future,
+                  armor: false
+              };
+              const decryptOpt = {
+                  privateKeys: privateKey_2038_2045.keys
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  decryptOpt.message = encrypted.message;
+                  return encrypted.message.decrypt(decryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+future);
+                  expect(packets.getText()).to.equal(plaintext);
+              });
+          });
+
+
+          it('should encrypt and decrypt binary data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+              const encryptOpt = {
+                  data,
+                  publicKeys: publicKey_2000_2008.keys,
+                  creationDate: past,
+                  armor: false
+              };
+              const decryptOpt = {
+                  privateKeys: privateKey_2000_2008.keys
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  decryptOpt.message = encrypted.message;
+                  return encrypted.message.decrypt(decryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+past);
+                  expect(packets.getLiteralData()).to.deep.equal(data);
+              });
+          });
+
+          it('should sign, encrypt and decrypt, verify cleartext data with a date in the past', function () {
+              const past = new Date(2005, 5, 5, 5, 5, 5, 0);
+              const encryptOpt = {
+                  data: plaintext,
+                  publicKeys: publicKey_2000_2008.keys,
+                  privateKeys: privateKey_2000_2008.keys,
+                  creationDate: past,
+                  armor: false
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  return encrypted.message.decrypt(encryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+past);
+                  expect(packets.getText()).to.equal(plaintext);
+                  return packets.verify(encryptOpt.publicKeys);
+              }).then(function (signatures) {
+                  expect(+signatures[0].signature.packets[0].created).to.equal(+past);
+                  expect(signatures[0].valid).to.be.true;
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, past))
+                      .to.be.not.a('null');
+                  expect(signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
+
+
+          it('should sign, encrypt and decrypt, verify binary data with a date in the future', function () {
+              const future = new Date(2040, 5, 5, 5, 5, 5, 0);
+              const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
+              const encryptOpt = {
+                  data,
+                  publicKeys: publicKey_2038_2045.keys,
+                  privateKeys: privateKey_2038_2045.keys,
+                  creationDate: future,
+                  armor: false
+              };
+
+              return openpgp.encrypt(encryptOpt).then(function (encrypted) {
+                  return encrypted.message.decrypt(encryptOpt.privateKeys);
+              }).then(function (packets) {
+                  const literals = packets.packets.filterByTag(openpgp.enums.packet.literal);
+                  expect(literals.length).to.equal(1);
+                  expect(+literals[0].date).to.equal(+future);
+                  expect(packets.getLiteralData()).to.deep.equal(data);
+                  return packets.verify(encryptOpt.publicKeys);
+              }).then(function (signatures) {
+                  expect(+signatures[0].signature.packets[0].created).to.equal(+future);
+                  expect(signatures[0].valid).to.be.true;
+                  expect(encryptOpt.privateKeys[0].getSigningKeyPacket(signatures[0].keyid, undefined, future))
+                      .to.be.not.a('null');
+                  expect(signatures[0].signature.packets.length).to.equal(1);
+              });
+          });
       });
 
       describe('ELG / DSA encrypt, decrypt, sign, verify', function() {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -642,8 +642,7 @@ describe("Signature", function() {
     });
   });
 
-  it('Verify test with expired verification public key and verify_expired_keys set to false', function() {
-    openpgp.config.verify_expired_keys = false;
+  it('Verify test with expired verification public key', function() {
     const pubKey = openpgp.key.readArmored(pub_expired).keys[0];
     const message = openpgp.message.readArmored(msg_sig_expired);
     return openpgp.verify({ publicKeys:[pubKey], message:message }).then(function(verified) {
@@ -655,11 +654,10 @@ describe("Signature", function() {
 
   });
 
-  it('Verify test with expired verification public key and verify_expired_keys set to true', function() {
-    openpgp.config.verify_expired_keys = true;
+  it('Verify test with expired verification public key and disable expiration checks using null date', function() {
     const pubKey = openpgp.key.readArmored(pub_expired).keys[0];
     const message = openpgp.message.readArmored(msg_sig_expired);
-    return openpgp.verify({ publicKeys:[pubKey], message:message }).then(function(verified) {
+    return openpgp.verify({ publicKeys:[pubKey], message:message, date: null }).then(function(verified) {
       expect(verified).to.exist;
       expect(verified.signatures).to.have.length(1);
       expect(verified.signatures[0].valid).to.be.true;
@@ -668,8 +666,7 @@ describe("Signature", function() {
 
   });
 
-  it('Verify test with expired verification public key and verify_expired_keys set to false', function() {
-    openpgp.config.verify_expired_keys = false;
+  it('Verify test with expired verification public key', function() {
     const pubKey = openpgp.key.readArmored(pub_expired).keys[0];
     const message = openpgp.message.readArmored(msg_sig_expired);
     return openpgp.verify({ publicKeys:[pubKey], message:message }).then(function(verified) {
@@ -681,11 +678,10 @@ describe("Signature", function() {
 
   });
 
-  it('Verify test with expired verification public key and verify_expired_keys set to true', function() {
-    openpgp.config.verify_expired_keys = true;
+  it('Verify test with expired verification public key and disable expiration checks using null date', function() {
     const pubKey = openpgp.key.readArmored(pub_expired).keys[0];
     const message = openpgp.message.readArmored(msg_sig_expired);
-    return openpgp.verify({ publicKeys:[pubKey], message:message }).then(function(verified) {
+    return openpgp.verify({ publicKeys:[pubKey], message:message, date: null }).then(function(verified) {
       expect(verified).to.exist;
       expect(verified.signatures).to.have.length(1);
       expect(verified.signatures[0].valid).to.be.true;


### PR DESCRIPTION
This allows:
- creating signatures with creation times different from the current clock time;
- verifying messages using a passed in time;
- loosely couple time from openpgp functions, so it doesn't have a static dependency allowing greater flexibility in testing.

In addition to adding the parameter I:
- removed the `verify_expired_keys` flag. Instead one can pass in a `null` date to disable expiration checking on keys
- started checking if the creation time of keys is later than the current time to detect invalid keys. This is disabled by passing in a `null` date.
- changed all `new Date()` calls to `util.currentDate()` which differs from `new Date()` in that it has second precision in contrast to millisecond precision. The reason for this is that openpgp uses normal unix timestamps (see [here](https://tools.ietf.org/html/rfc4880#section-3.5)) that doesn't store the exact milliseconds, so writing packages and reading the output afterwards currently change the creation date by dropping the millisecond precision.