### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,30 @@ matrix:
       env: OPENPGP_NODE_JS='8' OPENPGPJSTEST='unit'
     - node_js: "10"
       env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
-    - node_js: "9"
+    - node_js: "node"
+      env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
+    - node_js: "10"
       env: BROWSER='Firefox' VERSION='61' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Chrome' VERSION='49' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs' COMPAT=1
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Chrome' VERSION='68' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Internet Explorer' VERSION='11.103' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs' COMPAT=1
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='MicrosoftEdge' VERSION='17.17134' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs'
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Safari' VERSION='10' PLATFORM='macOS 10.12' OPENPGPJSTEST='saucelabs' COMPAT=1
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Safari' VERSION='11' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='Android' VERSION='6.0' OPENPGPJSTEST='saucelabs'
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='iPad' VERSION='10.0' OPENPGPJSTEST='saucelabs' COMPAT=1
-    - node_js: "9"
+    - node_js: "10"
       env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
   allow_failures:
-    - node_js: "9"
+    - node_js: "10"
 
 before_script:
   - npm install -g grunt-cli codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
       env: BROWSER='iPad' VERSION='10.0' OPENPGPJSTEST='saucelabs' COMPAT=1
     - node_js: "10"
       env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
-  allow_failures:
-    - node_js: "10"
 
 before_script:
   - npm install -g grunt-cli codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - node_js: "10"
       env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
     - node_js: "node"
-      env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
+      env: OPENPGP_NODE_JS='11' OPENPGPJSTEST='unit'
     - node_js: "10"
       env: BROWSER='Firefox' VERSION='61' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
     - node_js: "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,16 @@ matrix:
     - node_js: "10"
       env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
   allow_failures:
-    - env: OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='Firefox' VERSION='61' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='Chrome' VERSION='49' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - env: BROWSER='Chrome' VERSION='68' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='Internet Explorer' VERSION='11.103' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - env: BROWSER='MicrosoftEdge' VERSION='17.17134' PLATFORM='Windows 10' OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='Safari' VERSION='10' PLATFORM='macOS 10.12' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - env: BROWSER='Safari' VERSION='11' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='Android' VERSION='6.0' OPENPGPJSTEST='saucelabs'
+    - env: BROWSER='iPad' VERSION='10.0' OPENPGPJSTEST='saucelabs' COMPAT=1
+    - env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
 before_script:
   - npm install -g grunt-cli codeclimate-test-reporter
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - node_js: "10"
       env: OPENPGP_NODE_JS='10' OPENPGPJSTEST='unit'
     - node_js: "node"
-      env: OPENPGP_NODE_JS='11' OPENPGPJSTEST='unit'
+      env: OPENPGP_NODE_JS='latest' OPENPGPJSTEST='unit'
     - node_js: "10"
       env: BROWSER='Firefox' VERSION='61' PLATFORM='macOS 10.13' OPENPGPJSTEST='saucelabs'
     - node_js: "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 addons:
     code_climate:
         repo_token: $CODECLIMATE_REPO_TOKEN
+env: # empty env by default
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ matrix:
       env: BROWSER='iPad' VERSION='10.0' OPENPGPJSTEST='saucelabs' COMPAT=1
     - node_js: "10"
       env: BROWSER='iPad' VERSION='11.0' OPENPGPJSTEST='saucelabs'
-
+  allow_failures:
+    - env: OPENPGPJSTEST='saucelabs'
 before_script:
   - npm install -g grunt-cli codeclimate-test-reporter
 script:


### PR DESCRIPTION
Node.js 9 and other odd release numbers already reached their EOL and are short living.

https://github.com/nodejs/Release/blob/master/README.md

Only test 8, 10 and current stable (11).