### PR TITLE
Remove bzip2 compression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,12 +192,6 @@ module.exports = function(grunt) {
         src: ['mocha/mocha.css', 'mocha/mocha.js'],
         dest: 'test/lib/'
       },
-      bzip2: {
-        expand: true,
-        cwd: 'node_modules/compressjs/bin/',
-        src: ['bzip2.build.js'],
-        dest: 'src/compression/'
-      },
       openpgp_compat: {
         expand: true,
         cwd: 'dist/',
@@ -305,7 +299,7 @@ module.exports = function(grunt) {
   // Build tasks
   grunt.registerTask('version', ['replace:openpgp']);
   grunt.registerTask('replace_min', ['replace:openpgp_min', 'replace:worker_min']);
-  grunt.registerTask('build', ['copy:bzip2', 'browserify:openpgp', 'browserify:worker', 'version', 'uglify', 'replace_min']);
+  grunt.registerTask('build', ['browserify:openpgp', 'browserify:worker', 'version', 'uglify', 'replace_min']);
   grunt.registerTask('documentation', ['jsdoc']);
   grunt.registerTask('default', ['build']);
   // Test/Dev tasks

--- a/README.md
+++ b/README.md
@@ -259,13 +259,12 @@ ciphertext = await openpgp.encrypt(options);     // use ciphertext
 Or, override the config to enable compression:
 
 ```js
-openpgp.config.compression = openpgp.enums.compression.zip
+openpgp.config.compression = openpgp.enums.compression.zlib
 ```
 
 Where the value can be any of:
  * `openpgp.enums.compression.zip`
  * `openpgp.enums.compression.zlib`
- * `openpgp.enums.compression.bzip2`
 
 
 #### Streaming encrypt *Uint8Array* data with a password

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -169,7 +169,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -1828,24 +1829,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
       "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
-    },
-    "compressjs": {
-      "version": "github:openpgpjs/compressjs#ce5ccbede61f075926081e29573c8a79ddf10d88",
-      "from": "github:openpgpjs/compressjs",
-      "requires": {
-        "amdefine": "~1.0.0",
-        "commander": "~2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        }
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6547,6 +6530,23 @@
         "https-proxy-agent": "^1.0.0"
       }
     },
+    "seek-bzip": {
+      "version": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
+      "from": "github:openpgpjs/seek-bzip",
+      "requires": {
+        "commander": "~2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -7417,7 +7417,7 @@
       }
     },
     "web-stream-tools": {
-      "version": "github:openpgpjs/web-stream-tools#37c3542b11455856012b5ad87c39088457e2b3a1",
+      "version": "github:openpgpjs/web-stream-tools#9ab800d46add161db496506d67338202ad0114ce",
       "from": "github:openpgpjs/web-stream-tools"
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     "asn1.js": "^5.0.0",
     "bn.js": "^4.11.8",
     "buffer": "^5.0.8",
-    "compressjs": "github:openpgpjs/compressjs",
     "elliptic": "github:openpgpjs/elliptic",
     "hash.js": "^1.1.3",
     "node-fetch": "^2.1.2",
     "node-localstorage": "~1.3.0",
     "pako": "^1.0.6",
+    "seek-bzip": "github:openpgpjs/seek-bzip",
     "web-stream-tools": "github:openpgpjs/web-stream-tools"
   },
   "repository": {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -309,6 +309,9 @@ function withCompression(tests) {
 
   compressionTypes.forEach(function (compression) {
     const compressionName = openpgp.enums.read(openpgp.enums.compression, compression);
+    if (compressionName === 'bzip2') {
+      return; // bzip2 compression is not supported.
+    }
     const group = `compression - ${compressionName}`;
 
     describe(group, function() {


### PR DESCRIPTION
Fix #791.

- Removes bzip2 compression support
- For bzip2 decompression, switch from compressjs to seek-bzip