### PR TITLE
Parse user IDs & allow selecting user when encrypting/signing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,8 +29,8 @@ module.exports = function(grunt) {
           transform: [
             ["babelify", {
               global: true,
-              // Only babelify asmcrypto in node_modules
-              only: /^(?:.*\/node_modules\/asmcrypto\.js\/|(?!.*\/node_modules\/)).*$/,
+              // Only babelify asmcrypto and address-rfc2822 in node_modules
+              only: /^(?:.*\/node_modules\/asmcrypto\.js\/|.*\/node_modules\/address-rfc2822\/|(?!.*\/node_modules\/)).*$/,
               plugins: ["transform-async-to-generator",
                         "syntax-async-functions",
                         "transform-regenerator",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "dependencies": {
+    "address-rfc2822": "^2.0.3",
     "asmcrypto.js": "^0.22.0",
     "asn1.js": "^5.0.0",
     "bn.js": "^4.11.8",

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -70,11 +70,12 @@ CleartextMessage.prototype.getSigningKeyIds = function() {
  * @param  {Array<module:key.Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
  * @param  {Date} date                       (optional) The creation time of the signature that should be created
+ * @param  {Object} userId                   (optional) user ID to sign with, e.g. { name:'Steve Sender', email:'steve@openpgp.org' }
  * @returns {Promise<module:cleartext.CleartextMessage>} new cleartext message with signed content
  * @async
  */
-CleartextMessage.prototype.sign = async function(privateKeys, signature=null, date=new Date()) {
-  return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, date));
+CleartextMessage.prototype.sign = async function(privateKeys, signature=null, date=new Date(), userId={}) {
+  return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, date, userId));
 };
 
 /**
@@ -82,14 +83,15 @@ CleartextMessage.prototype.sign = async function(privateKeys, signature=null, da
  * @param  {Array<module:key.Key>} privateKeys private keys with decrypted secret key data for signing
  * @param  {Signature} signature             (optional) any existing detached signature
  * @param  {Date} date                       (optional) The creation time of the signature that should be created
+ * @param  {Object} userId                   (optional) user ID to sign with, e.g. { name:'Steve Sender', email:'steve@openpgp.org' }
  * @returns {Promise<module:signature.Signature>}      new detached signature of message content
  * @async
  */
-CleartextMessage.prototype.signDetached = async function(privateKeys, signature=null, date=new Date()) {
+CleartextMessage.prototype.signDetached = async function(privateKeys, signature=null, date=new Date(), userId={}) {
   const literalDataPacket = new packet.Literal();
   literalDataPacket.setText(this.text);
 
-  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, date));
+  return new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, date, userId));
 };
 
 /**

--- a/src/key.js
+++ b/src/key.js
@@ -1244,7 +1244,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options) {
 
   await Promise.all(options.userIds.map(async function(userId, index) {
     const userIdPacket = new packet.Userid();
-    userIdPacket.read(util.str_to_Uint8Array(userId));
+    userIdPacket.format(userId);
 
     const dataToSign = {};
     dataToSign.userid = userIdPacket;

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -115,7 +115,7 @@ export function destroyWorker() {
  */
 
 export function generateKey({ userIds=[], passphrase="", numBits=2048, keyExpirationTime=0, curve="", date=new Date(), subkeys=[{}] }) {
-  userIds = formatUserIds(userIds);
+  userIds = toArray(userIds);
   const options = { userIds, passphrase, numBits, keyExpirationTime, curve, date, subkeys };
   if (util.getWebCryptoAll() && numBits < 2048) {
     throw new Error('numBits should be 2048 or 4096, found: ' + numBits);
@@ -146,7 +146,7 @@ export function generateKey({ userIds=[], passphrase="", numBits=2048, keyExpira
  * @static
  */
 export function reformatKey({privateKey, userIds=[], passphrase="", keyExpirationTime=0, date}) {
-  userIds = formatUserIds(userIds);
+  userIds = toArray(userIds);
   const options = { privateKey, userIds, passphrase, keyExpirationTime, date};
   if (asyncProxy) {
     return asyncProxy.delegate('reformatKey', options);
@@ -482,36 +482,6 @@ function checkCleartextOrMessage(message) {
   if (!(message instanceof CleartextMessage) && !(message instanceof messageLib.Message)) {
     throw new Error('Parameter [message] needs to be of type Message or CleartextMessage');
   }
-}
-
-/**
- * Format user ids for internal use.
- */
-function formatUserIds(userIds) {
-  if (!userIds) {
-    return userIds;
-  }
-  userIds = toArray(userIds); // normalize to array
-  userIds = userIds.map(id => {
-    if (util.isString(id) && !util.isUserId(id)) {
-      throw new Error('Invalid user id format');
-    }
-    if (util.isUserId(id)) {
-      return id; // user id is already in correct format... no conversion necessary
-    }
-    // name and email address can be empty but must be of the correct type
-    id.name = id.name || '';
-    id.email = id.email || '';
-    if (!util.isString(id.name) || (id.email && !util.isEmailAddress(id.email))) {
-      throw new Error('Invalid user id format');
-    }
-    id.name = id.name.trim();
-    if (id.name.length > 0) {
-      id.name += ' ';
-    }
-    return id.name + '<' + id.email + '>';
-  });
-  return userIds;
 }
 
 /**

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -228,17 +228,19 @@ export function encryptKey({ privateKey, passphrase }) {
  * @param  {Boolean} returnSessionKey             (optional) if the unencrypted session key should be added to returned object
  * @param  {Boolean} wildcard                     (optional) use a key ID of 0 instead of the public key IDs
  * @param  {Date} date                            (optional) override the creation date of the message and the message signature
+ * @param  {Object} fromUserId                    (optional) user ID to sign with, e.g. { name:'Steve Sender', email:'steve@openpgp.org' }
+ * @param  {Object} toUserId                      (optional) user ID to encrypt for, e.g. { name:'Robert Receiver', email:'robert@openpgp.org' }
  * @returns {Promise<Object>}                      encrypted (and optionally signed message) in the form:
  *                                                  {data: ASCII armored message if 'armor' is true,
  *                                                  message: full Message object if 'armor' is false, signature: detached signature if 'detached' is true}
  * @async
  * @static
  */
-export function encrypt({ data, dataType, publicKeys, privateKeys, passwords, sessionKey, filename, compression=config.compression, armor=true, detached=false, signature=null, returnSessionKey=false, wildcard=false, date=new Date()}) {
+export function encrypt({ data, dataType, publicKeys, privateKeys, passwords, sessionKey, filename, compression=config.compression, armor=true, detached=false, signature=null, returnSessionKey=false, wildcard=false, date=new Date(), fromUserId={}, toUserId={} }) {
   checkData(data); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords);
 
   if (!nativeAEAD() && asyncProxy) { // use web worker if web crypto apis are not supported
-    return asyncProxy.delegate('encrypt', { data, dataType, publicKeys, privateKeys, passwords, sessionKey, filename, compression, armor, detached, signature, returnSessionKey, wildcard, date });
+    return asyncProxy.delegate('encrypt', { data, dataType, publicKeys, privateKeys, passwords, sessionKey, filename, compression, armor, detached, signature, returnSessionKey, wildcard, date, fromUserId, toUserId });
   }
   const result = {};
   return Promise.resolve().then(async function() {
@@ -248,14 +250,14 @@ export function encrypt({ data, dataType, publicKeys, privateKeys, passwords, se
     }
     if (privateKeys.length || signature) { // sign the message only if private keys or signature is specified
       if (detached) {
-        const detachedSignature = await message.signDetached(privateKeys, signature, date);
+        const detachedSignature = await message.signDetached(privateKeys, signature, date, fromUserId);
         result.signature = armor ? detachedSignature.armor() : detachedSignature;
       } else {
-        message = await message.sign(privateKeys, signature, date);
+        message = await message.sign(privateKeys, signature, date, fromUserId);
       }
     }
     message = message.compress(compression);
-    return message.encrypt(publicKeys, passwords, sessionKey, wildcard, date);
+    return message.encrypt(publicKeys, passwords, sessionKey, wildcard, date, toUserId);
 
   }).then(encrypted => {
     if (armor) {
@@ -322,19 +324,20 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
  * @param  {Boolean} armor                      (optional) if the return value should be ascii armored or the message object
  * @param  {Boolean} detached                   (optional) if the return value should contain a detached signature
  * @param  {Date} date                          (optional) override the creation date signature
+ * @param  {Object} fromUserId                  (optional) user ID to sign with, e.g. { name:'Steve Sender', email:'steve@openpgp.org' }
  * @returns {Promise<Object>}                    signed cleartext in the form:
  *                                                {data: ASCII armored message if 'armor' is true,
  *                                                message: full Message object if 'armor' is false, signature: detached signature if 'detached' is true}
  * @async
  * @static
  */
-export function sign({ data, dataType, privateKeys, armor=true, detached=false, date=new Date() }) {
+export function sign({ data, dataType, privateKeys, armor=true, detached=false, date=new Date(), fromUserId={} }) {
   checkData(data);
   privateKeys = toArray(privateKeys);
 
   if (asyncProxy) { // use web worker if available
     return asyncProxy.delegate('sign', {
-      data, dataType, privateKeys, armor, detached, date
+      data, dataType, privateKeys, armor, detached, date, fromUserId
     });
   }
 
@@ -343,10 +346,10 @@ export function sign({ data, dataType, privateKeys, armor=true, detached=false, 
     let message = util.isString(data) ? new CleartextMessage(data) : messageLib.fromBinary(data, dataType);
 
     if (detached) {
-      const signature = await message.signDetached(privateKeys, undefined, date);
+      const signature = await message.signDetached(privateKeys, undefined, date, fromUserId);
       result.signature = armor ? signature.armor() : signature;
     } else {
-      message = await message.sign(privateKeys, undefined, date);
+      message = await message.sign(privateKeys, undefined, date, fromUserId);
       if (armor) {
         result.data = message.armor();
       } else {
@@ -403,20 +406,22 @@ export function verify({ message, publicKeys, signature=null, date=new Date() })
  * @param  {Key|Array<Key>} publicKeys        (optional) array of public keys or single key, used to encrypt the key
  * @param  {String|Array<String>} passwords   (optional) passwords for the message
  * @param  {Boolean} wildcard                 (optional) use a key ID of 0 instead of the public key IDs
+ * @param  {Date} date                        (optional) override the date
+ * @param  {Object} toUserId                  (optional) user ID to encrypt for, e.g. { name:'Phil Zimmermann', email:'phil@openpgp.org' }
  * @returns {Promise<Message>}                 the encrypted session key packets contained in a message object
  * @async
  * @static
  */
-export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard=false }) {
+export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard=false, date=new Date(), toUserId={} }) {
   checkBinary(data); checkString(algorithm, 'algorithm'); publicKeys = toArray(publicKeys); passwords = toArray(passwords);
 
   if (asyncProxy) { // use web worker if available
-    return asyncProxy.delegate('encryptSessionKey', { data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard });
+    return asyncProxy.delegate('encryptSessionKey', { data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard, date, toUserId });
   }
 
   return Promise.resolve().then(async function() {
 
-    return { message: await messageLib.encryptSessionKey(data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard) };
+    return { message: await messageLib.encryptSessionKey(data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard, date, toUserId) };
 
   }).catch(onError.bind(null, 'Error encrypting session key'));
 }

--- a/src/packet/userid.js
+++ b/src/packet/userid.js
@@ -41,6 +41,10 @@ function Userid() {
    * @type {String}
    */
   this.userid = '';
+
+  this.name = '';
+  this.email = '';
+  this.comment = '';
 }
 
 /**
@@ -48,7 +52,17 @@ function Userid() {
  * @param {Uint8Array} input payload of a tag 13 packet
  */
 Userid.prototype.read = function (bytes) {
-  this.userid = util.decode_utf8(util.Uint8Array_to_str(bytes));
+  this.parse(util.decode_utf8(util.Uint8Array_to_str(bytes)));
+};
+
+/**
+ * Parse userid string, e.g. 'John Doe <john@example.com>'
+ */
+Userid.prototype.parse = function (userid) {
+  try {
+    Object.assign(this, util.parseUserId(userid));
+  } catch(e) {}
+  this.userid = userid;
 };
 
 /**
@@ -57,6 +71,17 @@ Userid.prototype.read = function (bytes) {
  */
 Userid.prototype.write = function () {
   return util.str_to_Uint8Array(util.encode_utf8(this.userid));
+};
+
+/**
+ * Set userid string from object, e.g. { name:'Phil Zimmermann', email:'phil@openpgp.org' }
+ */
+Userid.prototype.format = function (userid) {
+  if (util.isString(userid)) {
+    userid = util.parseUserId(userid);
+  }
+  Object.assign(this, userid);
+  this.userid = util.formatUserId(userid);
 };
 
 export default Userid;

--- a/src/util.js
+++ b/src/util.js
@@ -17,11 +17,13 @@
 
 /**
  * This object contains utility functions
+ * @requires address-rfc2822
  * @requires config
  * @requires encoding/base64
  * @module util
  */
 
+import rfc2822 from 'address-rfc2822';
 import config from './config';
 import util from './util'; // re-import module to access util functions
 import b64 from './encoding/base64';
@@ -567,6 +569,29 @@ export default {
     }
     const re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+([a-zA-Z]{2,}|xn--[a-zA-Z\-0-9]+)))$/;
     return re.test(data);
+  },
+
+  /**
+   * Format user id for internal use.
+   */
+  formatUserId: function(id) {
+    // name and email address can be empty but must be of the correct type
+    if ((id.name && !util.isString(id.name)) || (id.email && !util.isEmailAddress(id.email))) {
+      throw new Error('Invalid user id format');
+    }
+    return new rfc2822.Address(id.name, id.email, id.comment).format();
+  },
+
+  /**
+   * Parse user id.
+   */
+  parseUserId: function(userid) {
+    try {
+      const [{ phrase: name, address: email, comment }] = rfc2822.parse(userid);
+      return { name, email, comment: comment.replace(/^\(|\)$/g, '') };
+    } catch(e) {
+      throw new Error('Invalid user id format');
+    }
   },
 
   isUserId: function(data) {

--- a/src/util.js
+++ b/src/util.js
@@ -594,13 +594,6 @@ export default {
     }
   },
 
-  isUserId: function(data) {
-    if (!util.isString(data)) {
-      return false;
-    }
-    return /</.test(data) && />$/.test(data);
-  },
-
   /**
    * Normalize line endings to \r\n
    */

--- a/test/general/ecc_nist.js
+++ b/test/general/ecc_nist.js
@@ -156,8 +156,14 @@ describe('Elliptic Curve Cryptography', function () {
     return data[name].priv_key;
   }
   it('Load public key', function (done) {
-    load_pub_key('romeo');
-    load_pub_key('juliet');
+    const romeoPublic = load_pub_key('romeo');
+    expect(romeoPublic.users[0].userId.name).to.equal('Romeo Montague');
+    expect(romeoPublic.users[0].userId.email).to.equal('romeo@example.net');
+    expect(romeoPublic.users[0].userId.comment).to.equal('secp256k1');
+    const julietPublic = load_pub_key('juliet');
+    expect(julietPublic.users[0].userId.name).to.equal('Juliet Capulet');
+    expect(julietPublic.users[0].userId.email).to.equal('juliet@example.net');
+    expect(julietPublic.users[0].userId.comment).to.equal('secp256k1');
     done();
   });
   it('Load private key', async function () {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1555,6 +1555,7 @@ p92yZgB3r2+f6/GIe2+7
     publicKey.users[1].selfCertifications[0].preferredSymmetricAlgorithms = [openpgp.enums.symmetric.aes128];
     const encrypted = await openpgp.encrypt({data: 'hello', publicKeys: publicKey, privateKeys: privateKey, toUserId: {name: 'Test User', email: 'b@c.com'}, armor: false});
     expect(encrypted.message.packets[0].sessionKeyAlgorithm).to.equal('aes128');
+    await expect(openpgp.encrypt({data: 'hello', publicKeys: publicKey, privateKeys: privateKey, toUserId: {name: 'Test User', email: 'c@c.com'}, armor: false})).to.be.rejectedWith('Could not find user that matches that user ID');
   });
 
   it('Sign - specific user', async function() {
@@ -1574,6 +1575,7 @@ p92yZgB3r2+f6/GIe2+7
     expect(signed.message.signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
     const encrypted = await openpgp.encrypt({data: 'hello', publicKeys: publicKey, privateKeys: privateKey, fromUserId: {name: 'Test McTestington', email: 'test@example.com'}, detached: true, armor: false});
     expect(encrypted.signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
+    await expect(openpgp.encrypt({data: 'hello', publicKeys: publicKey, privateKeys: privateKey, fromUserId: {name: 'Not Test McTestington', email: 'test@example.com'}, detached: true, armor: false})).to.be.rejectedWith('Could not find user that matches that user ID');
   });
 
   it('Reformat key without passphrase', function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1297,6 +1297,9 @@ p92yZgB3r2+f6/GIe2+7
     const primUser = await key.getPrimaryUser();
     expect(primUser).to.exist;
     expect(primUser.user.userId.userid).to.equal('Signature Test <signature@test.com>');
+    expect(primUser.user.userId.name).to.equal('Signature Test');
+    expect(primUser.user.userId.email).to.equal('signature@test.com');
+    expect(primUser.user.userId.comment).to.equal('');
     expect(primUser.selfCertification).to.be.an.instanceof(openpgp.packet.Signature);
   });
 
@@ -1315,13 +1318,16 @@ p92yZgB3r2+f6/GIe2+7
   });
 
   it('Generate key - single userid', function() {
-    const userId = 'test <a@b.com>';
+    const userId = { name: 'test', email: 'a@b.com', comment: 'test comment' };
     const opt = {numBits: 512, userIds: userId, passphrase: '123'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
     return openpgp.generateKey(opt).then(function(key) {
       key = key.key;
       expect(key.users.length).to.equal(1);
-      expect(key.users[0].userId.userid).to.equal(userId);
+      expect(key.users[0].userId.userid).to.equal('test <a@b.com> (test comment)');
+      expect(key.users[0].userId.name).to.equal(userId.name);
+      expect(key.users[0].userId.email).to.equal(userId.email);
+      expect(key.users[0].userId.comment).to.equal(userId.comment);
     });
   });
 

--- a/test/general/util.js
+++ b/test/general/util.js
@@ -116,37 +116,6 @@ describe('Util unit tests', function() {
     });
   });
 
-  describe('isUserId', function() {
-    it('should return true for valid user id', function() {
-      const data = 'Test User <test@example.com>';
-      expect(openpgp.util.isUserId(data)).to.be.true;
-    });
-    it('should return false for invalid user id', function() {
-      const data = 'Test User test@example.com>';
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-    it('should return false for invalid user id', function() {
-      const data = 'Test User <test@example.com';
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-    it('should return false for invalid user id', function() {
-      const data = 'Test User test@example.com';
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-    it('should return false for empty string', function() {
-      const data = '';
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-    it('should return false for undefined', function() {
-      let data;
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-    it('should return false for Object', function() {
-      const data = {};
-      expect(openpgp.util.isUserId(data)).to.be.false;
-    });
-  });
-
   describe('getTransferables', function() {
     let zero_copyVal;
     const buf1 = new Uint8Array(1);


### PR DESCRIPTION
Fixes #595. Also, adds parameters to select the user by user ID to `openpgp.encrypt`, `sign` and `encryptSessionKey`.