### PR TITLE
More generateKey options

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -291,7 +291,6 @@ Key.prototype.getSigningKeyPacket = async function (keyId=null, date=new Date())
 };
 
 function isValidEncryptionKeyPacket(keyPacket, signature, date=new Date()) {
-  const normDate = util.normalizeDate(date);
   return keyPacket.algorithm !== enums.read(enums.publicKey, enums.publicKey.dsa) &&
          keyPacket.algorithm !== enums.read(enums.publicKey, enums.publicKey.rsa_sign) &&
          keyPacket.algorithm !== enums.read(enums.publicKey, enums.publicKey.ecdsa) &&
@@ -1100,18 +1099,34 @@ export function readArmored(armoredText) {
  *                             Assumes already in form of "User Name <username@email.com>"
  *                             If array is used, the first userId is set as primary user Id
  * @param {String}  options.passphrase The passphrase used to encrypt the resulting private key
- * @param {Boolean} [options.unlocked=false]    The secret part of the generated key is unlocked
  * @param {Number} [options.keyExpirationTime=0]
  *                             The number of seconds after the key creation time that the key expires
+ * @param  {String} curve            (optional) elliptic curve for ECC keys:
  * @param  {Date} date         Override the creation date of the key and the key signatures
+ * @param  {Array<Object>} subkeys   (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
+ *                                              sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
  * @returns {Promise<module:key.Key>}
  * @async
  * @static
  */
-export function generate(options) {
-  let secretKeyPacket;
-  let secretSubkeyPacket;
-  return Promise.resolve().then(() => {
+export async function generate(options) {
+
+  options = sanitizeKeyOptions(options);
+  options.subkeys = options.subkeys.map(function(subkey, index) { return sanitizeKeyOptions(options.subkeys[index], options); });
+
+  let promises = [generateSecretKey(options)];
+  promises = promises.concat(options.subkeys.map(generateSecretSubkey));
+  return Promise.all(promises).then(packets => wrapKeyObject(packets, options));
+
+  function sanitizeKeyOptions(options, subkeyDefaults={}) {
+    options.curve = options.curve || subkeyDefaults.curve;
+    options.numBits = options.numBits || subkeyDefaults.numBits;
+    options.keyExpirationTime = options.keyExpirationTime >= 0 ? options.keyExpirationTime : subkeyDefaults.keyExpirationTime;
+    options.passphrase = util.isString(options.passphrase) ? options.passphrase : subkeyDefaults.passphrase;
+    options.date = options.date || subkeyDefaults.date;
+
+    options.sign = options.sign || false;
+
     if (options.curve) {
       try {
         options.curve = enums.write(enums.curve, options.curve);
@@ -1119,81 +1134,63 @@ export function generate(options) {
         throw new Error('Not valid curve.');
       }
       if (options.curve === enums.curve.ed25519 || options.curve === enums.curve.curve25519) {
-        options.keyType = options.keyType || enums.publicKey.eddsa;
+        if (!subkeyDefaults.algorithm || options.sign) {
+          options.algorithm = options.algorithm || enums.publicKey.eddsa;
+          options.curve = enums.curve.ed25519;
+        } else {
+          options.algorithm = options.algorithm || enums.publicKey.ecdh;
+          options.curve = enums.curve.curve25519;
+        }
       } else {
-        options.keyType = options.keyType || enums.publicKey.ecdsa;
+        options.algorithm = options.algorithm || (!subkeyDefaults.algorithm ? enums.publicKey.ecdsa : enums.publicKey.ecdh);
+        if (options.algorithm !== enums.publicKey.ecdh && options.algorithm !== enums.publicKey.ecdsa) {
+          throw new Error('Invalid algorithm for curve');
+        }
       }
-      options.subkeyType = options.subkeyType || enums.publicKey.ecdh;
     } else if (options.numBits) {
-      options.keyType = options.keyType || enums.publicKey.rsa_encrypt_sign;
-      options.subkeyType = options.subkeyType || enums.publicKey.rsa_encrypt_sign;
+      options.algorithm = enums.publicKey.rsa_encrypt_sign;
     } else {
-      throw new Error('Key type not specified.');
+      throw new Error('Unrecognized key type');
     }
-
-    if (options.keyType !== enums.publicKey.rsa_encrypt_sign &&
-        options.keyType !== enums.publicKey.ecdsa &&
-        options.keyType !== enums.publicKey.eddsa) {
-      // RSA Encrypt-Only and RSA Sign-Only are deprecated and SHOULD NOT be generated
-      throw new Error('Unsupported key type');
-    }
-
-    if (options.subkeyType !== enums.publicKey.rsa_encrypt_sign &&
-        options.subkeyType !== enums.publicKey.ecdh) {
-      // RSA Encrypt-Only and RSA Sign-Only are deprecated and SHOULD NOT be generated
-      throw new Error('Unsupported subkey type');
-    }
-
-    if (!options.passphrase) { // Key without passphrase is unlocked by definition
-      options.unlocked = true;
-    }
-    if (util.isString(options.userIds)) {
-      options.userIds = [options.userIds];
-    }
-
-    return Promise.all([generateSecretKey(), generateSecretSubkey()]).then(() => wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options));
-  });
-
-  function generateSecretKey() {
-    secretKeyPacket = new packet.SecretKey(options.date);
-    secretKeyPacket.packets = null;
-    secretKeyPacket.algorithm = enums.read(enums.publicKey, options.keyType);
-    options.curve = options.curve === enums.curve.curve25519 ? enums.curve.ed25519 : options.curve;
-    return secretKeyPacket.generate(options.numBits, options.curve);
+    return options;
   }
 
-  function generateSecretSubkey() {
-    secretSubkeyPacket = new packet.SecretSubkey(options.date);
+  async function generateSecretKey(options) {
+    const secretKeyPacket = new packet.SecretKey(options.date);
     secretKeyPacket.packets = null;
-    secretSubkeyPacket.algorithm = enums.read(enums.publicKey, options.subkeyType);
-    options.curve = options.curve === enums.curve.ed25519 ? enums.curve.curve25519 : options.curve;
-    return secretSubkeyPacket.generate(options.numBits, options.curve);
+    secretKeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
+    await secretKeyPacket.generate(options.numBits, options.curve);
+    return secretKeyPacket;
+  }
+
+  async function generateSecretSubkey(options) {
+    const secretSubkeyPacket = new packet.SecretSubkey(options.date);
+    secretSubkeyPacket.packets = null;
+    secretSubkeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
+    await secretSubkeyPacket.generate(options.numBits, options.curve);
+    return secretSubkeyPacket;
   }
 }
 
 /**
- * Reformats and signs an OpenPGP with a given User ID. Currently only supports RSA keys.
+ * Reformats and signs an OpenPGP key with a given User ID. Currently only supports RSA keys.
  * @param {module:key.Key} options.privateKey   The private key to reformat
  * @param {module:enums.publicKey} [options.keyType=module:enums.publicKey.rsa_encrypt_sign]
  * @param {String|Array<String>}  options.userIds
  *                             Assumes already in form of "User Name <username@email.com>"
  *                             If array is used, the first userId is set as primary user Id
  * @param {String}  options.passphrase The passphrase used to encrypt the resulting private key
- * @param {Boolean} [options.unlocked=false]    The secret part of the generated key is unlocked
  * @param {Number} [options.keyExpirationTime=0]
  *                             The number of seconds after the key creation time that the key expires
+ * @param  {Date} date         Override the creation date of the key and the key signatures
+ * @param  {Array<Object>} subkeys   (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
+ *
  * @returns {Promise<module:key.Key>}
  * @async
  * @static
  */
 export async function reformat(options) {
-  let secretKeyPacket;
-  let secretSubkeyPacket;
-  options.keyType = options.keyType || enums.publicKey.rsa_encrypt_sign;
-  // RSA Encrypt-Only and RSA Sign-Only are deprecated and SHOULD NOT be generated
-  if (options.keyType !== enums.publicKey.rsa_encrypt_sign) {
-    throw new Error('Only RSA Encrypt or Sign supported');
-  }
+  options = sanitizeKeyOptions(options);
 
   try {
     const isDecrypted = options.privateKey.getKeyPackets().every(keyPacket => keyPacket.isDecrypted);
@@ -1204,36 +1201,55 @@ export async function reformat(options) {
     throw new Error('Key not decrypted');
   }
 
-  if (!options.passphrase) { // Key without passphrase is unlocked by definition
-    options.unlocked = true;
-  }
-  if (util.isString(options.userIds)) {
-    options.userIds = [options.userIds];
-  }
   const packetlist = options.privateKey.toPacketlist();
+  let secretKeyPacket;
+  const secretSubkeyPackets = [];
   for (let i = 0; i < packetlist.length; i++) {
     if (packetlist[i].tag === enums.packet.secretKey) {
       secretKeyPacket = packetlist[i];
-      options.keyType = secretKeyPacket.algorithm;
     } else if (packetlist[i].tag === enums.packet.secretSubkey) {
-      secretSubkeyPacket = packetlist[i];
-      options.subkeyType = secretSubkeyPacket.algorithm;
+      secretSubkeyPackets.push(packetlist[i]);
     }
   }
   if (!secretKeyPacket) {
     throw new Error('Key does not contain a secret key packet');
   }
-  return wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options);
+
+  if (!options.subkeys) {
+    options.subkeys = secretSubkeyPackets.map(() => ({}));
+  }
+
+  if (options.subkeys.length !== secretSubkeyPackets.length) {
+    throw new Error('Number of subkey options does not match number of subkeys');
+  }
+
+  options.subkeys = options.subkeys.map(function(subkey, index) { return sanitizeKeyOptions(options.subkeys[index], options); });
+
+  return wrapKeyObject([secretKeyPacket].concat(secretSubkeyPackets), options);
+
+    function sanitizeKeyOptions(options, subkeyDefaults={}) {
+    options.keyExpirationTime = options.keyExpirationTime || subkeyDefaults.keyExpirationTime;
+    options.passphrase = util.isString(options.passphrase) ? options.passphrase : subkeyDefaults.passphrase;
+    options.date = options.date || subkeyDefaults.date;
+
+    return options;
+  }
 }
 
-async function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
+async function wrapKeyObject(packets, options) {
+  const secretKeyPacket = packets[0];
+  const secretSubkeyPackets = packets.slice(1);
   // set passphrase protection
   if (options.passphrase) {
     await secretKeyPacket.encrypt(options.passphrase);
-    if (secretSubkeyPacket) {
-      await secretSubkeyPacket.encrypt(options.passphrase);
-    }
   }
+
+  await Promise.all(secretSubkeyPackets.map(async function(secretSubkeyPacket, index) {
+    const subkeyPassphrase = options.subkeys[index].passphrase;
+    if (subkeyPassphrase) {
+      await secretSubkeyPacket.encrypt(subkeyPassphrase);
+    }
+  }));
 
   const packetlist = new packet.List();
 
@@ -1248,7 +1264,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
     dataToSign.key = secretKeyPacket;
     const signaturePacket = new packet.Signature(options.date);
     signaturePacket.signatureType = enums.signature.cert_generic;
-    signaturePacket.publicKeyAlgorithm = options.keyType;
+    signaturePacket.publicKeyAlgorithm = secretKeyPacket.algorithm;
     signaturePacket.hashAlgorithm = await getPreferredHashAlgo(secretKeyPacket);
     signaturePacket.keyFlags = [enums.keyFlags.certify_keys | enums.keyFlags.sign_data];
     signaturePacket.preferredSymmetricAlgorithms = [];
@@ -1277,6 +1293,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
       signaturePacket.keyExpirationTime = options.keyExpirationTime;
       signaturePacket.keyNeverExpires = false;
     }
+
     await signaturePacket.sign(secretKeyPacket, dataToSign);
 
     return { userIdPacket, signaturePacket };
@@ -1287,31 +1304,41 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPacket, options) {
     });
   });
 
-  if (secretSubkeyPacket) {
+  await Promise.all(secretSubkeyPackets.map(async function(secretSubkeyPacket, index) {
+    const subkeyOptions = options.subkeys[index];
     const dataToSign = {};
     dataToSign.key = secretKeyPacket;
     dataToSign.bind = secretSubkeyPacket;
-    const subkeySignaturePacket = new packet.Signature(options.date);
+    const subkeySignaturePacket = new packet.Signature(subkeyOptions.date);
     subkeySignaturePacket.signatureType = enums.signature.subkey_binding;
-    subkeySignaturePacket.publicKeyAlgorithm = options.keyType;
+    subkeySignaturePacket.publicKeyAlgorithm = secretKeyPacket.algorithm;
     subkeySignaturePacket.hashAlgorithm = await getPreferredHashAlgo(secretSubkeyPacket);
-    subkeySignaturePacket.keyFlags = [enums.keyFlags.encrypt_communication | enums.keyFlags.encrypt_storage];
-    if (options.keyExpirationTime > 0) {
-      subkeySignaturePacket.keyExpirationTime = options.keyExpirationTime;
+    subkeySignaturePacket.keyFlags = subkeyOptions.sign ? enums.keyFlags.sign_data : [enums.keyFlags.encrypt_communication | enums.keyFlags.encrypt_storage];
+    if (subkeyOptions.keyExpirationTime > 0) {
+      subkeySignaturePacket.keyExpirationTime = subkeyOptions.keyExpirationTime;
       subkeySignaturePacket.keyNeverExpires = false;
     }
     await subkeySignaturePacket.sign(secretKeyPacket, dataToSign);
 
-    packetlist.push(secretSubkeyPacket);
-    packetlist.push(subkeySignaturePacket);
+    return { secretSubkeyPacket, subkeySignaturePacket};
+  })).then(packets => {
+    packets.forEach(({ secretSubkeyPacket, subkeySignaturePacket }) => {
+      packetlist.push(secretSubkeyPacket);
+      packetlist.push(subkeySignaturePacket);
+    });
+  });
+
+  // set passphrase protection
+  if (options.passphrase) {
+    secretKeyPacket.clearPrivateParams();
   }
 
-  if (!options.unlocked) {
-    secretKeyPacket.clearPrivateParams();
-    if (secretSubkeyPacket) {
+  await Promise.all(secretSubkeyPackets.map(async function(secretSubkeyPacket, index) {
+    const subkeyPassphrase = options.subkeys[index].passphrase;
+    if (subkeyPassphrase) {
       secretSubkeyPacket.clearPrivateParams();
     }
-  }
+  }));
 
   return new Key(packetlist);
 }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -161,9 +161,9 @@ export function reformatKey({privateKey, userIds=[], passphrase="", keyExpiratio
 
 /**
  * Unlock a private key with your passphrase.
- * @param  {Key} privateKey      the private key that is to be decrypted
- * @param  {String} passphrase   the user's passphrase chosen during key generation
- * @returns {Promise<Object>}     the unlocked key object in the form: { key:Key }
+ * @param  {Key} privateKey                    the private key that is to be decrypted
+ * @param  {String|Array<String>} passphrase   the user's passphrase(s) chosen during key generation
+ * @returns {Promise<Object>}                  the unlocked key object in the form: { key:Key }
  * @async
  */
 export function decryptKey({ privateKey, passphrase }) {
@@ -182,9 +182,9 @@ export function decryptKey({ privateKey, passphrase }) {
 
 /**
  * Lock a private key with your passphrase.
- * @param  {Key} privateKey      the private key that is to be decrypted
- * @param  {String} passphrase   the user's passphrase chosen during key generation
- * @returns {Promise<Object>}     the locked key object in the form: { key:Key }
+ * @param  {Key} privateKey                      the private key that is to be decrypted
+ * @param  {String|Array<String>} passphrase     the user's passphrase(s) chosen during key generation
+ * @returns {Promise<Object>}                    the locked key object in the form: { key:Key }
  * @async
  */
 export function encryptKey({ privateKey, passphrase }) {

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -99,26 +99,22 @@ export function destroyWorker() {
  * @param  {Array<Object>} userIds   array of user IDs e.g. [{ name:'Phil Zimmermann', email:'phil@openpgp.org' }]
  * @param  {String} passphrase       (optional) The passphrase used to encrypt the resulting private key
  * @param  {Number} numBits          (optional) number of bits for RSA keys: 2048 or 4096.
+ * @param  {Number} keyExpirationTime (optional) The number of seconds after the key creation time that the key expires
  * @param  {String} curve            (optional) elliptic curve for ECC keys:
  *                                              curve25519, p256, p384, p521, secp256k1,
  *                                              brainpoolP256r1, brainpoolP384r1, or brainpoolP512r1.
- * @param  {Boolean} unlocked        (optional) If the returned secret part of the generated key is unlocked
- * @param  {Number} keyExpirationTime (optional) The number of seconds after the key creation time that the key expires
  * @param  {Date} date               (optional) override the creation date of the key and the key signatures
+ * @param  {Array<Object>} subkeys   (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
+ *                                              sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
  * @returns {Promise<Object>}         The generated key object in the form:
  *                                     { key:Key, privateKeyArmored:String, publicKeyArmored:String }
  * @async
  * @static
  */
 
-export function generateKey({
-  userIds=[], passphrase, numBits=2048, unlocked=false, keyExpirationTime=0, curve="", date=new Date()
-} = {}) {
+export function generateKey({ userIds=[], passphrase="", numBits=2048, keyExpirationTime=0, curve="", date=new Date(), subkeys=[{}] }) {
   userIds = formatUserIds(userIds);
-  const options = {
-    userIds, passphrase, numBits, unlocked, keyExpirationTime, curve, date
-  };
-
+  const options = { userIds, passphrase, numBits, keyExpirationTime, curve, date, subkeys };
   if (util.getWebCryptoAll() && numBits < 2048) {
     throw new Error('numBits should be 2048 or 4096, found: ' + numBits);
   }
@@ -141,22 +137,15 @@ export function generateKey({
  * @param  {Key} privateKey          private key to reformat
  * @param  {Array<Object>} userIds   array of user IDs e.g. [{ name:'Phil Zimmermann', email:'phil@openpgp.org' }]
  * @param  {String} passphrase       (optional) The passphrase used to encrypt the resulting private key
- * @param  {Boolean} unlocked        (optional) If the returned secret part of the generated key is unlocked
  * @param  {Number} keyExpirationTime (optional) The number of seconds after the key creation time that the key expires
  * @returns {Promise<Object>}         The generated key object in the form:
  *                                     { key:Key, privateKeyArmored:String, publicKeyArmored:String }
  * @async
  * @static
  */
-export function reformatKey({
-  privateKey, userIds=[], passphrase="", unlocked=false, keyExpirationTime=0
-} = {}) {
+export function reformatKey({privateKey, userIds=[], passphrase="", keyExpirationTime=0, date}) {
   userIds = formatUserIds(userIds);
-
-  const options = {
-    privateKey, userIds, passphrase, unlocked, keyExpirationTime
-  };
-
+  const options = { privateKey, userIds, passphrase, keyExpirationTime, date};
   if (asyncProxy) {
     return asyncProxy.delegate('reformatKey', options);
   }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1081,7 +1081,6 @@ describe('Key', function() {
     const opt = {
       userIds: { name: 'Test User', email: 'text@example.com' },
       passphrase: 'secret',
-      unlocked: true,
       date: past
     };
 
@@ -1105,6 +1104,47 @@ describe('Key', function() {
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
       expect(key.users[1].userId.userid).to.equal(userId2);
       expect(key.users[1].selfCertifications[0].isPrimaryUserID).to.be.null;
+    });
+  });
+
+  it('Generate key - two subkeys with default values', function() {
+    const userId = 'test <a@b.com>';
+    const opt = {curve: 'curve25519', userIds: [userId], passphrase: '123', subkeys:[{},{}]};
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
+      expect(key.users.length).to.equal(1);
+      expect(key.users[0].userId.userid).to.equal(userId);
+      expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
+      expect(key.subKeys).to.have.lengthOf(2);
+      expect(key.subKeys[0].subKey.algorithm).to.equal('ecdh');
+      expect(key.subKeys[1].subKey.algorithm).to.equal('ecdh');
+    });
+  });
+
+  it('Generate key - one signing subkey', function() {
+    const userId = 'test <a@b.com>';
+    const opt = {curve: 'curve25519', userIds: [userId], passphrase: '123', subkeys:[{}, {sign: true}]};
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
+      expect(key.users.length).to.equal(1);
+      expect(key.users[0].userId.userid).to.equal(userId);
+      expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
+      expect(key.subKeys).to.have.lengthOf(2);
+      expect(key.subKeys[0].subKey.algorithm).to.equal('ecdh');
+      expect(key.subKeys[1].subKey.algorithm).to.equal('eddsa');
+    });
+  });
+
+  it('Generate key - override main key options for subkey', function() {
+    const userId = 'test <a@b.com>';
+    const opt = {numBits: 2048, userIds: [userId], passphrase: '123', subkeys:[{curve: 'curve25519'}]};
+    return openpgp.generateKey(opt).then(function(key) {
+      key = key.key;
+      expect(key.users.length).to.equal(1);
+      expect(key.users[0].userId.userid).to.equal(userId);
+      expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
+      expect(key.primaryKey.algorithm).to.equal('rsa_encrypt_sign');
+      expect(key.subKeys[0].subKey.algorithm).to.equal('ecdh');
     });
   });
 
@@ -1258,6 +1298,28 @@ describe('Key', function() {
       expect(newKey.users.length).to.equal(1);
       expect(newKey.users[0].userId.userid).to.equal(userId);
       expect(newKey.primaryKey.isDecrypted).to.be.false;
+    });
+  });
+
+  it('Reformat key with two subkeys with passphrase', function() {
+    const userId1 = 'test <a@b.com>';
+    const userId2 = 'test <b@c.com>';
+    const now = openpgp.util.normalizeDate(new Date());
+    const before = openpgp.util.normalizeDate(new Date(0));
+    const opt1 = {curve: 'curve25519', userIds: [userId1], date: now};
+    return openpgp.generateKey(opt1).then(function(newKey) {
+      newKey = newKey.key;
+      expect(newKey.users[0].userId.userid).to.equal(userId1);
+      expect(+newKey.primaryKey.created).to.equal(+now);
+      expect(+newKey.subKeys[0].subKey.created).to.equal(+now);
+      expect(+newKey.subKeys[0].bindingSignatures[0].created).to.equal(+now);
+      const opt2 = {privateKey: newKey, userIds: [userId2], date: before};
+      return openpgp.reformatKey(opt2).then(function(refKey) {
+        refKey = refKey.key;
+        expect(refKey.users.length).to.equal(1);
+        expect(refKey.users[0].userId.userid).to.equal(userId2);
+        expect(+refKey.subKeys[0].bindingSignatures[0].created).to.equal(+before);
+      });
     });
   });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -483,43 +483,26 @@ describe('OpenPGP.js public api tests', function() {
     });
 
     it('should have default params set', function() {
-      const now = new Date();
+      const now = openpgp.util.normalizeDate(new Date());
       const opt = {
         userIds: { name: 'Test User', email: 'text@example.com' },
         passphrase: 'secret',
-        unlocked: true,
-        date: now
+        date: now,
+        subkeys: []
       };
       return openpgp.generateKey(opt).then(function(newKey) {
         expect(keyGenStub.withArgs({
           userIds: ['Test User <text@example.com>'],
           passphrase: 'secret',
           numBits: 2048,
-          unlocked: true,
           keyExpirationTime: 0,
           curve: "",
-          date: now
+          date: now,
+          subkeys: [],
         }).calledOnce).to.be.true;
         expect(newKey.key).to.exist;
         expect(newKey.privateKeyArmored).to.exist;
         expect(newKey.publicKeyArmored).to.exist;
-      });
-    });
-
-    it('should work for no params', function() {
-      const now = new Date();
-
-      return openpgp.generateKey({date: now}).then(function(newKey) {
-        expect(keyGenStub.withArgs({
-          userIds: [],
-          passphrase: undefined,
-          numBits: 2048,
-          unlocked: false,
-          keyExpirationTime: 0,
-          curve: "",
-          date: now
-        }).calledOnce).to.be.true;
-        expect(newKey.key).to.exist;
       });
     });
 
@@ -533,7 +516,12 @@ describe('OpenPGP.js public api tests', function() {
       const proxyGenStub = stub(openpgp.getWorker(), 'delegate');
       getWebCryptoAllStub.returns();
 
-      openpgp.generateKey();
+      const opt = {
+        userIds: { name: 'Test User', email: 'text@example.com' },
+        passphrase: 'secret',
+        subkeys: []
+      };
+      openpgp.generateKey(opt);
       expect(proxyGenStub.calledOnce).to.be.true;
       expect(keyGenStub.calledOnce).to.be.false;
     });


### PR DESCRIPTION
Adds a `subkeys` parameter to the `generateKey` function that allows users to customize options for subkeys. This includes:
1) Generating a key with multiple subkeys
2) Choosing whether each subkey is an encrypting (the default) or signing subkey
3) Choosing a different algorithm for each subkey
4) Choosing different expiration times/dates for each subkey

If the `subkeys` parameter is not defined, the default behavior is to create a single encryption subkey with the same parameters as the main key. 

Similarly adds this parameter to the `reformatKey` route.

Also removes the `unlocked` parameter from these routes - the key will be unlocked if and only if no passphrase or an empty passphrase is present. 