### PR TITLE
Rename `numBits` and `bits` to `rsaBits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ RSA keys:
 ```js
 var options = {
     userIds: [{ name:'Jon Smith', email:'jon@example.com' }], // multiple user IDs
-    numBits: 4096,                                            // RSA key size
+    rsaBits: 4096,                                            // RSA key size
     passphrase: 'super long and hard to guess secret'         // protects the private key
 };
 ```

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -105,7 +105,7 @@ export function destroyWorker() {
  * Generates a new OpenPGP key pair. Supports RSA and ECC keys. Primary and subkey will be of same type.
  * @param  {Array<Object>} userIds   array of user IDs e.g. [{ name:'Phil Zimmermann', email:'phil@openpgp.org' }]
  * @param  {String} passphrase       (optional) The passphrase used to encrypt the resulting private key
- * @param  {Number} numBits          (optional) number of bits for RSA keys: 2048 or 4096.
+ * @param  {Number} rsaBits          (optional) number of bits for RSA keys: 2048 or 4096.
  * @param  {Number} keyExpirationTime (optional) The number of seconds after the key creation time that the key expires
  * @param  {String} curve            (optional) elliptic curve for ECC keys:
  *                                              curve25519, p256, p384, p521, secp256k1,
@@ -119,11 +119,11 @@ export function destroyWorker() {
  * @static
  */
 
-export function generateKey({ userIds = [], passphrase = "", numBits = 2048, keyExpirationTime = 0, curve = "", date = new Date(), subkeys = [{}] }) {
+export function generateKey({ userIds = [], passphrase = "", numBits = 2048, rsaBits = numBits, keyExpirationTime = 0, curve = "", date = new Date(), subkeys = [{}] }) {
   userIds = toArray(userIds);
-  const options = { userIds, passphrase, numBits, keyExpirationTime, curve, date, subkeys };
-  if (util.getWebCryptoAll() && numBits < 2048) {
-    throw new Error('numBits should be 2048 or 4096, found: ' + numBits);
+  const options = { userIds, passphrase, rsaBits, keyExpirationTime, curve, date, subkeys };
+  if (util.getWebCryptoAll() && rsaBits < 2048) {
+    throw new Error('rsaBits should be 2048 or 4096, found: ' + rsaBits);
   }
 
   if (!util.getWebCryptoAll() && asyncProxy) { // use web worker if web crypto apis are not supported

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -248,13 +248,14 @@ PublicKey.prototype.hasSameFingerprintAs = function(other) {
 
 /**
  * Returns algorithm information
- * @returns {Object} An object of the form {algorithm: String, bits:int, curve:String}
+ * @returns {Object} An object of the form {algorithm: String, rsaBits:int, curve:String}
  */
 PublicKey.prototype.getAlgorithmInfo = function () {
   const result = {};
   result.algorithm = this.algorithm;
   if (this.params[0] instanceof type_mpi) {
-    result.bits = this.params[0].byteLength() * 8;
+    result.rsaBits = this.params[0].byteLength() * 8;
+    result.bits = result.rsaBits; // Deprecated.
   } else {
     result.curve = this.params[0].getName();
   }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1895,6 +1895,7 @@ function versionSpecificTests() {
       expect(key.users[0].userId.userid).to.equal(userId);
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
       expect(key.getAlgorithmInfo().algorithm).to.equal('rsa_encrypt_sign');
+      expect(key.getAlgorithmInfo().bits).to.equal(opt.numBits);
       expect(key.subKeys[0].getAlgorithmInfo().algorithm).to.equal('ecdh');
     });
   });
@@ -2881,6 +2882,7 @@ describe('addSubkey functionality testing', function(){
     const pkN = privateKey.primaryKey.params[0];
     expect(subkeyN.byteLength()).to.be.equal(pkN.byteLength());
     expect(subKey.getAlgorithmInfo().algorithm).to.be.equal('rsa_encrypt_sign');
+    expect(subKey.getAlgorithmInfo().rsaBits).to.be.equal(1024);
     expect(await subKey.verify(newPrivateKey.primaryKey)).to.be.equal(openpgp.enums.keyStatus.valid);
   });
 
@@ -2901,6 +2903,7 @@ describe('addSubkey functionality testing', function(){
     const pkN = privateKey.primaryKey.params[0];
     expect(subkeyN.byteLength()).to.be.equal(pkN.byteLength());
     expect(subKey.getAlgorithmInfo().algorithm).to.be.equal('rsa_encrypt_sign');
+    expect(subKey.getAlgorithmInfo().rsaBits).to.be.equal(1024);
     expect(await subKey.verify(importedPrivateKey.primaryKey)).to.be.equal(openpgp.enums.keyStatus.valid);
   });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -586,7 +586,7 @@ describe('OpenPGP.js public api tests', function() {
         expect(keyGenStub.withArgs({
           userIds: [{ name: 'Test User', email: 'text@example.com' }],
           passphrase: 'secret',
-          numBits: 2048,
+          rsaBits: 2048,
           keyExpirationTime: 0,
           curve: "",
           date: now,

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -10,7 +10,7 @@ const expect = chai.expect;
 async function generateTestData() {
   const victimPrivKey = await key.generate({
     userIds: ['Victim <victim@example.com>'],
-    numBits: openpgp.util.getWebCryptoAll() ? 2048 : 1024,
+    rsaBits: openpgp.util.getWebCryptoAll() ? 2048 : 1024,
     subkeys: [{
       sign: true
     }]
@@ -19,7 +19,7 @@ async function generateTestData() {
 
   const attackerPrivKey = await key.generate({
     userIds: ['Attacker <attacker@example.com>'],
-    numBits: openpgp.util.getWebCryptoAll() ? 2048 : 1024,
+    rsaBits: openpgp.util.getWebCryptoAll() ? 2048 : 1024,
     subkeys: [],
     sign: false
   });


### PR DESCRIPTION
Fix #969.

Keep supporting the old names as well though in `openpgp.generateKey` and `getAlgorithmInfo`, but not in `openpgp.key.generate` (as it is recommended that developers use `openpgp.generateKey` instead, and it now throws when using `numBits` instead of `rsaBits`, so there's no risk of silent key security downgrade).

The old names can now be considered deprecated, and might be removed in v5.