### PR TITLE
Improve iterated S2K performance

### DIFF
--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -167,9 +167,9 @@ S2K.prototype.produce_key = async function (passphrase, numBytes) {
         toHash = util.concatUint8Array([new Uint8Array(prefixlen), this.salt, passphrase]);
         break;
       case 'iterated': {
-        const count = this.get_count();
         const data = util.concatUint8Array([this.salt, passphrase]);
         let datalen = data.length;
+        const count = Math.max(this.get_count(), datalen);
         toHash = new Uint8Array(prefixlen + count);
         toHash.set(data, prefixlen);
         for (let pos = prefixlen + datalen; pos < count; pos += datalen, datalen *= 2) {


### PR DESCRIPTION
Instead of copying the salt+password to the buffer that we're gonna hash repeatedly, we copy it once, and then we internally copy it repeatedly. In essence, we fill the buffer exponentially, reducing the total number of copies, and making S2K much faster.