### PR TITLE
Fix revocation example in README, use `revocationCertificate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,17 +379,17 @@ var options = {
 openpgp.generateKey(options).then(function(key) {
     var privkey = key.privateKeyArmored; // '-----BEGIN PGP PRIVATE KEY BLOCK ... '
     var pubkey = key.publicKeyArmored;   // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
-    var revocationSignature = key.revocationSignature; // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
+    var revocationCertificate = key.revocationCertificate; // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 });
 ```
 
 #### Revoke a key
 
-Using a revocation signature:
+Using a revocation certificate:
 ```js
 var options = {
     key: openpgp.key.readArmored(pubkey).keys[0],
-    revocationSignature: revocationSignature
+    revocationCertificate: revocationCertificate
 };
 ```
 


### PR DESCRIPTION
There is no longer any `revocationSignature` member of OpenPGP.js `key`
objects, and the `options` object passed to the `revokeKey()` method no
longer accepts a `revocationSignature` member, either. These have been
changed to `revocationCertificate`, so this commit updates the examples
that use this part of the API to reflect the current implementation.