### PR TITLE
Email parser fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,8 +47,8 @@ module.exports = function(grunt) {
           transform: [
             ["babelify", {
               global: true,
-              // Only babelify web-streams-polyfill, web-stream-tools, asmcrypto, address-rfc2822 and seek-bzip in node_modules
-              only: /^(?:.*\/node_modules\/@mattiasbuelens\/web-streams-polyfill\/|.*\/node_modules\/web-stream-tools\/|.*\/node_modules\/asmcrypto\.js\/|.*\/node_modules\/address-rfc2822\/|.*\/node_modules\/seek-bzip\/|(?!.*\/node_modules\/)).*$/,
+              // Only babelify web-streams-polyfill, web-stream-tools, asmcrypto, email-addresses and seek-bzip in node_modules
+              only: /^(?:.*\/node_modules\/@mattiasbuelens\/web-streams-polyfill\/|.*\/node_modules\/web-stream-tools\/|.*\/node_modules\/asmcrypto\.js\/|.*\/node_modules\/email-addresses\/|.*\/node_modules\/seek-bzip\/|(?!.*\/node_modules\/)).*$/,
               plugins: compat ? [
                 "transform-async-to-generator",
                 "syntax-async-functions",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -104,15 +104,6 @@
         }
       }
     },
-    "address-rfc2822": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/address-rfc2822/-/address-rfc2822-2.0.3.tgz",
-      "integrity": "sha1-LzDSHYEVCGLBSJpHL0lARQIa+IE=",
-      "dev": true,
-      "requires": {
-        "email-addresses": "^3.0.0"
-      }
-    },
     "agent-base": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -2312,9 +2303,8 @@
       }
     },
     "email-addresses": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.1.tgz",
-      "integrity": "sha1-wfwgwYnn+W1AEtN121/qzN0kORw=",
+      "version": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
+      "from": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
       "dev": true
     },
     "encodeurl": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2303,8 +2303,8 @@
       }
     },
     "email-addresses": {
-      "version": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
-      "from": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
+      "version": "github:openpgpjs/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
+      "from": "github:openpgpjs/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118",
       "dev": true
     },
     "encodeurl": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "seek-bzip": "github:openpgpjs/seek-bzip#6187fc025851d35c4e104a25ea15a10b9b8d6f7d",
     "tweetnacl": "github:openpgpjs/tweetnacl-js#1ef755f2b252a3e328ac739848d00e0dad76be2d",
     "web-stream-tools": "github:openpgpjs/web-stream-tools#dc4b05e8a272b45819233f3df735423432beacfc",
-    "email-addresses": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118"
+    "email-addresses": "github:openpgpjs/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118"
   },
   "dependencies": {
     "asn1.js": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "text-encoding-utf-8": "^1.0.2",
     "whatwg-fetch": "^2.0.3",
     "@mattiasbuelens/web-streams-polyfill": "^0.3.1",
-    "address-rfc2822": "^2.0.3",
     "asmcrypto.js": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
     "bn.js": "^4.11.8",
     "buffer": "^5.0.8",
@@ -80,7 +79,8 @@
     "pako": "^1.0.6",
     "seek-bzip": "github:openpgpjs/seek-bzip#6187fc025851d35c4e104a25ea15a10b9b8d6f7d",
     "tweetnacl": "github:openpgpjs/tweetnacl-js#1ef755f2b252a3e328ac739848d00e0dad76be2d",
-    "web-stream-tools": "github:openpgpjs/web-stream-tools#dc4b05e8a272b45819233f3df735423432beacfc"
+    "web-stream-tools": "github:openpgpjs/web-stream-tools#dc4b05e8a272b45819233f3df735423432beacfc",
+    "email-addresses": "github:chesnokovilya/email-addresses#686743c6452b44bafcd06d47db7f36ddf3f3f118"
   },
   "dependencies": {
     "asn1.js": "^5.0.0",

--- a/src/util.js
+++ b/src/util.js
@@ -19,14 +19,14 @@
 
 /**
  * This object contains utility functions
- * @requires address-rfc2822
+ * @requires email-addresses
  * @requires web-stream-tools
  * @requires config
  * @requires encoding/base64
  * @module util
  */
 
-import rfc2822 from 'address-rfc2822';
+import emailAddresses from 'email-addresses';
 import stream from 'web-stream-tools';
 import config from './config';
 import util from './util'; // re-import module to access util functions
@@ -687,8 +687,8 @@ export default {
       throw new Error('User id string is too long');
     }
     try {
-      const [{ phrase: name, address: email, comment }] = rfc2822.parse(userid);
-      return { name, email, comment: comment.replace(/^\(|\)$/g, '') };
+      const { name, address: email, comments } = emailAddresses.parseOneAddress(userid);
+      return { name, email, comment: comments.replace(/^\(|\)$/g, '') };
     } catch(e) {
       throw new Error('Invalid user id format');
     }

--- a/test/general/util.js
+++ b/test/general/util.js
@@ -116,6 +116,22 @@ describe('Util unit tests', function() {
     });
   });
 
+  describe('parseUserID', function() {
+    it('should parse email address', function() {
+      const email = "TestName Test  <test@example.com>";
+      const result = openpgp.util.parseUserId(email);
+      expect(result.name).to.equal('TestName Test');
+      expect(result.email).to.equal('test@example.com');
+    });
+    it('should parse email address with @ in display name and comment', function() {
+      const email = "Test@Name Test (a comment) <test@example.com>";
+      const result = openpgp.util.parseUserId(email);
+      expect(result.name).to.equal('Test@Name Test');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.comment).to.equal('a comment');
+    });
+  });
+
   describe('getTransferables', function() {
     const buf1 = new Uint8Array(1);
     const buf2 = new Uint8Array(1);


### PR DESCRIPTION
Fixes issue https://github.com/openpgpjs/openpgpjs/issues/918
Deprecating email-rfc2822 and using custom build of `email-addresses` package.
Resulted build size should decrease around 10 kb for `openpgp.js` and around 3 kb for `openpgp.min.js`.