### PR TITLE
Throw when trying to encrypt a key that's already encrypted

### DIFF
--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -273,6 +273,10 @@ SecretKey.prototype.encrypt = async function (passphrase) {
     return false;
   }
 
+  if (!this.isDecrypted()) {
+    throw new Error('Key packet is already encrypted');
+  }
+
   if (this.isDecrypted() && !passphrase) {
     this.s2k_usage = 0;
     return false;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2840,4 +2840,14 @@ VYGdb3eNlV8CfoEC
       expect(key.users[1].userId).to.be.null;
     });
   });
+
+  it("Should throw when trying to encrypt a key that's already encrypted", async function() {
+    await expect((async function() {
+      let { privateKeyArmored } = await openpgp.generateKey({ userIds: [{ email: 'hello@user.com' }], passphrase: 'pass', numBits: openpgp.util.getWebCryptoAll() ? 2048 : 512 });
+      let { keys: [k] } = await openpgp.key.readArmored(privateKeyArmored);
+      await k.decrypt('pass');
+      await k.encrypt('pass');
+      await k.encrypt('pass');
+    })()).to.be.rejectedWith('Key packet is already encrypted');
+  });
 });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -843,6 +843,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
       key[0].params = mpi;
       key[0].algorithm = "rsa_sign";
+      key[0].isEncrypted = false;
       await key[0].encrypt('hello');
 
       const raw = key.write();
@@ -874,6 +875,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
       key[0].params = mpi;
       key[0].algorithm = "rsa_sign";
+      key[0].isEncrypted = false;
       await key[0].encrypt('hello');
 
       const raw = key.write();


### PR DESCRIPTION
Fix #943. Currently, encrypting a key twice would produce a key that's broken (including after armoring), which is dangerous.

