### PR TITLE
Fix verifying one-pass signatures in the compat build

### DIFF
--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -133,7 +133,7 @@ OnePassSignature.prototype.hash = Signature.prototype.hash;
 OnePassSignature.prototype.toHash = Signature.prototype.toHash;
 OnePassSignature.prototype.toSign = Signature.prototype.toSign;
 OnePassSignature.prototype.calculateTrailer = function(...args) {
-  return stream.fromAsync(async () => (await this.correspondingSig).calculateTrailer(...args));
+  return stream.fromAsync(async () => Signature.prototype.calculateTrailer.apply(await this.correspondingSig, args));
 };
 
 OnePassSignature.prototype.verify = async function() {


### PR DESCRIPTION
This was broken in 735d6d088f96419ae016adf84c50f843f6d2deb3.

See https://github.com/babel/babel/issues/10431.