### PR TITLE
Update Sauce Labs browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,46 +10,31 @@ matrix:
   fast_finish: true
   include:
     - node_js: "8"
-      env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='8'
+      env: OPENPGP_NODE_JS='8' OPENPGPJSTEST='unit'
     - node_js: "10"
-      env: OPENPGPJSTEST='unit' OPENPGP_NODE_JS='10'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-0' BROWSER='firefox 38'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-1' BROWSER='firefox 54'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-2' BROWSER='chrome 38'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-3' BROWSER='chrome 59'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-6' BROWSER='safari 8'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-7' BROWSER='safari 10'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-5' BROWSER='microsoft edge 15'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-4' BROWSER='internet explorer 11'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-8' BROWSER='android 4.4'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-9' BROWSER='android 6.0'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-10' BROWSER='iphone 7.0'
-    - node_js: "8"
-      env: OPENPGPJSTEST='end2end-11' BROWSER='iphone 11.0'
+      env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
+    - node_js: "9"
+      env: BROWSER='Firefox' VERSION='61' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - node_js: "9"
+      env: BROWSER='Chrome' VERSION='49' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - node_js: "9"
+      env: BROWSER='Chrome' VERSION='68' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - node_js: "9"
+      env: BROWSER='Internet Explorer' VERSION='11.103' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - node_js: "9"
+      env: BROWSER='MicrosoftEdge' VERSION='17.17134' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs'
+    - node_js: "9"
+      env: BROWSER='Safari' VERSION='10' PLATFORM='macOS 10.12' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - node_js: "9"
+      env: BROWSER='Safari' VERSION='11' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - node_js: "9"
+      env: BROWSER='Android' VERSION='6.0' OPENPGPJSTEST='saucelabs'
+    - node_js: "9"
+      env: BROWSER='iPad' VERSION='10.0' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - node_js: "9"
+      env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
   allow_failures:
-    - env: OPENPGPJSTEST='end2end-0' BROWSER='firefox 38'
-    - env: OPENPGPJSTEST='end2end-1' BROWSER='firefox 54'
-    - env: OPENPGPJSTEST='end2end-2' BROWSER='chrome 38'
-    - env: OPENPGPJSTEST='end2end-3' BROWSER='chrome 59'
-    - env: OPENPGPJSTEST='end2end-6' BROWSER='safari 8'
-    - env: OPENPGPJSTEST='end2end-7' BROWSER='safari 10'
-    - env: OPENPGPJSTEST='end2end-5' BROWSER='microsoft edge 15'
-    - env: OPENPGPJSTEST='end2end-4' BROWSER='internet explorer 11'
-    - env: OPENPGPJSTEST='end2end-8' BROWSER='android 4.4'
-    - env: OPENPGPJSTEST='end2end-9' BROWSER='android 6.0'
-    - env: OPENPGPJSTEST='end2end-10' BROWSER='iphone 7.0'
-    - env: OPENPGPJSTEST='end2end-11' BROWSER='iphone 11.0'
+    - node_js: "9"
 
 before_script:
   - npm install -g grunt-cli codeclimate-test-reporter

--- a/travis.sh
+++ b/travis.sh
@@ -11,31 +11,11 @@ elif [ $OPENPGPJSTEST = "unit" ]; then
   echo "Running OpenPGP.js unit tests on node.js."
   npm test
 
-elif [[ $OPENPGPJSTEST =~ ^end2end-.* ]]; then
+elif [ $OPENPGPJSTEST = "saucelabs" ]; then
   echo "Running OpenPGP.js browser unit tests on Saucelabs."
 
-  declare -a capabilities=(
-    "export COMPAT=1 SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Firefox\", \"version\":\"34\", \"platform\":\"OS X 10.12\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Firefox\", \"version\":\"54\", \"platform\":\"OS X 10.12\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export COMPAT=1 SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Chrome\", \"version\":\"41\", \"platform\":\"OS X 10.12\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\", \"extendedDebugging\":true}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Chrome\", \"version\":\"59\", \"platform\":\"OS X 10.12\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\", \"extendedDebugging\":true}'"
-    "export COMPAT=1 SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Internet Explorer\", \"version\":\"11.103\", \"platform\":\"Windows 10\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"MicrosoftEdge\", \"version\":\"15.15063\", \"platform\":\"Windows 10\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export COMPAT=1 SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Safari\", \"version\":\"8\", \"platform\":\"OS X 10.10\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Safari\", \"version\":\"10\", \"platform\":\"macOS 10.12\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Browser\", \"platformName\":\"Android\", \"platformVersion\": \"4.4\", \"deviceName\": \"Android Emulator\", \"deviceOrientation\": \"portrait\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\":\"Chrome\", \"platformName\":\"Android\", \"platformVersion\": \"6.0\", \"deviceName\": \"Android Emulator\", \"deviceOrientation\": \"portrait\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\": \"Safari\", \"platformName\":\"iOS\", \"platformVersion\": \"8.1\", \"deviceName\": \"iPad Simulator\", \"deviceOrientation\": \"portrait\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-    "export SELENIUM_BROWSER_CAPABILITIES='{\"browserName\": \"Safari\", \"platformName\":\"iOS\", \"platformVersion\": \"11.0\", \"deviceName\": \"iPad Air 2 Simulator\", \"deviceOrientation\": \"portrait\", \"maxDuration\":\"7200\", \"commandTimeout\":\"600\", \"idleTimeout\":\"270\"}'"
-  )
-
-  testkey=$(echo $OPENPGPJSTEST | cut -f2 -d-)
-
-  ## now loop through the above array
-  capability=${capabilities[${testkey}]}
-
-  echo "Testing Configuration: ${testkey}"
-  eval $capability
+  export SELENIUM_BROWSER_CAPABILITIES="{\"browserName\":\"$BROWSER\", \"version\":\"$VERSION\", \"platform\":\"$PLATFORM\", \"extendedDebugging\":true}"
+  echo "SELENIUM_BROWSER_CAPABILITIES='$SELENIUM_BROWSER_CAPABILITIES'"
   grunt saucelabs --compat=$COMPAT &
   background_process_pid=$!
 


### PR DESCRIPTION
Update Sauce Labs browsers to IE11, Safari 10+, Chrome 49+ and recent Firefox.

Also, make mobile tests actually run on mobile.