### PR TITLE
Run tests with randomly generated strings

### DIFF
--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -223,12 +223,12 @@ describe('Brainpool Cryptography', function () {
           const bye = secondKey.key;
           const pubBye = bye.toPublic();
 
-          const testdata = input.createSomeMessage();
-          const testdata2 = input.createSomeMessage();
+          const testData = input.createSomeMessage();
+          const testData2 = input.createSomeMessage();
           return Promise.all([
             // Signing message
             openpgp.sign(
-              { data: testdata, privateKeys: hi }
+              { data: testData, privateKeys: hi }
             ).then(signed => {
               const msg = openpgp.cleartext.readArmored(signed.data);
               // Verifying signed message
@@ -238,7 +238,7 @@ describe('Brainpool Cryptography', function () {
                 ).then(output => expect(output.signatures[0].valid).to.be.true),
                 // Verifying detached signature
                 openpgp.verify(
-                  { message: openpgp.message.fromText(testdata),
+                  { message: openpgp.message.fromText(testData),
                     publicKeys: pubHi,
                     signature: openpgp.signature.readArmored(signed.data) }
                 ).then(output => expect(output.signatures[0].valid).to.be.true)
@@ -246,7 +246,7 @@ describe('Brainpool Cryptography', function () {
             }),
             // Encrypting and signing
             openpgp.encrypt(
-              { data: testdata2,
+              { data: testData2,
                 publicKeys: [pubBye],
                 privateKeys: [hi] }
             ).then(encrypted => {
@@ -257,7 +257,7 @@ describe('Brainpool Cryptography', function () {
                   privateKeys: bye,
                   publicKeys: [pubHi] }
               ).then(output => {
-                expect(output.data).to.equal(testdata2);
+                expect(output.data).to.equal(testData2);
                 expect(output.signatures[0].valid).to.be.true;
               });
             })

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -4,6 +4,7 @@ const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
+const input = require('./testInputs.js');
 
 const expect = chai.expect;
 
@@ -222,10 +223,12 @@ describe('Brainpool Cryptography', function () {
           const bye = secondKey.key;
           const pubBye = bye.toPublic();
 
+          const testdata = input.createSomeMessage();
+          const testdata2 = input.createSomeMessage();
           return Promise.all([
             // Signing message
             openpgp.sign(
-              { data: 'Hi, this is me, Hi!', privateKeys: hi }
+              { data: testdata, privateKeys: hi }
             ).then(signed => {
               const msg = openpgp.cleartext.readArmored(signed.data);
               // Verifying signed message
@@ -235,7 +238,7 @@ describe('Brainpool Cryptography', function () {
                 ).then(output => expect(output.signatures[0].valid).to.be.true),
                 // Verifying detached signature
                 openpgp.verify(
-                  { message: openpgp.message.fromText('Hi, this is me, Hi!'),
+                  { message: openpgp.message.fromText(testdata),
                     publicKeys: pubHi,
                     signature: openpgp.signature.readArmored(signed.data) }
                 ).then(output => expect(output.signatures[0].valid).to.be.true)
@@ -243,7 +246,7 @@ describe('Brainpool Cryptography', function () {
             }),
             // Encrypting and signing
             openpgp.encrypt(
-              { data: 'Hi, Hi wrote this but only Bye can read it!',
+              { data: testdata2,
                 publicKeys: [pubBye],
                 privateKeys: [hi] }
             ).then(encrypted => {
@@ -254,7 +257,7 @@ describe('Brainpool Cryptography', function () {
                   privateKeys: bye,
                   publicKeys: [pubHi] }
               ).then(output => {
-                expect(output.data).to.equal('Hi, Hi wrote this but only Bye can read it!');
+                expect(output.data).to.equal(testdata2);
                 expect(output.signatures[0].valid).to.be.true;
               });
             })

--- a/test/general/ecc_nist.js
+++ b/test/general/ecc_nist.js
@@ -239,8 +239,8 @@ describe('Elliptic Curve Cryptography', function () {
   function omnibus() {
     it('Omnibus NIST P-256 Test', function () {
       const options = { userIds: {name: "Hi", email: "hi@hel.lo"}, curve: "p256" };
-      const testdata = input.createSomeMessage();
-      const testdata2 = input.createSomeMessage();
+      const testData = input.createSomeMessage();
+      const testData2 = input.createSomeMessage();
       return openpgp.generateKey(options).then(function (firstKey) {
         const hi = firstKey.key;
         const pubHi = hi.toPublic();
@@ -254,7 +254,7 @@ describe('Elliptic Curve Cryptography', function () {
             // Signing message
 
             openpgp.sign(
-              { data: testdata, privateKeys: hi }
+              { data: testData, privateKeys: hi }
             ).then(signed => {
               const msg = openpgp.cleartext.readArmored(signed.data);
               // Verifying signed message
@@ -264,7 +264,7 @@ describe('Elliptic Curve Cryptography', function () {
                 ).then(output => expect(output.signatures[0].valid).to.be.true),
                 // Verifying detached signature
                 openpgp.verify(
-                  { message: openpgp.message.fromText(testdata),
+                  { message: openpgp.message.fromText(testData),
                     publicKeys: pubHi,
                     signature: openpgp.signature.readArmored(signed.data) }
                 ).then(output => expect(output.signatures[0].valid).to.be.true)
@@ -272,7 +272,7 @@ describe('Elliptic Curve Cryptography', function () {
             }),
             // Encrypting and signing
             openpgp.encrypt(
-              { data: testdata2,
+              { data: testData2,
                 publicKeys: [pubBye],
                 privateKeys: [hi] }
             ).then(encrypted => {
@@ -283,7 +283,7 @@ describe('Elliptic Curve Cryptography', function () {
                   privateKeys: bye,
                   publicKeys: [pubHi] }
               ).then(output => {
-                expect(output.data).to.equal(testdata2);
+                expect(output.data).to.equal(testData2);
                 expect(output.signatures[0].valid).to.be.true;
               });
             })

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -4,6 +4,7 @@ const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp
 
 const spy = require('sinon/lib/sinon/spy');
 const stub = require('sinon/lib/sinon/stub');
+const input = require('./testInputs.js');
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
@@ -286,7 +287,7 @@ DECl1Qu4QyeXin29uEXWiekMpNlZVsEuc8icCw6ABhIZ
 -----END PGP PRIVATE KEY BLOCK-----`;
 
 const passphrase = 'hello world';
-const plaintext = 'short message\nnext line\n한국어/조선말';
+const plaintext = input.createSomeMessage() + '\n한국어/조선말';
 const password1 = 'I am a password';
 const password2 = 'I am another password';
 const password3 = 'I am a third password';
@@ -1991,7 +1992,7 @@ describe('OpenPGP.js public api tests', function() {
             passwords: password2
           };
           return openpgp.decrypt(decOpt).then(function (decrypted) {
-            expect(decrypted.data).to.equal(plaintext);
+            expect(decrypted.data).to.equal('short message\nnext line\n한국어/조선말');
             expect(decrypted.signatures.length).to.equal(0);
           });
         });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -59,10 +59,10 @@ describe("Packet", function() {
 
   it('Symmetrically encrypted packet', async function() {
     const message = new openpgp.packet.List();
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
-    literal.setText(testtext);
+    literal.setText(testText);
 
     const enc = new openpgp.packet.SymmetricallyEncrypted();
     message.push(enc);
@@ -83,10 +83,10 @@ describe("Packet", function() {
 
   it('Symmetrically encrypted packet - MDC error for modern cipher', async function() {
     const message = new openpgp.packet.List();
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
-    literal.setText(testtext);
+    literal.setText(testText);
 
     const enc = new openpgp.packet.SymmetricallyEncrypted();
     message.push(enc);
@@ -105,14 +105,14 @@ describe("Packet", function() {
   it('Sym. encrypted integrity protected packet', async function() {
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
     const enc = new openpgp.packet.SymEncryptedIntegrityProtected();
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText(testtext);
+    literal.setText(testText);
     enc.packets.push(literal);
     await enc.encrypt(algo, key);
 
@@ -127,13 +127,13 @@ describe("Packet", function() {
   it('Sym. encrypted AEAD protected packet', function() {
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
     const literal = new openpgp.packet.Literal();
     const enc = new openpgp.packet.SymEncryptedAEADProtected();
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText(testtext);
+    literal.setText(testText);
     enc.packets.push(literal);
 
     const msg2 = new openpgp.packet.List();
@@ -151,7 +151,7 @@ describe("Packet", function() {
     let aead_protect_versionVal = openpgp.config.aead_protect_version;
     openpgp.config.aead_protect = true;
     openpgp.config.aead_protect_version = 4;
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
 
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
@@ -161,7 +161,7 @@ describe("Packet", function() {
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText(testtext);
+    literal.setText(testText);
     enc.packets.push(literal);
 
     const msg2 = new openpgp.packet.List();
@@ -398,7 +398,7 @@ describe("Packet", function() {
   it('Sym. encrypted session key reading/writing', async function() {
     const passphrase = 'hello';
     const algo = 'aes256';
-    const testtext = input.createSomeMessage();
+    const testText = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
     const key_enc = new openpgp.packet.SymEncryptedSessionKey();
@@ -413,7 +413,7 @@ describe("Packet", function() {
 
     const key = key_enc.sessionKey;
 
-    literal.setText(testtext);
+    literal.setText(testText);
     enc.packets.push(literal);
     await enc.encrypt(algo, key);
 
@@ -436,7 +436,7 @@ describe("Packet", function() {
     try {
       const passphrase = 'hello';
       const algo = 'aes256';
-      const testtext = input.createSomeMessage();
+      const testText = input.createSomeMessage();
 
       const literal = new openpgp.packet.Literal();
       const key_enc = new openpgp.packet.SymEncryptedSessionKey();
@@ -451,7 +451,7 @@ describe("Packet", function() {
 
       const key = key_enc.sessionKey;
 
-      literal.setText(testtext);
+      literal.setText(testText);
       enc.packets.push(literal);
       await enc.encrypt(algo, key);
 
@@ -781,7 +781,7 @@ describe("Packet", function() {
         mpi = mpi.map(function(k) {
           return new openpgp.MPI(k);
         });
-        const testtext = input.createSomeMessage();
+        const testText = input.createSomeMessage();
 
         key.params = mpi;
         key.algorithm = "rsa_sign";
@@ -790,7 +790,7 @@ describe("Packet", function() {
         const literal = new openpgp.packet.Literal();
         const signature = new openpgp.packet.Signature();
 
-        literal.setText(testtext);
+        literal.setText(testText);
 
         signature.hashAlgorithm = 'sha256';
         signature.publicKeyAlgorithm = 'rsa_sign';

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
 const { expect } = chai;
+const input = require('./testInputs.js');
 
 function stringify(array) {
   if(!Uint8Array.prototype.isPrototypeOf(array)) {
@@ -58,9 +59,10 @@ describe("Packet", function() {
 
   it('Symmetrically encrypted packet', async function() {
     const message = new openpgp.packet.List();
+    const testtext = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
-    literal.setText('Hello world');
+    literal.setText(testtext);
 
     const enc = new openpgp.packet.SymmetricallyEncrypted();
     message.push(enc);
@@ -81,9 +83,10 @@ describe("Packet", function() {
 
   it('Symmetrically encrypted packet - MDC error for modern cipher', async function() {
     const message = new openpgp.packet.List();
+    const testtext = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
-    literal.setText('Hello world');
+    literal.setText(testtext);
 
     const enc = new openpgp.packet.SymmetricallyEncrypted();
     message.push(enc);
@@ -102,13 +105,14 @@ describe("Packet", function() {
   it('Sym. encrypted integrity protected packet', async function() {
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
+    const testtext = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
     const enc = new openpgp.packet.SymEncryptedIntegrityProtected();
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText('Hello world!');
+    literal.setText(testtext);
     enc.packets.push(literal);
     await enc.encrypt(algo, key);
 
@@ -123,13 +127,13 @@ describe("Packet", function() {
   it('Sym. encrypted AEAD protected packet', function() {
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
-
+    const testtext = input.createSomeMessage();
     const literal = new openpgp.packet.Literal();
     const enc = new openpgp.packet.SymEncryptedAEADProtected();
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText('Hello world!');
+    literal.setText(testtext);
     enc.packets.push(literal);
 
     const msg2 = new openpgp.packet.List();
@@ -147,6 +151,7 @@ describe("Packet", function() {
     let aead_protect_versionVal = openpgp.config.aead_protect_version;
     openpgp.config.aead_protect = true;
     openpgp.config.aead_protect_version = 4;
+    const testtext = input.createSomeMessage();
 
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
@@ -156,7 +161,7 @@ describe("Packet", function() {
     const msg = new openpgp.packet.List();
 
     msg.push(enc);
-    literal.setText('Hello world!');
+    literal.setText(testtext);
     enc.packets.push(literal);
 
     const msg2 = new openpgp.packet.List();
@@ -393,6 +398,7 @@ describe("Packet", function() {
   it('Sym. encrypted session key reading/writing', async function() {
     const passphrase = 'hello';
     const algo = 'aes256';
+    const testtext = input.createSomeMessage();
 
     const literal = new openpgp.packet.Literal();
     const key_enc = new openpgp.packet.SymEncryptedSessionKey();
@@ -407,7 +413,7 @@ describe("Packet", function() {
 
     const key = key_enc.sessionKey;
 
-    literal.setText('Hello world!');
+    literal.setText(testtext);
     enc.packets.push(literal);
     await enc.encrypt(algo, key);
 
@@ -430,6 +436,7 @@ describe("Packet", function() {
     try {
       const passphrase = 'hello';
       const algo = 'aes256';
+      const testtext = input.createSomeMessage();
 
       const literal = new openpgp.packet.Literal();
       const key_enc = new openpgp.packet.SymEncryptedSessionKey();
@@ -444,7 +451,7 @@ describe("Packet", function() {
 
       const key = key_enc.sessionKey;
 
-      literal.setText('Hello world!');
+      literal.setText(testtext);
       enc.packets.push(literal);
       await enc.encrypt(algo, key);
 
@@ -774,6 +781,7 @@ describe("Packet", function() {
         mpi = mpi.map(function(k) {
           return new openpgp.MPI(k);
         });
+        const testtext = input.createSomeMessage();
 
         key.params = mpi;
         key.algorithm = "rsa_sign";
@@ -782,7 +790,7 @@ describe("Packet", function() {
         const literal = new openpgp.packet.Literal();
         const signature = new openpgp.packet.Signature();
 
-        literal.setText('Hello world');
+        literal.setText(testtext);
 
         signature.hashAlgorithm = 'sha256';
         signature.publicKeyAlgorithm = 'rsa_sign';

--- a/test/general/testInputs.js
+++ b/test/general/testInputs.js
@@ -1,0 +1,17 @@
+
+/**
+ * Generates a 50 character long javascript string out of the whole utf-8 range.
+ */
+function createSomeMessage(){
+    const length = 50;
+    let arr = [];
+    for (let i= 0; i < length; i++){
+        arr.push(String.fromCharCode(
+            Math.floor(Math.random() * 10174) + 1));
+    }
+    return arr.join('');
+}
+
+ module.exports = {
+     createSomeMessage: createSomeMessage
+ };

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -6,6 +6,7 @@ const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
 const { expect } = chai;
+const input = require('./testInputs');
 
 describe('X25519 Cryptography', function () {
   const data = {
@@ -169,14 +170,15 @@ describe('X25519 Cryptography', function () {
 
   it('Sign message', async function () {
     const name = 'light';
+    const randomdata = input.createSomeMessage();
     const priv = await load_priv_key(name);
-    const signed = await openpgp.sign({ privateKeys: [priv], data: data[name].message + "\n" });
+    const signed = await openpgp.sign({ privateKeys: [priv], data: randomdata});
     const pub = load_pub_key(name);
     const msg = openpgp.cleartext.readArmored(signed.data);
     const result = await openpgp.verify({ publicKeys: [pub], message: msg});
 
     expect(result).to.exist;
-    expect(result.data.trim()).to.equal(data[name].message);
+    expect(result.data.trim()).to.equal(randomdata);
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });
@@ -197,7 +199,8 @@ describe('X25519 Cryptography', function () {
   it('Encrypt and sign message', async function () {
     const nightPublic = load_pub_key('night');
     const lightPrivate = await load_priv_key('light');
-    const encrypted = await openpgp.encrypt({ publicKeys: [nightPublic], privateKeys: [lightPrivate], data: data.light.message + "\n" });
+    const randomdata = input.createSomeMessage();
+    const encrypted = await openpgp.encrypt({ publicKeys: [nightPublic], privateKeys: [lightPrivate], data: randomdata });
 
     const message = openpgp.message.readArmored(encrypted.data);
     const lightPublic = load_pub_key('light');
@@ -205,7 +208,7 @@ describe('X25519 Cryptography', function () {
     const result = await openpgp.decrypt({ privateKeys: nightPrivate, publicKeys: [lightPublic], message: message });
 
     expect(result).to.exist;
-    expect(result.data.trim()).to.equal(data.light.message);
+    expect(result.data.trim()).to.equal(randomdata);
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -170,15 +170,15 @@ describe('X25519 Cryptography', function () {
 
   it('Sign message', async function () {
     const name = 'light';
-    const randomdata = input.createSomeMessage();
+    const randomData = input.createSomeMessage();
     const priv = await load_priv_key(name);
-    const signed = await openpgp.sign({ privateKeys: [priv], data: randomdata});
+    const signed = await openpgp.sign({ privateKeys: [priv], data: randomData});
     const pub = load_pub_key(name);
     const msg = openpgp.cleartext.readArmored(signed.data);
     const result = await openpgp.verify({ publicKeys: [pub], message: msg});
 
     expect(result).to.exist;
-    expect(result.data.trim()).to.equal(randomdata);
+    expect(result.data.trim()).to.equal(randomData);
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });
@@ -199,8 +199,8 @@ describe('X25519 Cryptography', function () {
   it('Encrypt and sign message', async function () {
     const nightPublic = load_pub_key('night');
     const lightPrivate = await load_priv_key('light');
-    const randomdata = input.createSomeMessage();
-    const encrypted = await openpgp.encrypt({ publicKeys: [nightPublic], privateKeys: [lightPrivate], data: randomdata });
+    const randomData = input.createSomeMessage();
+    const encrypted = await openpgp.encrypt({ publicKeys: [nightPublic], privateKeys: [lightPrivate], data: randomData });
 
     const message = openpgp.message.readArmored(encrypted.data);
     const lightPublic = load_pub_key('light');
@@ -208,7 +208,7 @@ describe('X25519 Cryptography', function () {
     const result = await openpgp.decrypt({ privateKeys: nightPrivate, publicKeys: [lightPublic], message: message });
 
     expect(result).to.exist;
-    expect(result.data.trim()).to.equal(randomdata);
+    expect(result.data.trim()).to.equal(randomData);
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });


### PR DESCRIPTION
I'm working on introducing random data into the tests, in order to ease fuzzy tests.

As a first step, I replaced all 'Hello World' and similar with some pseudorandom utf-8 generation.

The downside is that the string generation itself takes a bit of time, thus many of these tests get slightly worse in performance.
