### PR TITLE
Make ephemeral secret available from ECDH module

### DIFF
--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -105,7 +105,7 @@ async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
  * @param  {module:type/oid}        oid          Elliptic curve object identifier
  * @param  {module:enums.symmetric} cipher_algo  Symmetric cipher to use
  * @param  {module:enums.hash}      hash_algo    Hash algorithm to use
- * @param  {BN}                     V            Public part of ephemeral key
+ * @param  {Uint8Array}             V            Public part of ephemeral key
  * @param  {Uint8Array}             d            Recipient private key
  * @param  {String}                 fingerprint  Recipient fingerprint
  * @returns {Promise<Uint8Array>}                Generated ephemeral secret
@@ -127,7 +127,7 @@ async function genPrivateEphemeralKey(oid, cipher_algo, hash_algo, V, d, fingerp
  * @param  {module:type/oid}        oid          Elliptic curve object identifier
  * @param  {module:enums.symmetric} cipher_algo  Symmetric cipher to use
  * @param  {module:enums.hash}      hash_algo    Hash algorithm to use
- * @param  {BN}                     V            Public part of ephemeral key
+ * @param  {Uint8Array}             V            Public part of ephemeral key
  * @param  {Uint8Array}             C            Encrypted and wrapped value derived from session key
  * @param  {Uint8Array}             d            Recipient private key
  * @param  {String}                 fingerprint  Recipient fingerprint

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -66,7 +66,7 @@ async function kdf(hash_algo, X, length, param) {
  * @param  {module:enums.hash}      hash_algo    Hash algorithm to use
  * @param  {Uint8Array}             Q            Recipient public key
  * @param  {String}                 fingerprint  Recipient fingerprint
- * @returns {Promise<{V: BN, C: Uint8Array}>}    Returns public part of ephemeral key and generated ephemeral secret
+ * @returns {Promise<{V: BN, Z: Uint8Array}>}    Returns public part of ephemeral key and generated ephemeral secret
  * @async
  */
 async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint) {

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -96,7 +96,7 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
   const { V, Z } = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
   return {
-      V: BN(V),
+      V: new BN(V),
       C: aes_kw.wrap(Z, m.toString())
   };
 }
@@ -133,7 +133,7 @@ async function genPrivateEphemeralKey(oid, cipher_algo, hash_algo, V, d, fingerp
  * @param  {Uint8Array}             C            Encrypted and wrapped value derived from session key
  * @param  {Uint8Array}             d            Recipient private key
  * @param  {String}                 fingerprint  Recipient fingerprint
- * @returns {Promise<Uint8Array>}                Value derived from session
+ * @returns {Promise<BN>}                        Value derived from session
  * @async
  */
 async function decrypt(oid, cipher_algo, hash_algo, V, C, d, fingerprint) {

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -96,7 +96,7 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
  * @async
  */
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
-  const key = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
+  const { V, Z } = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
   const C = aes_kw.wrap(key.Z, m.toString());
   return {
     V: key.V,

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -61,12 +61,12 @@ async function kdf(hash_algo, X, length, param) {
 /**
  * Generate ECDHE ephemeral key and secret from public key
  *
- * @param  {module:type/oid}        oid          Elliptic curve object identifier
- * @param  {module:enums.symmetric} cipher_algo  Symmetric cipher to use
- * @param  {module:enums.hash}      hash_algo    Hash algorithm to use
- * @param  {Uint8Array}             Q            Recipient public key
- * @param  {String}                 fingerprint  Recipient fingerprint
- * @returns {Promise<{V: BN, Z: Uint8Array}>}    Returns public part of ephemeral key and generated ephemeral secret
+ * @param  {module:type/oid}        oid                 Elliptic curve object identifier
+ * @param  {module:enums.symmetric} cipher_algo         Symmetric cipher to use
+ * @param  {module:enums.hash}      hash_algo           Hash algorithm to use
+ * @param  {Uint8Array}             Q                   Recipient public key
+ * @param  {String}                 fingerprint         Recipient fingerprint
+ * @returns {Promise<{V: Uint8Array, Z: Uint8Array}>}   Returns public part of ephemeral key and generated ephemeral secret
  * @async
  */
 async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint) {
@@ -76,7 +76,7 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
   const v = await curve.genKeyPair();
   Q = curve.keyFromPublic(Q);
   const S = v.derive(Q);
-  const V = new BN(v.getPublic());
+  const V = new Uint8Array(v.getPublic());
   const Z = await kdf(hash_algo, S, cipher[cipher_algo].keySize, param);
   return { V, Z };
 }
@@ -95,8 +95,10 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
  */
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
   const { V, Z } = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
-  const C = aes_kw.wrap(Z, m.toString());
-  return { V, C };
+  return {
+      V: BN(V),
+      C: aes_kw.wrap(Z, m.toString())
+  };
 }
 
 /**

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -76,10 +76,9 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
   const v = await curve.genKeyPair();
   Q = curve.keyFromPublic(Q);
   const S = v.derive(Q);
-  const Z = await kdf(hash_algo, S, cipher[cipher_algo].keySize, param);
   return {
     V: new BN(v.getPublic()),
-    Z: Z
+    Z: await kdf(hash_algo, S, cipher[cipher_algo].keySize, param)
   };
 }
 
@@ -97,11 +96,8 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
  */
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
   const { V, Z } = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
-  const C = aes_kw.wrap(key.Z, m.toString());
+  const C = aes_kw.wrap(Z, m.toString());
   return { V, C };
-    V: key.V,
-    C: C
-  };
 }
 
 /**

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -76,10 +76,9 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
   const v = await curve.genKeyPair();
   Q = curve.keyFromPublic(Q);
   const S = v.derive(Q);
-  return {
-    V: new BN(v.getPublic()),
-    Z: await kdf(hash_algo, S, cipher[cipher_algo].keySize, param)
-  };
+  const V = new BN(v.getPublic());
+  const Z = await kdf(hash_algo, S, cipher[cipher_algo].keySize, param);
+  return { V, Z };
 }
 
 /**

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -98,7 +98,7 @@ async function genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
   const { V, Z } = await genPublicEphemeralKey(oid, cipher_algo, hash_algo, Q, fingerprint);
   const C = aes_kw.wrap(key.Z, m.toString());
-  return {
+  return { V, C };
     V: key.V,
     C: C
   };


### PR DESCRIPTION
Split the session key encryption and decryption process in two steps, thus allowing an ECDHE exchange through functions genPublicEphemeralKey and genPrivateEphemeralKey.