### PR TITLE
Move non-external dependencies to devDependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -340,6 +340,7 @@ module.exports = {
     "new-cap": [ 0, { "properties": false, "capIsNewExceptionPattern": "^type_.*" }],
     "no-lonely-if": 0,
     "import/extensions": 0,
+    "import/no-extraneous-dependencies": 0,
     "no-buffer-constructor": 0, // deprecated
   }
 };

--- a/package.json
+++ b/package.json
@@ -69,22 +69,23 @@
     "mocha": "^5.0.0",
     "sinon": "^4.3.0",
     "text-encoding-utf-8": "^1.0.2",
-    "whatwg-fetch": "^2.0.3"
-  },
-  "dependencies": {
+    "whatwg-fetch": "^2.0.3",
+
     "@mattiasbuelens/web-streams-polyfill": "^0.3.1",
     "address-rfc2822": "^2.0.3",
     "asmcrypto.js": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
-    "asn1.js": "^5.0.0",
     "bn.js": "^4.11.8",
     "buffer": "^5.0.8",
     "elliptic": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
     "hash.js": "^1.1.3",
-    "node-fetch": "^2.1.2",
-    "node-localstorage": "~1.3.0",
     "pako": "^1.0.6",
     "seek-bzip": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
     "web-stream-tools": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
+  },
+  "dependencies": {
+    "asn1.js": "^5.0.0",
+    "node-fetch": "^2.1.2",
+    "node-localstorage": "~1.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -8,8 +8,6 @@
 
 import util from './util';
 
-/* eslint-disable import/no-extraneous-dependencies */
-
 if (typeof window !== 'undefined') {
   /********************************************************************
    * NOTE: This list is duplicated in Gruntfile.js,                   *


### PR DESCRIPTION
They are not needed to use the dist file.

This should fix #736, fix #764, and fix #877.