### PR TITLE
Fix verification of EdDSA signatures with short MPIs

### DIFF
--- a/src/type/mpi.js
+++ b/src/type/mpi.js
@@ -98,16 +98,11 @@ MPI.prototype.toUint8Array = function (endian, length) {
   length = length || this.data.length;
 
   const payload = new Uint8Array(length);
-  const start = length - this.data.length;
-  if (start < 0) {
-    throw new Error('Payload is too large.');
-  }
-
+  const start = endian === 'le' ? 0 : length - this.data.length;
   payload.set(this.data, start);
   if (endian === 'le') {
     payload.reverse();
   }
-
   return payload;
 };
 


### PR DESCRIPTION
We would fail to verify EdDSA signatures with leading zeros, when encoded according to the spec (without leading zeros, leading to short MPIs). OpenPGP.js itself encodes them with leading zeros. This is accepted by many implementations, but not valid according to the spec. We will fix that in a future version.