### PR TITLE
Return String in openpgp.revokeKey()

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -209,14 +209,14 @@ export function revokeKey({
       const publicKey = key.toPublic();
       return {
         privateKey: key,
-        privateKeyArmored: key.armor(),
+        privateKeyArmored: convertStream(key.armor()),
         publicKey: publicKey,
-        publicKeyArmored: publicKey.armor()
+        publicKeyArmored: convertStream(publicKey.armor())
       };
     }
     return {
       publicKey: key,
-      publicKeyArmored: key.armor()
+      publicKeyArmored: convertStream(key.armor())
     };
   }).catch(onError.bind(null, 'Error revoking key'));
 }


### PR DESCRIPTION
The `revokeKey()` should return String, but not the readableStream.

I found that there is a function called `convertStreams()`, but I have no idea why it throws

> `Error revoking key: This stream has already been locked for exclusive reading by another reader at new e`

That's why I used `convertStream()` directly.