### PR TITLE
Fix verification of User Attributes

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -594,14 +594,14 @@ Signature.prototype.toSign = function (type, data) {
       let packet;
       let tag;
 
-      if (data.userid !== undefined) {
+      if (data.userId) {
         tag = 0xB4;
-        packet = data.userid;
-      } else if (data.userattribute !== undefined) {
+        packet = data.userId;
+      } else if (data.userAttribute) {
         tag = 0xD1;
-        packet = data.userattribute;
+        packet = data.userAttribute;
       } else {
-        throw new Error('Either a userid or userattribute packet needs to be ' +
+        throw new Error('Either a userId or userAttribute packet needs to be ' +
           'supplied for certification.');
       }
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -662,7 +662,7 @@ describe("Packet", function() {
     return Promise.all([
       expect(key[2].verify(key[0],
         {
-            userid: key[1],
+            userId: key[1],
             key: key[0]
         })).to.eventually.be.true,
       expect(key[4].verify(key[0],

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -876,7 +876,7 @@ yYDnCgA=
 
   it('Verify V3 certification signature', function(done) {
     const pubKey = openpgp.key.readArmored(pub_v3).keys[0];
-    expect(pubKey.users[0].selfCertifications[0].verify(pubKey.primaryKey, {key: pubKey.primaryKey, userid: pubKey.users[0].userId})).to.eventually.be.true.notify(done);
+    expect(pubKey.users[0].selfCertifications[0].verify(pubKey.primaryKey, {key: pubKey.primaryKey, userId: pubKey.users[0].userId})).to.eventually.be.true.notify(done);
   });
 
   it('Write unhashed subpackets', function() {
@@ -1013,6 +1013,37 @@ yYDnCgA=
       expect(signatures[1].valid).to.be.true;
       expect(signatures[1].keyid.toHex()).to.equal(signerKey.getKeyId().toHex());
     });
+  });
+
+  it('Verify signed UserIDs and User Attributes', async function() {
+    const armoredKeyWithPhoto = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EW1CJGAEEAM+BzuFzcYk9HttmDbjGexQ8dfme074Q5PuHas3PBISPm0AwmnDM
+tzjlcrrg2VGuLqHvNF600w2ZgOo2gElNYCOas1q/fVFuIgJ4SUduNOEe/JnIW4uP
+iEGU9l6zOVVgTc/nGVpZdvHgvOL8nl9BKHtWEnMD3Du7UYAm+Avshu9jABEBAAG0
+AViI1AQTAQoAPhYhBKcH118Rrg0wLBrTk5IyMikCym+4BQJbUIkYAhsDBQkDwmcA
+BQsJCAcDBRUKCQgLBRYDAgEAAh4BAheAAAoJEJIyMikCym+4K8oEAJc7YFiNau6V
+HTVK4cTvWU5MuYiejejFZai4ELUJy+WF6cZYrLuF/z/kRt8B7hpumXChPCUlT0q7
+FWypQtA3leu83DGMXqhfS80h2S1+VLmDVVWKQXOwgOb44jT9F08bDU5QK08SkjF8
+/EirIy8ANzdwCA4rHytIS2yx6tLlthvX0cBwwG4BEAABAQAAAAAAAAAAAAAAAP/Y
+/+AAEEpGSUYAAQEAAAEAAQAA/9sAQwABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
+AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB/9sAQwEBAQEB
+AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
+AQEBAQEBAQEBAQEB/8AAEQgAAQABAwEiAAIRAQMRAf/EABUAAQEAAAAAAAAAAAAA
+AAAAAAAK/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/EABQBAQAAAAAAAAAAAAAAAAAA
+AAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwC/gAH/2YjUBBMB
+CgA+FiEEpwfXXxGuDTAsGtOTkjIyKQLKb7gFAltQimUCGwMFCQPCZwAFCwkIBwMF
+FQoJCAsFFgMCAQACHgECF4AACgkQkjIyKQLKb7gm/wQAiyZF89qr8hf3XQNJ6Ir/
+QtaniPcesjrYCIE47ZfeDYpBTPeiMm295o2dZXVJS4ItllYsplASw5DJiIMnQKlJ
+mbXakYFzzclTa/JrKzFYCy/DPT95xK+633omgrIUgJodizoKJE7XeB2U6aRUJJ4O
+iTuGu4fEU1UligAXSrZmCdE=
+=VK6I
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+    const key = openpgp.key.readArmored(armoredKeyWithPhoto).keys[0];
+    for (const user of key.users) {
+      expect(await user.verify(key.primaryKey)).to.equal(openpgp.enums.keyStatus.valid);
+    }
   });
 
 });

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -240,7 +240,7 @@ describe('X25519 Cryptography', function () {
         // Self Certificate is valid
         const user = hi.users[0];
         await expect(user.selfCertifications[0].verify(
-          primaryKey, { userid: user.userId, key: primaryKey }
+          primaryKey, { userId: user.userId, key: primaryKey }
         )).to.eventually.be.true;
         await expect(user.verifyCertificate(
           primaryKey, user.selfCertifications[0], [hi.toPublic()]
@@ -260,7 +260,7 @@ describe('X25519 Cryptography', function () {
           // Self Certificate is valid
           const user = bye.users[0];
           await expect(user.selfCertifications[0].verify(
-            bye.primaryKey, { userid: user.userId, key: bye.primaryKey }
+            bye.primaryKey, { userId: user.userId, key: bye.primaryKey }
           )).to.eventually.be.true;
           await expect(user.verifyCertificate(
             bye.primaryKey, user.selfCertifications[0], [bye.toPublic()]
@@ -270,7 +270,7 @@ describe('X25519 Cryptography', function () {
             // Hi trusts Bye!
             bye.toPublic().signPrimaryUser([hi]).then(trustedBye => {
               expect(trustedBye.users[0].otherCertifications[0].verify(
-                primaryKey, { userid: user.userId, key: bye.toPublic().primaryKey }
+                primaryKey, { userId: user.userId, key: bye.toPublic().primaryKey }
               )).to.eventually.be.true;
             }),
             // Signing message
@@ -539,7 +539,7 @@ describe('X25519 Cryptography', function () {
     expect(results.user).to.exist;
     const user = results.user;
     expect(user.selfCertifications[0].verify(
-      hi.primaryKey, {userid: user.userId, key: hi.primaryKey}
+      hi.primaryKey, {userId: user.userId, key: hi.primaryKey}
     )).to.eventually.be.true;
     expect(user.verifyCertificate(
       hi.primaryKey, user.selfCertifications[0], [hi]


### PR DESCRIPTION
This change corrects verification of certifications over User Attributes (such as photos).

Before this change the code did not differentiate between User IDs and User Attributes as both of them are [stored in `data.userid`][0] and incorrectly used the User ID constant (0xB4) for both cases.

This change moves the signature certification tag value to User ID and User Attribute classes and uses that in calculation of data for the signature.

[0]: https://github.com/openpgpjs/openpgpjs/blob/11b2d2de3cf39949e5fdfb2b95d027d8329c41fe/src/key.js#L872