### PR TITLE
await getReader()

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Where the value can be any of:
 
     // Either pipe the above stream somewhere, pass it to another function,
     // or read it manually as follows:
-    const reader = openpgp.stream.getReader(encrypted);
+    const reader = await openpgp.stream.getReader(encrypted);
     while (true) {
         const { done, value } = await reader.read();
         if (done) break;


### PR DESCRIPTION
From experiments, `getReader()` may not be immediately ready (at least in case a lot of input data is to be compression).
In these case, the first `await reader.read() / readBytes()` would return undefined unless we explicitely waited for the reader.