### PR TITLE
Support non-human-readable notation values

### DIFF
--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -819,13 +819,26 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
     const key = (await openpgp.key.readArmored(pubkey)).keys[0];
 
-    const notations = key.users[0].selfCertifications[0].notations;
+    const { notations, rawNotations } = key.users[0].selfCertifications[0];
 
-    expect(notations.length).to.equal(2);
-    expect(notations[0][0]).to.equal('test@example.com');
-    expect(notations[0][1]).to.equal('2');
-    expect(notations[1][0]).to.equal('test@example.com');
-    expect(notations[1][1]).to.equal('3');
+    // Even though there are two notations with the same keys
+    // the `notations` property reads only the single one:
+    // the last one encountered during parse
+    expect(Object.keys(notations).length).to.equal(1);
+    expect(notations['test@example.com']).to.equal('3');
+
+    // On the other hand `rawNotations` property provides access to all
+    // notations, even non human-readable. The values are not deserialized
+    // and they are byte-arrays.
+    expect(rawNotations.length).to.equal(2);
+
+    expect(rawNotations[0].name).to.equal('test@example.com');
+    expect(rawNotations[0].value).to.deep.equal(Uint8Array.from(['2'.charCodeAt(0)]));
+    expect(rawNotations[0].humanReadable).to.equal(true);
+
+    expect(rawNotations[1].name).to.equal('test@example.com');
+    expect(rawNotations[1].value).to.deep.equal(Uint8Array.from(['3'.charCodeAt(0)]));
+    expect(rawNotations[1].humanReadable).to.equal(true);
   });
 
   it('Writing and encryption of a secret key packet.', function() {


### PR DESCRIPTION
This change adds support for binary (non-human-readable) values in signature notations. Signature notations that have the human-readable flag (0x80) will be deserialized into string values while anything else into raw Uint8Array buffers.

Additionally the check for human-readable flag was modified to check the existence of the flag instead of comparison with the whole value.

Some of these changes were suggested back then: https://github.com/openpgpjs/openpgpjs/issues/897#issuecomment-490030917

For the record, the signature with binary notations displayed in an OpenPGP packet parser on [dump.sequoia-pgp.org](https://dump.sequoia-pgp.org/?data=-----BEGIN%20PGP%20SIGNATURE-----%0D%0AVersion%3A%20OpenPGP.js%20v4.6.2%0D%0AComment%3A%20https%3A//openpgpjs.org%0D%0A%0D%0AwncEARYKAB8FAl2TS9MYFAAAAAAADAADdGVzdEBrZXkuY29tAQIDAAoJEGZ9%0D%0AgtV/iL8hrhMBAOQ/UgqRTbx1Z8inGmRdUx1cJU1SR4Pnq/eJNH/CFk5DAP0Q%0D%0AhUhMKMuiM3pRwdIyDOItkUWQmjEEw7/XmhgInkXsCw%3D%3D%0D%0A%3DZGXr%0D%0A-----END%20PGP%20SIGNATURE-----%0D%0A).