### PR TITLE
Fix IE11 support

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -15,9 +15,10 @@ if (typeof Array.prototype.find === 'undefined') {
 if (typeof Array.from === 'undefined') {
   require('core-js/fn/array/from');
 }
-if (typeof Promise === 'undefined') {
-  require('core-js/fn/promise');
-}
+
+// No if-statement on Promise because of IE11. Otherwise Promise is undefined in the service worker.
+require('core-js/fn/promise');
+
 if (typeof Uint8Array.from === 'undefined') {
   require('core-js/fn/typed/uint8-array');
 }

--- a/src/util.js
+++ b/src/util.js
@@ -30,8 +30,9 @@ import config from './config';
 import util from './util'; // re-import module to access util functions
 import b64 from './encoding/base64';
 
-export default {
+const isIE11 = typeof navigator !== 'undefined' && !!navigator.userAgent.match(/Trident\/7\.0.*rv:([0-9.]+).*\).*Gecko$/);
 
+export default {
   isString: function(data) {
     return typeof data === 'string' || String.prototype.isPrototypeOf(data);
   },
@@ -51,6 +52,10 @@ export default {
    * @returns {Array<ArrayBuffer>}   an array of binary data to be passed
    */
   getTransferables: function(obj) {
+    // Internet Explorer does not support Transferable objects.
+    if (isIE11) {
+      return undefined;
+    }
     if (config.zero_copy && Object.prototype.isPrototypeOf(obj)) {
       const transferables = [];
       util.collectBuffers(obj, transferables);


### PR DESCRIPTION
With IE11 it would throw a `DataCloneError` when using `postMessage` to the service worker. This was because it was sending an array as transferable which IE11 does not support.

https://developer.mozilla.org/en-US/docs/Web/API/Transferable
[1] Internet Explorer 10 only accepts a single Transferable object as a parameter, but not an array.

~~Also, I had to change the actual function call. IE11 still threw the error if I returned `undefined` in `getTransferables`.~~

2) After I fixed that I noticed that an error was thrown in `PublicKeyEncryptedSessionKey.prototype.decrypt` that `Promise` was undefined. So to fix that I always require the Promise polyfills.
