### PR TITLE
Web Crypto CFB encryption

### DIFF
--- a/src/crypto/cfb.js
+++ b/src/crypto/cfb.js
@@ -36,45 +36,6 @@ const nodeCrypto = util.getNodeCrypto();
 const Buffer = util.getNodeBuffer();
 
 export default {
-
-  /**
-   * Decrypts the prefixed data for the Modification Detection Code (MDC) computation
-   * @param {String} cipherfn.encrypt Cipher function to use,
-   *  @see module:crypto/cipher.
-   * @param {Uint8Array} key Uint8Array representation of key to be used to check the mdc
-   * This will be passed to the cipherfn
-   * @param {Uint8Array} ciphertext The encrypted data
-   * @returns {Uint8Array} plaintext Data of D(ciphertext) with blocksize length +2
-   */
-  mdc: function(cipherfn, key, ciphertext) {
-    cipherfn = new cipher[cipherfn](key);
-    const block_size = cipherfn.blockSize;
-
-    let iblock = new Uint8Array(block_size);
-    let ablock = new Uint8Array(block_size);
-    let i;
-
-
-    // initialisation vector
-    for (i = 0; i < block_size; i++) {
-      iblock[i] = 0;
-    }
-
-    iblock = cipherfn.encrypt(iblock);
-    for (i = 0; i < block_size; i++) {
-      ablock[i] = ciphertext[i];
-      iblock[i] ^= ablock[i];
-    }
-
-    ablock = cipherfn.encrypt(ablock);
-
-    const result = new Uint8Array(iblock.length + 2);
-    result.set(iblock);
-    result[iblock.length] = ablock[0] ^ ciphertext[block_size];
-    result[iblock.length + 1] = ablock[1] ^ ciphertext[block_size + 1];
-    return result;
-  },
-
   encrypt: function(algo, key, plaintext, iv) {
     if (algo.substr(0, 3) === 'aes') {
       return aesEncrypt(algo, key, plaintext, iv);

--- a/src/crypto/cfb.js
+++ b/src/crypto/cfb.js
@@ -18,113 +18,24 @@
  */
 
 /**
+ * @requires web-stream-tools
  * @requires crypto/cipher
+ * @requires util
  * @module crypto/cfb
  */
 
+import { AES_CFB } from 'asmcrypto.js/dist_es5/aes/cfb';
+
+import stream from 'web-stream-tools';
 import cipher from './cipher';
+import config from '../config';
+import util from '../util';
+
+const webCrypto = util.getWebCrypto();
+const nodeCrypto = util.getNodeCrypto();
+const Buffer = util.getNodeBuffer();
 
 export default {
-
-  /**
-   * This function encrypts a given plaintext with the specified prefixrandom
-   * using the specified blockcipher
-   * @param {Uint8Array} prefixrandom random bytes of block_size length
-   *  to be used in prefixing the data
-   * @param {String} cipherfn the algorithm cipher class to encrypt
-   *  data in one block_size encryption, {@link module:crypto/cipher}.
-   * @param {Uint8Array} plaintext data to be encrypted
-   * @param {Uint8Array} key key to be used to encrypt the plaintext.
-   * This will be passed to the cipherfn
-   * @param {Boolean} resync a boolean value specifying if a resync of the
-   *  IV should be used or not. The encrypteddatapacket uses the
-   *  "old" style with a resync. Encryption within an
-   *  encryptedintegrityprotecteddata packet is not resyncing the IV.
-   * @returns {Uint8Array} encrypted data
-   */
-  encrypt: function(prefixrandom, cipherfn, plaintext, key, resync) {
-    cipherfn = new cipher[cipherfn](key);
-    const block_size = cipherfn.blockSize;
-
-    const FR = new Uint8Array(block_size);
-    let FRE = new Uint8Array(block_size);
-
-    const new_prefix = new Uint8Array(prefixrandom.length + 2);
-    new_prefix.set(prefixrandom);
-    new_prefix[prefixrandom.length] = prefixrandom[block_size-2];
-    new_prefix[prefixrandom.length+1] = prefixrandom[block_size-1];
-    prefixrandom = new_prefix;
-
-    let ciphertext = new Uint8Array(plaintext.length + 2 + block_size * 2);
-    let i;
-    let n;
-    let begin;
-    const offset = resync ? 0 : 2;
-
-    // 1.  The feedback register (FR) is set to the IV, which is all zeros.
-    for (i = 0; i < block_size; i++) {
-      FR[i] = 0;
-    }
-
-    // 2.  FR is encrypted to produce FRE (FR Encrypted).  This is the
-    //     encryption of an all-zero value.
-    FRE = cipherfn.encrypt(FR);
-    // 3.  FRE is xored with the first BS octets of random data prefixed to
-    //     the plaintext to produce C[1] through C[BS], the first BS octets
-    //     of ciphertext.
-    for (i = 0; i < block_size; i++) {
-      ciphertext[i] = FRE[i] ^ prefixrandom[i];
-    }
-
-    // 4.  FR is loaded with C[1] through C[BS].
-    FR.set(ciphertext.subarray(0, block_size));
-
-    // 5.  FR is encrypted to produce FRE, the encryption of the first BS
-    //     octets of ciphertext.
-    FRE = cipherfn.encrypt(FR);
-
-    // 6.  The left two octets of FRE get xored with the next two octets of
-    //     data that were prefixed to the plaintext.  This produces C[BS+1]
-    //     and C[BS+2], the next two octets of ciphertext.
-    ciphertext[block_size] = FRE[0] ^ prefixrandom[block_size];
-    ciphertext[block_size + 1] = FRE[1] ^ prefixrandom[block_size + 1];
-
-    if (resync) {
-      // 7.  (The resync step) FR is loaded with C[3] through C[BS+2].
-      FR.set(ciphertext.subarray(2, block_size + 2));
-    } else {
-      FR.set(ciphertext.subarray(0, block_size));
-    }
-    // 8.  FR is encrypted to produce FRE.
-    FRE = cipherfn.encrypt(FR);
-
-    // 9.  FRE is xored with the first BS octets of the given plaintext, now
-    //     that we have finished encrypting the BS+2 octets of prefixed
-    //     data.  This produces C[BS+3] through C[BS+(BS+2)], the next BS
-    //     octets of ciphertext.
-    for (i = 0; i < block_size; i++) {
-      ciphertext[block_size + 2 + i] = FRE[i + offset] ^ plaintext[i];
-    }
-    for (n = block_size; n < plaintext.length + offset; n += block_size) {
-      // 10. FR is loaded with C[BS+3] to C[BS + (BS+2)] (which is C11-C18 for
-      // an 8-octet block).
-      begin = n + 2 - offset;
-      FR.set(ciphertext.subarray(begin, begin + block_size));
-
-      // 11. FR is encrypted to produce FRE.
-      FRE = cipherfn.encrypt(FR);
-
-      // 12. FRE is xored with the next BS octets of plaintext, to produce
-      // the next BS octets of ciphertext.  These are loaded into FR, and
-      // the process is repeated until the plaintext is used up.
-      for (i = 0; i < block_size; i++) {
-        ciphertext[block_size + begin + i] = FRE[i] ^ plaintext[n + i - offset];
-      }
-    }
-
-    ciphertext = ciphertext.subarray(0, plaintext.length + 2 + block_size);
-    return ciphertext;
-  },
 
   /**
    * Decrypts the prefixed data for the Modification Detection Code (MDC) computation
@@ -164,127 +75,50 @@ export default {
     return result;
   },
 
-  /**
-   * This function decrypts a given ciphertext using the specified blockcipher
-   * @param {String} cipherfn the algorithm cipher class to decrypt
-   *  data in one block_size encryption, {@link module:crypto/cipher}.
-   * @param {Uint8Array} key Uint8Array representation of key to be used to decrypt the ciphertext.
-   * This will be passed to the cipherfn
-   * @param {Uint8Array} ciphertext to be decrypted
-   * @param {Boolean} resync a boolean value specifying if a resync of the
-   *  IV should be used or not. The encrypteddatapacket uses the
-   *  "old" style with a resync. Decryption within an
-   *  encryptedintegrityprotecteddata packet is not resyncing the IV.
-   * @returns {Uint8Array} the plaintext data
-   */
-  decrypt: function(cipherfn, key, ciphertext, resync) {
-    cipherfn = new cipher[cipherfn](key);
-    const block_size = cipherfn.blockSize;
-
-    const iblock = new Uint8Array(block_size);
-    let ablock = new Uint8Array(block_size);
-
-    let i;
-    let j;
-    let n;
-    let text = new Uint8Array(ciphertext.length - block_size);
-
-    /*  RFC4880: Tag 18 and Resync:
-     *  [...] Unlike the Symmetrically Encrypted Data Packet, no
-     *  special CFB resynchronization is done after encrypting this prefix
-     *  data.  See "OpenPGP CFB Mode" below for more details.
-     */
-
-    j = 0;
-    if (resync) {
-      for (i = 0; i < block_size; i++) {
-        iblock[i] = ciphertext[i + 2];
-      }
-      for (n = block_size + 2; n < ciphertext.length; n += block_size) {
-        ablock = cipherfn.encrypt(iblock);
-
-        for (i = 0; i < block_size && i + n < ciphertext.length; i++) {
-          iblock[i] = ciphertext[n + i];
-          if (j < text.length) {
-            text[j] = ablock[i] ^ iblock[i];
-            j++;
-          }
-        }
-      }
-    } else {
-      for (i = 0; i < block_size; i++) {
-        iblock[i] = ciphertext[i];
-      }
-      for (n = block_size; n < ciphertext.length; n += block_size) {
-        ablock = cipherfn.encrypt(iblock);
-        for (i = 0; i < block_size && i + n < ciphertext.length; i++) {
-          iblock[i] = ciphertext[n + i];
-          if (j < text.length) {
-            text[j] = ablock[i] ^ iblock[i];
-            j++;
-          }
-        }
-      }
+  encrypt: function(algo, key, plaintext, iv) {
+    if (algo.substr(0, 3) === 'aes') {
+      return aesEncrypt(algo, key, plaintext, iv);
     }
 
-    n = resync ? 0 : 2;
-
-    text = text.subarray(n, ciphertext.length - block_size - 2 + n);
-
-    return text;
-  },
-
-  normalEncrypt: function(cipherfn, key, plaintext, iv) {
-    cipherfn = new cipher[cipherfn](key);
+    const cipherfn = new cipher[algo](key);
     const block_size = cipherfn.blockSize;
 
     let blocki = new Uint8Array(block_size);
-    const blockc = new Uint8Array(block_size);
+    const blockc = iv;
     let pos = 0;
-    const cyphertext = new Uint8Array(plaintext.length);
+    const ciphertext = new Uint8Array(plaintext.length);
     let i;
     let j = 0;
 
-    if (iv === null) {
-      for (i = 0; i < block_size; i++) {
-        blockc[i] = 0;
-      }
-    } else {
-      for (i = 0; i < block_size; i++) {
-        blockc[i] = iv[i];
-      }
-    }
     while (plaintext.length > block_size * pos) {
       const encblock = cipherfn.encrypt(blockc);
       blocki = plaintext.subarray((pos * block_size), (pos * block_size) + block_size);
       for (i = 0; i < blocki.length; i++) {
         blockc[i] = blocki[i] ^ encblock[i];
-        cyphertext[j++] = blockc[i];
+        ciphertext[j++] = blockc[i];
       }
       pos++;
     }
-    return cyphertext;
+    return ciphertext;
   },
 
-  normalDecrypt: function(cipherfn, key, ciphertext, iv) {
-    cipherfn = new cipher[cipherfn](key);
+  decrypt: async function(algo, key, ciphertext, iv) {
+    if (algo.substr(0, 3) === 'aes') {
+      return aesDecrypt(algo, key, ciphertext, iv);
+    }
+
+    ciphertext = await stream.readToEnd(ciphertext);
+
+    const cipherfn = new cipher[algo](key);
     const block_size = cipherfn.blockSize;
 
-    let blockp;
+    let blockp = iv;
     let pos = 0;
     const plaintext = new Uint8Array(ciphertext.length);
     const offset = 0;
     let i;
     let j = 0;
 
-    if (iv === null) {
-      blockp = new Uint8Array(block_size);
-      for (i = 0; i < block_size; i++) {
-        blockp[i] = 0;
-      }
-    } else {
-      blockp = iv.subarray(0, block_size);
-    }
     while (ciphertext.length > (block_size * pos)) {
       const decblock = cipherfn.encrypt(blockp);
       blockp = ciphertext.subarray((pos * (block_size)) + offset, (pos * (block_size)) + (block_size) + offset);
@@ -297,3 +131,60 @@ export default {
     return plaintext;
   }
 };
+
+function aesEncrypt(algo, key, pt, iv) {
+  if (
+    util.getWebCrypto() &&
+    key.length !== 24 && // Chrome doesn't support 192 bit keys, see https://www.chromium.org/blink/webcrypto#TOC-AES-support
+    !util.isStream(pt) &&
+    pt.length >= 3000 * config.min_bytes_for_web_crypto // Default to a 3MB minimum. Chrome is pretty slow for small messages, see: https://bugs.chromium.org/p/chromium/issues/detail?id=701188#c2
+  ) { // Web Crypto
+    return webEncrypt(algo, key, pt, iv);
+  }
+  if (nodeCrypto) { // Node crypto library.
+    return nodeEncrypt(algo, key, pt, iv);
+  } // asm.js fallback
+  const cfb = new AES_CFB(key);
+  return stream.transform(pt, value => cfb.AES_Encrypt_process(value), () => cfb.AES_Encrypt_finish());
+}
+
+function aesDecrypt(algo, key, ct, iv) {
+  if (nodeCrypto) { // Node crypto library.
+    return nodeDecrypt(algo, key, ct, iv);
+  }
+  if (util.isStream(ct)) {
+    const cfb = new AES_CFB(key);
+    return stream.transform(ct, value => cfb.AES_Decrypt_process(value), () => cfb.AES_Decrypt_finish());
+  }
+  return AES_CFB.decrypt(ct, key, iv);
+}
+
+function xorMut(a, b) {
+  for (let i = 0; i < a.length; i++) {
+    a[i] = a[i] ^ b[i];
+  }
+}
+
+async function webEncrypt(algo, key, pt, iv) {
+  const ALGO = 'AES-CBC';
+  const _key = await webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt']);
+  const { blockSize } = cipher[algo];
+  const cbc_pt = util.concatUint8Array([new Uint8Array(blockSize), pt]);
+  const ct = new Uint8Array(await webCrypto.encrypt({ name: ALGO, iv }, _key, cbc_pt)).subarray(0, pt.length);
+  xorMut(ct, pt);
+  return ct;
+}
+
+function nodeEncrypt(algo, key, pt, iv) {
+  key = new Buffer(key);
+  iv = new Buffer(iv);
+  const cipherObj = new nodeCrypto.createCipheriv('aes-' + algo.substr(3, 3) + '-cfb', key, iv);
+  return stream.transform(pt, value => new Uint8Array(cipherObj.update(new Buffer(value))));
+}
+
+function nodeDecrypt(algo, key, ct, iv) {
+  key = new Buffer(key);
+  iv = new Buffer(iv);
+  const decipherObj = new nodeCrypto.createDecipheriv('aes-' + algo.substr(3, 3) + '-cfb', key, iv);
+  return stream.transform(ct, value => new Uint8Array(decipherObj.update(new Buffer(value))));
+}

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -28,6 +28,7 @@
  * @requires type/mpi
  * @requires type/oid
  * @requires enums
+ * @requires util
  * @module crypto/crypto
  */
 
@@ -39,6 +40,7 @@ import type_kdf_params from '../type/kdf_params';
 import type_mpi from '../type/mpi';
 import type_oid from '../type/oid';
 import enums from '../enums';
+import util from '../util';
 
 function constructParams(types, data) {
   return types.map(function(type, i) {
@@ -291,11 +293,13 @@ export default {
    * Generates a random byte prefix for the specified algorithm
    * See {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC 4880 9.2} for algorithms.
    * @param {module:enums.symmetric} algo Symmetric encryption algorithm
-   * @returns {Uint8Array}                Random bytes with length equal to the block size of the cipher
+   * @returns {Uint8Array}                Random bytes with length equal to the block size of the cipher, plus the last two bytes repeated.
    * @async
    */
-  getPrefixRandom: function(algo) {
-    return random.getRandomBytes(cipher[algo].blockSize);
+  getPrefixRandom: async function(algo) {
+    const prefixrandom = await random.getRandomBytes(cipher[algo].blockSize);
+    const repeat = new Uint8Array([prefixrandom[prefixrandom.length - 2], prefixrandom[prefixrandom.length - 1]]);
+    return util.concat([prefixrandom, repeat]);
   },
 
   /**

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -195,7 +195,7 @@ SecretKey.prototype.encrypt = async function (passphrase) {
     arr = [new Uint8Array([254, enums.write(enums.symmetric, symmetric)])];
     arr.push(s2k.write());
     arr.push(iv);
-    arr.push(crypto.cfb.normalEncrypt(symmetric, key, util.concatUint8Array([
+    arr.push(crypto.cfb.encrypt(symmetric, key, util.concatUint8Array([
       cleartext,
       await crypto.hash.sha1(cleartext)
     ]), iv));
@@ -293,7 +293,7 @@ SecretKey.prototype.decrypt = async function (passphrase) {
       }
     }
   } else {
-    const cleartextWithHash = crypto.cfb.normalDecrypt(symmetric, key, ciphertext, iv);
+    const cleartextWithHash = await crypto.cfb.decrypt(symmetric, key, ciphertext, iv);
 
     let hash;
     let hashlen;

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -145,7 +145,7 @@ SymEncryptedSessionKey.prototype.decrypt = async function(passphrase) {
     const modeInstance = await mode(algo, key);
     this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
   } else if (this.encrypted !== null) {
-    const decrypted = crypto.cfb.normalDecrypt(algo, key, this.encrypted, null);
+    const decrypted = await crypto.cfb.decrypt(algo, key, this.encrypted, new Uint8Array(crypto.cipher[algo].blockSize));
 
     this.sessionKeyAlgorithm = enums.read(enums.symmetric, decrypted[0]);
     this.sessionKey = decrypted.subarray(1, decrypted.length);
@@ -188,7 +188,7 @@ SymEncryptedSessionKey.prototype.encrypt = async function(passphrase) {
   } else {
     const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
     const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
-    this.encrypted = crypto.cfb.normalEncrypt(algo, key, private_key, null);
+    this.encrypted = await crypto.cfb.encrypt(algo, key, private_key, new Uint8Array(crypto.cipher[algo].blockSize));
   }
 
   return true;


### PR DESCRIPTION
Web Crypto doesn't support CFB*, but it does support CBC. Wikipedia [mentions](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Feedback_(CFB)) that CFB mode is "a close relative of CBC". "Operation is very similar; in particular, CFB decryption is almost identical to CBC encryption performed in reverse." Subsequently I've been banging my head against a wall for a while now tring to implement CFB decryption on top of CBC encryption, but since Web Crypto doesn't have an "in reverse" parameter, I'm pretty sure that's impossible. However it turns out CFB encryption is also very similar to CBC encryption, and not in reverse, so we use Web Crypto's CBC mode to implement CFB here.

Chrome in particular is pretty slow at one-off CBC encryptions, on the order of 100ms - see https://bugs.chromium.org/p/chromium/issues/detail?id=701188#c2 for an explanation. So I've set the default cutoff point to use Web Crypto rather high, at 3MB.

As the linked comment mentions, there's a tradeoff here between performance and security - using Web Crypto is more secure against timing attacks and such. So setting `openpgp.config.min_bytes_for_web_crypto = 0` is probably a good idea for security, especially in environments where timing attacks are conceivable.

*Safari 11 actually supports CFB in Web Crypto directly, even though it's not in the spec. It might be worth using that as well, even though it's only supported by one browser.