### PR TITLE
Split Sauce Labs JS unit tests into multiple parts for slow browsers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -226,13 +226,17 @@ module.exports = function(grunt) {
         options: {
           username: 'openpgpjs',
           key: getSauceKey,
-          urls: ['http://localhost:3000/test/unittests.html?saucelabs=true'],
+          urls: [
+            'http://localhost:3000/test/unittests.html?saucelabs=true&grep=' + encodeURIComponent('Sauce Labs Group 1'),
+            'http://localhost:3000/test/unittests.html?saucelabs=true&grep=' + encodeURIComponent('Sauce Labs Group 2'),
+            'http://localhost:3000/test/unittests.html?saucelabs=true&grep=' + encodeURIComponent('^(?!.*Sauce Labs Group [1-2])')
+          ],
           build: process.env.TRAVIS_BUILD_ID,
           testname: 'Sauce Unit Test for openpgpjs',
           browsers: [browser_capabilities],
           public: "public",
           maxRetries: 3,
-          throttled: 2,
+          throttled: 3,
           pollInterval: 10000,
           sauceConfig: {maxDuration: 1800, commandTimeout: 600, idleTimeout: 1000},
           statusCheckAttempts: 200

--- a/test/general/index.js
+++ b/test/general/index.js
@@ -3,8 +3,10 @@ describe('General', function () {
   require('./armor.js');
   require('./packet.js');
   require('./keyring.js');
-  require('./signature.js');
-  require('./key.js');
+  describe('[Sauce Labs Group 1]', function() {
+    require('./signature.js');
+    require('./key.js');
+  });
   require('./openpgp.js');
   require('./hkp.js');
   require('./wkd.js');

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -352,7 +352,7 @@ function withCompression(tests) {
   });
 }
 
-describe('OpenPGP.js public api tests', function() {
+describe('[Sauce Labs Group 2] OpenPGP.js public api tests', function() {
 
   let rsaGenStub;
   let rsaGenValue = openpgp.crypto.publicKey.rsa.generate(openpgp.util.getWebCryptoAll() ? 2048 : 512, "10001");


### PR DESCRIPTION
Sauce Labs has a timeout of 5 minutes (including emulator/browser startup time). Sauce Labs support recommended us to divide the test suite into smaller chunks.