### PR TITLE
Reject signatures using insecure hash algorithms

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -210,5 +210,15 @@ export default {
    * @memberof module:config
    * @property {Object} indutny_elliptic_fetch_options Options object to pass to `fetch` when loading the indutny/elliptic library. Only has an effect if `config.external_indutny_elliptic` is true.
    */
-  indutny_elliptic_fetch_options: {}
+  indutny_elliptic_fetch_options: {},
+  /**
+   * @memberof module:config
+   * @property {Set<Integer>} reject_hash_algorithms Reject insecure hash algorithms {@link module:enums.hash}
+   */
+  reject_hash_algorithms: new Set([enums.hash.md5, enums.hash.ripemd]),
+  /**
+   * @memberof module:config
+   * @property {Set<Integer>} reject_message_hash_algorithms Reject insecure message hash algorithms {@link module:enums.hash}
+   */
+  reject_message_hash_algorithms: new Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1])
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -215,10 +215,10 @@ export default {
    * @memberof module:config
    * @property {Set<Integer>} reject_hash_algorithms Reject insecure hash algorithms {@link module:enums.hash}
    */
-  reject_hash_algorithms: new Set([enums.hash.md5, enums.hash.ripemd]),
+  reject_hash_algorithms: new global.Set([enums.hash.md5, enums.hash.ripemd]),
   /**
    * @memberof module:config
    * @property {Set<Integer>} reject_message_hash_algorithms Reject insecure message hash algorithms {@link module:enums.hash}
    */
-  reject_message_hash_algorithms: new Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1])
+  reject_message_hash_algorithms: new global.Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1])
 };

--- a/src/enums.js
+++ b/src/enums.js
@@ -403,18 +403,6 @@ export default {
     shared_private_key: 128
   },
 
-  /** Key status
-   * @enum {Integer}
-   * @readonly
-   */
-  keyStatus: {
-    invalid:      0,
-    expired:      1,
-    revoked:      2,
-    valid:        3,
-    no_self_cert: 4
-  },
-
   /** Armor type
    * @enum {Integer}
    * @readonly

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -111,8 +111,8 @@ export async function reformat(options) {
 
   if (!options.subkeys) {
     options.subkeys = await Promise.all(secretSubkeyPackets.map(async secretSubkeyPacket => ({
-      sign: await options.privateKey.getSigningKey(secretSubkeyPacket.getKeyId(), null) &&
-          !await options.privateKey.getEncryptionKey(secretSubkeyPacket.getKeyId(), null)
+      sign: await options.privateKey.getSigningKey(secretSubkeyPacket.getKeyId(), null).catch(() => {}) &&
+          !await options.privateKey.getEncryptionKey(secretSubkeyPacket.getKeyId(), null).catch(() => {})
     })));
   }
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -683,7 +683,7 @@ async function prepareSignatures(signatures) {
     try {
       signature.valid = await signature.verified;
     } catch (e) {
-      signature.valid = null;
+      signature.valid = false;
       signature.error = e;
       util.print_debug_error(e);
     }

--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -86,9 +86,11 @@ function verificationObjectToClone(verObject) {
       const packets = (await signature).packets;
       try {
         await verified;
+      } catch (e) {}
+      if (packets && packets[0]) {
         delete packets[0].signature;
         delete packets[0].hashed;
-      } catch (e) {}
+      }
       return packets;
     });
   } else {

--- a/src/util.js
+++ b/src/util.js
@@ -753,5 +753,18 @@ export default {
       result += ALPHABET[MASK & (buffer >> bitsLeft)];
     }
     return result;
+  },
+
+  wrapError: function(message, error) {
+    if (!error) {
+      return new Error(message);
+    }
+
+    // update error message
+    try {
+      error.message = message + ': ' + error.message;
+    } catch (e) {}
+
+    return error;
   }
 };

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2388,7 +2388,7 @@ describe('OpenPGP.js public api tests', function() {
           }).then(function(encrypted) {
             throw new Error('Should not encrypt with revoked key');
           }).catch(function(error) {
-            expect(error.message).to.match(/Could not find valid key packet for encryption/);
+            expect(error.message).to.match(/Error encrypting message: Primary key is revoked/);
           });
         });
       });
@@ -2405,7 +2405,7 @@ describe('OpenPGP.js public api tests', function() {
           }).then(function(encrypted) {
             throw new Error('Should not encrypt with revoked subkey');
           }).catch(function(error) {
-            expect(error.message).to.match(/Could not find valid key packet for encryption/);
+            expect(error.message).to.match(/Could not find valid encryption key packet/);
           });
         });
       });

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -425,9 +425,9 @@ const input = require('./testInputs');
     expect(user.selfCertifications[0].verify(
       hi.primaryKey, {userId: user.userId, key: hi.primaryKey}
     )).to.eventually.be.true;
-    expect(user.verifyCertificate(
+    await user.verifyCertificate(
       hi.primaryKey, user.selfCertifications[0], [hi]
-    )).to.eventually.equal(openpgp.enums.keyStatus.valid);
+    );
   }); */
 });
 
@@ -460,9 +460,9 @@ function omnibus() {
       await expect(user.selfCertifications[0].verify(
         primaryKey, openpgp.enums.signature.cert_generic, { userId: user.userId, key: primaryKey }
       )).to.eventually.be.true;
-      await expect(user.verifyCertificate(
+      await user.verifyCertificate(
         primaryKey, user.selfCertifications[0], [hi.toPublic()]
-      )).to.eventually.equal(openpgp.enums.keyStatus.valid);
+      );
 
       const options = {
         userIds: { name: "Bye", email: "bye@good.bye" },
@@ -480,9 +480,9 @@ function omnibus() {
         await expect(user.selfCertifications[0].verify(
           bye.primaryKey, openpgp.enums.signature.cert_generic, { userId: user.userId, key: bye.primaryKey }
         )).to.eventually.be.true;
-        await expect(user.verifyCertificate(
+        await user.verifyCertificate(
           bye.primaryKey, user.selfCertifications[0], [bye.toPublic()]
-        )).to.eventually.equal(openpgp.enums.keyStatus.valid);
+        );
 
         return Promise.all([
           // Hi trusts Bye!

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -51,7 +51,7 @@ describe('Unit Tests', function () {
       if (key && key !== 'grep') {
         openpgp.config[key] = decodeURIComponent(value);
         try {
-          openpgp.config[key] = JSON.parse(openpgp.config[key]);
+          openpgp.config[key] = eval(openpgp.config[key]);
         } catch(e) {}
       }
     });

--- a/test/worker/application_worker.js
+++ b/test/worker/application_worker.js
@@ -12,7 +12,7 @@ function tests() {
 
   it('Should support loading OpenPGP.js from inside a Web Worker', async function() {
     try {
-      eval('async function() {}');
+      eval('(async function() {})');
     } catch (e) {
       console.error(e);
       this.skip();


### PR DESCRIPTION
- Reject all signatures using MD5 or RIPEMD by default
- Reject message signatures using MD5, RIPEMD or SHA1 by default


Also, switch from returning false to throwing errors in most `verify*()` functions, as well as `await signatures[*].verified`, in order to be able to show more informative error messages.