### PR TITLE
Fix "TypeError: fetch is not a function" in Node.js environment

### DIFF
--- a/src/hkp.js
+++ b/src/hkp.js
@@ -32,7 +32,7 @@ import config from './config';
  */
 function HKP(keyServerBaseUrl) {
   this._baseUrl = keyServerBaseUrl || config.keyserver;
-  this._fetch = typeof global !== 'undefined' ? global.fetch : require('node-fetch');
+  this._fetch = typeof global.fetch === 'function' ? global.fetch : require('node-fetch');
 }
 
 /**


### PR DESCRIPTION
The HKP.lookup method throws "TypeError: fetch is not a function" in Node.js environment.