### PR TITLE
add postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "build": "grunt build --compat copy:openpgp_compat && grunt build --lightweight copy:openpgp_lightweight clean:js && grunt build",
     "pretest": "grunt",
     "test": "grunt test",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "postinstall": "rm -f browserify-cache*"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
remove browserify-cache files on npm install, since they could cause
javascript exceptions