### PR TITLE
Don't keep entire decrypted message in memory while streaming

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -312,13 +312,13 @@ function dearmor(input) {
         }
       }));
       data = stream.transformPair(data, async (readable, writable) => {
-        const checksumVerified = getCheckSum(stream.passiveClone(readable));
+        const checksumVerified = stream.readToEnd(getCheckSum(stream.passiveClone(readable)));
         await stream.pipe(readable, writable, {
           preventClose: true
         });
         const writer = stream.getWriter(writable);
         try {
-          const checksumVerifiedString = await stream.readToEnd(checksumVerified);
+          const checksumVerifiedString = await checksumVerified;
           if (checksum !== checksumVerifiedString && (checksum || config.checksum_required)) {
             throw new Error("Ascii armor integrity check on message failed: '" + checksum + "' should be '" +
                     checksumVerifiedString + "'");

--- a/src/message.js
+++ b/src/message.js
@@ -585,7 +585,7 @@ Message.prototype.verify = async function(keys, date = new Date(), streaming) {
         onePassSig.correspondingSigReject = reject;
       });
       onePassSig.signatureData = stream.fromAsync(async () => (await onePassSig.correspondingSig).signatureData);
-      onePassSig.hashed = await onePassSig.hash(onePassSig.signatureType, literalDataList[0], undefined, false, streaming);
+      onePassSig.hashed = stream.readToEnd(await onePassSig.hash(onePassSig.signatureType, literalDataList[0], undefined, false, streaming));
     }));
     msg.packets.stream = stream.transformPair(msg.packets.stream, async (readable, writable) => {
       const reader = stream.getReader(readable);

--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -87,6 +87,7 @@ function verificationObjectToClone(verObject) {
       try {
         await verified;
         delete packets[0].signature;
+        delete packets[0].hashed;
       } catch (e) {}
       return packets;
     });

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -699,7 +699,7 @@ Signature.prototype.verify = async function (key, signatureType, data, detached 
   let toHash;
   let hash;
   if (this.hashed) {
-    hash = this.hashed;
+    hash = await this.hashed;
   } else {
     toHash = this.toHash(signatureType, data, detached);
     if (!streaming) toHash = await stream.readToEnd(toHash);


### PR DESCRIPTION
(When `config.allow_unauthenticated_stream` is set or the message is AEAD-encrypted.)

Fix https://github.com/openpgpjs/openpgpjs/issues/974#issuecomment-544496642.