### PR TITLE
Fix multiple workers

### DIFF
--- a/src/worker/async_proxy.js
+++ b/src/worker/async_proxy.js
@@ -135,7 +135,7 @@ AsyncProxy.prototype.delegate = function(method, options) {
 
   const id = this.getID();
   const requests = this.workers.map(worker => worker.requests);
-  const minRequests = Math.min(requests);
+  const minRequests = Math.min(...requests);
   let workerId = 0;
   for(; workerId < this.workers.length; workerId++) {
     if (this.workers[workerId].requests === minRequests) {


### PR DESCRIPTION
Currently, initialising 2 workers makes the `encrypt`/`decrypt` openpgp functions crash. This fixes a bug that causes the function calls to crash. Also adds a test function so we can identify these crashes.