### PR TITLE
Also create issuer fingerprint subpacket for v4 keys.

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -163,13 +163,8 @@ Signature.prototype.sign = async function (key, data, detached = false, streamin
   }
   const arr = [new Uint8Array([this.version, signatureType, publicKeyAlgorithm, hashAlgorithm])];
 
-  if (key.version === 5) {
-    // We could also generate this subpacket for version 4 keys, but for
-    // now we don't.
-    this.issuerKeyVersion = key.version;
-    this.issuerFingerprint = key.getFingerprintBytes();
-  }
-
+  this.issuerKeyVersion = key.version;
+  this.issuerFingerprint = key.getFingerprintBytes();
   this.issuerKeyId = key.getKeyId();
 
   // Add hashed subpackets


### PR DESCRIPTION
Do not limit creation of signatures with issuer fingerprint subpacket to v5 keys.

This allows a recipient using GnuPG to get the key via auto-key-retrieve from a key server (if the key is already on the server of course).
If the issuer fingerprint subpacket is missing, GnuPG would not automatically download the key.