### PR TITLE
Fixes brainpool sign/verify bug. Closing issue #854

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2289,8 +2289,8 @@
       "dev": true
     },
     "elliptic": {
-      "version": "github:openpgpjs/elliptic#1beea74833b48bd5698ed079c75fd21f0eb70b1c",
-      "from": "github:openpgpjs/elliptic#1beea74833b48bd5698ed079c75fd21f0eb70b1c",
+      "version": "github:openpgpjs/elliptic#6b7801573b8940a49e7b8253176ece2725841efd",
+      "from": "github:openpgpjs/elliptic#6b7801573b8940a49e7b8253176ece2725841efd",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "asmcrypto.js": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
     "bn.js": "^4.11.8",
     "buffer": "^5.0.8",
-    "elliptic": "github:openpgpjs/elliptic#1beea74833b48bd5698ed079c75fd21f0eb70b1c",
+    "elliptic": "github:openpgpjs/elliptic#6b7801573b8940a49e7b8253176ece2725841efd",
     "hash.js": "^1.1.3",
     "pako": "^1.0.6",
     "seek-bzip": "github:openpgpjs/seek-bzip#6187fc025851d35c4e104a25ea15a10b9b8d6f7d",

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -69,7 +69,23 @@ describe('Brainpool Cryptography', function () {
         'tZa9Z9Eq1OfX2n8kR7BnPnWn9qlhg/63sgNT',
         '=lNCW',
         '-----END PGP MESSAGE-----'
-      ].join('\n')
+      ].join('\n'),
+      message_with_leading_zero_in_hash: 'test message\n277',
+      message_encrypted_with_leading_zero_in_hash:
+`-----BEGIN PGP MESSAGE-----
+Version: OpenPGP.js v4.5.5
+Comment: https://openpgpjs.org
+
+wX4DSpmSuiUYN4MSAgMERlxfWMZgb9Xdu9v5mYq1TP2QZO9lLloIIO45tn/W
+3Eg5DbJfGiBvR7QUXbFY1KiILiXXYxEm1x8i0qw793NlizAdHSiZmifeBJXX
+4sV1NDOaIUXVs6Aes7rhV7G3jADlDVu2N50Ti+MdGHz8rWqYt1zSwBgBo4ag
+i7YemCOYIHqpa+R6lId0+BOXKUFZYCTH8J7QSZYYkH06DFvt1LOPXJHuJrX9
+E++ph0fvdrZVm9kpOFv3fnn/EeDOL4chvemC0dawTLhs0rg+bin9xhGjzpl+
+tbIxp3v4WG6xt9fkNwDSVC7yYMj+LeYcF+ZG1Bw5pCdMoBnJtqKLAJbqP3Ph
+TRELeagBcoQblRDF03XxrjpeCbLqZFwpFQqac9T2eqDRtvi2DA+JYCJdJorO
+KnthADE6hYMCSZVS9Q1IGN3TjROB5rrB/N3xItPsXuc=
+=A7qX
+-----END PGP MESSAGE-----`
     },
     juliet: {
       id: '37e16a986b8af99e',
@@ -194,6 +210,17 @@ describe('Brainpool Cryptography', function () {
 
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message);
+    expect(result.signatures).to.have.length(1);
+    expect(result.signatures[0].valid).to.be.true;
+  });
+  it('Decrypt and verify message with leading zero in hash', async function () {
+    const juliet = await load_priv_key('juliet');
+    const romeo = await load_pub_key('romeo');
+    const msg = await openpgp.message.readArmored(data.romeo.message_encrypted_with_leading_zero_in_hash);
+    const result = await openpgp.decrypt({privateKeys: juliet, publicKeys: [romeo], message: msg});
+
+    expect(result).to.exist;
+    expect(result.data).to.equal(data.romeo.message_with_leading_zero_in_hash);
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -85,7 +85,23 @@ tbIxp3v4WG6xt9fkNwDSVC7yYMj+LeYcF+ZG1Bw5pCdMoBnJtqKLAJbqP3Ph
 TRELeagBcoQblRDF03XxrjpeCbLqZFwpFQqac9T2eqDRtvi2DA+JYCJdJorO
 KnthADE6hYMCSZVS9Q1IGN3TjROB5rrB/N3xItPsXuc=
 =A7qX
------END PGP MESSAGE-----`
+-----END PGP MESSAGE-----`,
+      message_encrypted_with_leading_zero_in_hash_signed_by_elliptic_with_old_implementation:
+`-----BEGIN PGP MESSAGE-----
+Version: OpenPGP.js v4.6.0
+Comment: https://openpgpjs.org
+
+wX4DSpmSuiUYN4MSAgMEdWwp5tYcxcyj3G36EkQ61Xx/gVzYbgh7U54sDsl9
+NKyc9gqjtEn5OQzXJ7Uteb+ojZsRy4b5cWBNQPdXJci0kTC+s98RugN7vEHe
+ulmNfwICTJ7SA4OSb0WEeACG6B1yUZmwWDcPxUfotFL3BCZGxN7SwBgBm2bQ
+wzRBU3SZ8xtqSCwC50PhXXmtqlDmQqJ84oTsyikH8e6zEgI78QXTf1WK530K
+0W/r+OqQufWu5ZKXK9AyeDyLc577P6/CnDcjjoJOsOZm5XMcSXlJWAvsH7KJ
+X/ua3tHArWaOmBYTtbfeZc3NpI5ne/gin3Gsz0llbWKG2KF4Op2/nt+Vhqa9
+tkYrARUF5n9K9+TEasU4z1k898YkS5cIzFyBSGMhGDzdj7t1K93EyOxXPc84
+EJ4QcD/oQ6x1M/8X/iKQCtxZP8RnlrbH7ExkNON5s5g=
+=KDoL
+-----END PGP MESSAGE-----`,
+       message_with_leading_zero_in_hash_old_elliptic_implementation: 'test message\n199',
     },
     juliet: {
       id: '37e16a986b8af99e',
@@ -224,6 +240,18 @@ KnthADE6hYMCSZVS9Q1IGN3TjROB5rrB/N3xItPsXuc=
     expect(result.signatures).to.have.length(1);
     expect(result.signatures[0].valid).to.be.true;
   });
+  it('Decrypt and verify message with leading zero in hash signed with old elliptic algorithm', async function () {
+    const juliet = await load_priv_key('juliet');
+    const romeo = await load_pub_key('romeo');
+    const msg = await openpgp.message.readArmored(data.romeo. message_encrypted_with_leading_zero_in_hash_signed_by_elliptic_with_old_implementation);
+    const result = await openpgp.decrypt({privateKeys: juliet, publicKeys: [romeo], message: msg});
+
+    expect(result).to.exist;
+    expect(result.data).to.equal(data.romeo.message_with_leading_zero_in_hash_old_elliptic_implementation);
+    expect(result.signatures).to.have.length(1);
+    expect(result.signatures[0].valid).to.be.true;
+  });
+
   it('Encrypt and sign message', async function () {
     const romeoPrivate = await load_priv_key('romeo');
     const julietPublic = await load_pub_key('juliet');


### PR DESCRIPTION
Update elliptic to the version with correct signature creation and verification in the case of leading zero in hash.
Closing issue https://github.com/openpgpjs/openpgpjs/issues/854