### PR TITLE
Support PKCS5 padding longer than 8 bytes

### DIFF
--- a/src/crypto/pkcs5.js
+++ b/src/crypto/pkcs5.js
@@ -41,7 +41,7 @@ function decode(msg) {
   const len = msg.length;
   if (len > 0) {
     const c = msg.charCodeAt(len - 1);
-    if (c >= 1 && c <= 8) {
+    if (c >= 1) {
       const provided = msg.substr(len - c);
       const computed = String.fromCharCode(c).repeat(c);
       if (provided === computed) {


### PR DESCRIPTION
This is allowed by the spec to hide the length of the session key:

> For example, assuming that an AES algorithm is
> used for the session key, the sender MAY use 21, 13, and 5 bytes of
> padding for AES-128, AES-192, and AES-256, respectively, to provide
> the same number of octets, 40 total, as an input to the key wrapping
> method.