### PR TITLE
[v5] Remove SHA-1 defaults

### DIFF
--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -191,10 +191,9 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options) {
       ], config.aead_mode);
     }
     signaturePacket.preferredHashAlgorithms = createdPreferredAlgos([
-      // prefer fast asm.js implementations (SHA-256). SHA-1 will not be secure much longer...move to bottom of list
+      // prefer fast asm.js implementations (SHA-256)
       enums.hash.sha256,
-      enums.hash.sha512,
-      enums.hash.sha1
+      enums.hash.sha512
     ], config.prefer_hash_algorithm);
     signaturePacket.preferredCompressionAlgorithms = createdPreferredAlgos([
       enums.compression.zlib,

--- a/src/type/kdf_params.js
+++ b/src/type/kdf_params.js
@@ -27,8 +27,6 @@
  * @module type/kdf_params
  */
 
-import enums from '../enums.js';
-
 /**
  * @constructor
  * @param  {enums.hash}       hash    Hash algorithm
@@ -39,8 +37,8 @@ function KDFParams(data) {
     this.hash = data[0];
     this.cipher = data[1];
   } else {
-    this.hash = enums.hash.sha1;
-    this.cipher = enums.symmetric.aes128;
+    this.hash = null;
+    this.cipher = null;
   }
 }
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1820,7 +1820,7 @@ function versionSpecificTests() {
         expect(key.users[0].selfCertifications[0].preferredAeadAlgorithms).to.eql([aead.eax, aead.ocb]);
       }
       const hash = openpgp.enums.hash;
-      expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512, hash.sha1]);
+      expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512]);
       const compr = openpgp.enums.compression;
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.zlib, compr.zip, compr.uncompressed]);
       expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.v5_keys ? [7] : [1]);
@@ -1862,7 +1862,7 @@ function versionSpecificTests() {
         expect(key.users[0].selfCertifications[0].preferredAeadAlgorithms).to.eql([aead.experimental_gcm, aead.eax, aead.ocb]);
       }
       const hash = openpgp.enums.hash;
-      expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha224, hash.sha256, hash.sha512, hash.sha1]);
+      expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha224, hash.sha256, hash.sha512]);
       const compr = openpgp.enums.compression;
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.zlib, compr.zip, compr.uncompressed]);
       expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.v5_keys ? [7] : [1]);


### PR DESCRIPTION
Remove SHA-1 as default from:
- Preferred hash algorithms for signatures
- KDF (value was unused anyway)