### PR TITLE
Fix reading signersUserId packet in signatures

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -522,7 +522,7 @@ Signature.prototype.read_sub_packet = function (bytes) {
       break;
     case 28:
       // Signer's User ID
-      this.signersUserId += util.Uint8Array_to_str(bytes.subarray(mypos, bytes.length));
+      this.signersUserId = util.Uint8Array_to_str(bytes.subarray(mypos, bytes.length));
       break;
     case 29:
       // Reason for Revocation

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -708,6 +708,25 @@ describe("Packet", function() {
     });
   });
 
+  it('Reading signersUserId from armored signature', async function() {
+    const armored_sig =
+`-----BEGIN PGP SIGNATURE-----
+
+iQFKBAEBCgA0FiEEdOyNPagqedqiXfEMa6Ve2Dq64bsFAlszXwQWHHRlc3Qtd2tk
+QG1ldGFjb2RlLmJpegAKCRBrpV7YOrrhuw1PB/9KhFRR/M3OR6NmIent6ri1ekWn
+vlcnVqj6N4Xqi1ahRVw19/Jx36mGyijxNwqqGrziqRiPCdT0pKfCfv7nXQf2Up1Z
+LoR1StqpBMSDQfuF6JAJmJuB9T+mPQO8wYeUp+O63vQnm5CgqyoRlIoqX8MN6GTY
+xK5PdTRjw6IEIGr9uLgSoUwTd0ECY1F9ptyuLGD5ET5ZtyUenQSbX+cw5WCGLFzi
+7TwKTY+kGQpkwDJKZJSGpoP7ob6xdDfZx6dHV6IfIJg8/F9gtAXFp8uE51L90cV2
+kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
+=wEIR
+-----END PGP SIGNATURE-----`;
+
+    const signature = openpgp.signature.readArmored(armored_sig);
+
+    expect(signature.packets[0].signersUserId).to.equal('test-wkd@metacode.biz');
+  });
+
   it('Writing and encryption of a secret key packet.', function() {
     const key = new openpgp.packet.List();
     key.push(new openpgp.packet.SecretKey());


### PR DESCRIPTION
This bug caused all signersUserIds strings to be prefixed with `"null"`
string. Changed to use only the last value for this packet type.

Previous implementation probably assumed that there will be more than one
signersUserId packet but I haven't been able to generate such signature
using gpg (only last user id was embedded). Moreover signature
serialization function `write_all_sub_packets` writes only one value of
this packet as a UTF-8 string.