### PR TITLE
Support 3des as a valid algorithmname in a session key

### DIFF
--- a/src/enums.js
+++ b/src/enums.js
@@ -126,6 +126,7 @@ export default {
     plaintext: 0,
     /** Not implemented! */
     idea: 1,
+    '3des': 2,
     tripledes: 2,
     cast5: 3,
     blowfish: 4,


### PR DESCRIPTION
This adds 3des as an alias for tripledes. enums.read still outputs tripledes.