### PR TITLE
Use public view of elliptic curve repository.

### DIFF
--- a/dist/openpgp.js
+++ b/dist/openpgp.js
@@ -16947,7 +16947,7 @@ module.exports={
   "name": "elliptic",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/indutny/elliptic.git"
+    "url": "https://github.com/indutny/elliptic.git"
   },
   "scripts": {
     "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",


### PR DESCRIPTION
Using ssh to access the elliptic curve repository requires a client
that has ssh access to github, since github doesn't grant anonymous
ssh access.

Using the public view should resolve this problem.