### PR TITLE
adds support to reuse primaryKeyPacket when generating new keys

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -643,6 +643,7 @@ Key.prototype.update = async function(key) {
       this.subKeys.push(srcSubKey);
     }
   }));
+  return this;
 };
 
 /**
@@ -1366,6 +1367,14 @@ export async function generate(options) {
   }
 
   async function generateSecretKey(options) {
+    if (options.primaryKeyPacket) {
+      if (options.primaryKeyPacket.tag !== enums.packet.secretKey) {
+        throw new Error(
+          'primaryKeyPacket.tag must be enums.packet.secretKey, was ' + enums.read(enums.packet, options.primaryKeyPacket.tag) + '.'
+        );
+      }
+      return options.primaryKeyPacket;
+    }
     const secretKeyPacket = new packet.SecretKey(options.date);
     secretKeyPacket.packets = null;
     secretKeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -104,6 +104,7 @@ export function destroyWorker() {
 /**
  * Generates a new OpenPGP key pair. Supports RSA and ECC keys. Primary and subkey will be of same type.
  * @param  {Array<Object>} userIds   array of user IDs e.g. [{ name:'Phil Zimmermann', email:'phil@openpgp.org' }]
+ * @param  {String} primaryKeyPacket (optional) An decrypted SecretKey packet to be used as primary key of the new generated key
  * @param  {String} passphrase       (optional) The passphrase used to encrypt the resulting private key
  * @param  {Number} numBits          (optional) number of bits for RSA keys: 2048 or 4096.
  * @param  {Number} keyExpirationTime (optional) The number of seconds after the key creation time that the key expires
@@ -119,9 +120,9 @@ export function destroyWorker() {
  * @static
  */
 
-export function generateKey({ userIds=[], passphrase="", numBits=2048, keyExpirationTime=0, curve="", date=new Date(), subkeys=[{}] }) {
+export function generateKey({ primaryKeyPacket=null, userIds=[], passphrase="", numBits=2048, keyExpirationTime=0, curve="", date=new Date(), subkeys=[{}] }) {
   userIds = toArray(userIds);
-  const options = { userIds, passphrase, numBits, keyExpirationTime, curve, date, subkeys };
+  const options = { primaryKeyPacket, userIds, passphrase, numBits, keyExpirationTime, curve, date, subkeys };
   if (util.getWebCryptoAll() && numBits < 2048) {
     throw new Error('numBits should be 2048 or 4096, found: ' + numBits);
   }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1791,7 +1791,8 @@ function versionSpecificTests() {
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; }
 
     return openpgp.generateKey(opt).then(async function(firstKey) {
-      const secondKey = await openpgp.generateKey({ ...opt, primaryKeyPacket: firstKey.key.primaryKey });
+      Object.assign(opt, { primaryKeyPacket: firstKey.key.primaryKey });
+      const secondKey = await openpgp.generateKey(opt);
       expect(secondKey.key).to.exist;
       expect(
         [secondKey.key.primaryKey.keyid.toHex(), secondKey.key.getFingerprint()]
@@ -1806,7 +1807,8 @@ function versionSpecificTests() {
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; }
 
     return openpgp.generateKey(opt).then(async function(firstKey) {
-      const secondKey = await openpgp.generateKey({ ...opt, primaryKeyPacket: firstKey.key.primaryKey, keyExpirationTime: 3600, subkeys:[{ sign: true }] });
+      Object.assign(opt, { primaryKeyPacket: firstKey.key.primaryKey, keyExpirationTime: 3600, subkeys:[{ sign: true }] });
+      const secondKey = await openpgp.generateKey(opt);
       return firstKey.key.update(secondKey.key).then(mergedKey => {
         expect(mergedKey.subKeys.map(sk => sk.getAlgorithmInfo())).to.deep.eql([
           { algorithm: 'ecdh', curve: 'curve25519' },
@@ -1828,7 +1830,8 @@ function versionSpecificTests() {
 
     return openpgp.generateKey(opt).then(function(firstKey) {
       firstKey.key.primaryKey.clearPrivateParams();
-      return openpgp.generateKey({ ...opt, primaryKeyPacket: firstKey.key.primaryKey });
+      Object.assign(opt, { primaryKeyPacket: firstKey.key.primaryKey });
+      return openpgp.generateKey(opt);
     }).then(
       () => { assert.fail('Expected to fail'); },
       err => { expect(err.message).to.equal('Error generating keypair: Private key is not decrypted.'); }
@@ -1840,7 +1843,8 @@ function versionSpecificTests() {
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; }
 
     return openpgp.generateKey(opt).then(function(firstKey) {
-      return openpgp.generateKey({ ...opt, primaryKeyPacket: firstKey.key.toPublic().primaryKey });
+      Object.assign(opt, { primaryKeyPacket: firstKey.key.toPublic().primaryKey });
+      return openpgp.generateKey(opt);
     }).then(
       () => { assert.fail('Expected to fail'); },
       err => { expect(err.message).to.equal('Error generating keypair: primaryKeyPacket.tag must be enums.packet.secretKey, was publicKey.'); }

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -583,15 +583,18 @@ describe('[Sauce Labs Group 2] OpenPGP.js public api tests', function() {
         subkeys: []
       };
       return openpgp.generateKey(opt).then(function(newKey) {
-        expect(keyGenStub.withArgs({
-          userIds: [{ name: 'Test User', email: 'text@example.com' }],
-          passphrase: 'secret',
-          numBits: 2048,
-          keyExpirationTime: 0,
-          curve: "",
-          date: now,
-          subkeys: []
-        }).calledOnce).to.be.true;
+        expect(keyGenStub.getCalls().map(c => c.args)).to.deep.eql([
+          [{
+            userIds: [{ name: 'Test User', email: 'text@example.com' }],
+            passphrase: 'secret',
+            numBits: 2048,
+            keyExpirationTime: 0,
+            curve: '',
+            date: now,
+            subkeys: [],
+            primaryKeyPacket: null
+          }]
+        ]);
         expect(newKey.key).to.exist;
         expect(newKey.privateKeyArmored).to.exist;
         expect(newKey.publicKeyArmored).to.exist;


### PR DESCRIPTION
I was looking for a way to generate new subkeys for an existing key. In order for me to `update` an existing key, the fingerprint of the newly generated key has to match the one with the new subkeys. The only way to support that, as far as I could tell, was to reuse the primary key of the key to be updated. And this is not currently supported by the library. Here's my implementation.

If there's a exsiting way to generate new subkeys and add them to an existing key that I couldn't find, please tell me.