### PR TITLE
Add missing browserify command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -312,6 +312,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['eslint', 'mochaTest']);
   grunt.registerTask('coverage', ['mocha_istanbul:coverage']);
   grunt.registerTask('saucelabs', ['build', 'browserify:unittests', 'copy:browsertest', 'connect:test', 'saucelabs-mocha']);
-  grunt.registerTask('browsertest', ['build', 'copy:browsertest', 'connect:test', 'watch']);
+  grunt.registerTask('browsertest', ['build', 'browserify:unittests', 'copy:browsertest', 'connect:test', 'watch']);
 
 };


### PR DESCRIPTION
If you switch branches from an old version to the latest version and run the browsertest, the old `unittest-bundle.js` is still included. Only when you change something the unittest bundle is rebuild.
This fixes that bug.