### PR TITLE
Process KDF params as object

### DIFF
--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -91,9 +91,9 @@ export default {
         data = new type_mpi(pkcs5.encode(data));
         const oid = pub_params[0];
         const Q = pub_params[1].toUint8Array();
-        const kdf_params = pub_params[2];
+        const kdfParams = pub_params[2];
         const { publicKey: V, wrappedKey: C } = await publicKey.elliptic.ecdh.encrypt(
-          oid, kdf_params.cipher, kdf_params.hash, data, Q, fingerprint);
+          oid, kdfParams, data, Q, fingerprint);
         return constructParams(types, [V, C]);
       }
       default:
@@ -138,13 +138,13 @@ export default {
       }
       case enums.publicKey.ecdh: {
         const oid = key_params[0];
-        const kdf_params = key_params[2];
+        const kdfParams = key_params[2];
         const V = data_params[0].toUint8Array();
         const C = data_params[1].data;
         const Q = key_params[1].toUint8Array();
         const d = key_params[3].toUint8Array();
         const result = new type_mpi(await publicKey.elliptic.ecdh.decrypt(
-          oid, kdf_params.cipher, kdf_params.hash, V, C, Q, d, fingerprint));
+          oid, kdfParams, V, C, Q, d, fingerprint));
         return pkcs5.decode(result.toString());
       }
       default:
@@ -285,7 +285,12 @@ export default {
         });
       case enums.publicKey.ecdh:
         return publicKey.elliptic.generate(oid).then(function (keyObject) {
-          return constructParams(types, [keyObject.oid, keyObject.Q, [keyObject.hash, keyObject.cipher], keyObject.d]);
+          return constructParams(types, [
+            keyObject.oid,
+            keyObject.Q,
+            { hash: keyObject.hash, cipher: keyObject.cipher },
+            keyObject.d
+          ]);
         });
       default:
         throw new Error('Invalid public key algorithm.');

--- a/src/type/kdf_params.js
+++ b/src/type/kdf_params.js
@@ -27,20 +27,19 @@
  * @module type/kdf_params
  */
 
-import enums from '../enums.js';
-
 /**
  * @constructor
  * @param  {enums.hash}       hash    Hash algorithm
  * @param  {enums.symmetric}  cipher  Symmetric algorithm
  */
 function KDFParams(data) {
-  if (data && data.length === 2) {
-    this.hash = data[0];
-    this.cipher = data[1];
+  if (data) {
+    const { hash, cipher } = data;
+    this.hash = hash;
+    this.cipher = cipher;
   } else {
-    this.hash = enums.hash.sha1;
-    this.cipher = enums.symmetric.aes128;
+    this.hash = null;
+    this.cipher = null;
   }
 }
 
@@ -67,7 +66,8 @@ KDFParams.prototype.write = function () {
 };
 
 KDFParams.fromClone = function (clone) {
-  return new KDFParams([clone.hash, clone.cipher]);
+  const { hash, cipher } = clone;
+  return new KDFParams({ hash, cipher });
 };
 
 export default KDFParams;

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -19,8 +19,7 @@ describe('ECDH key exchange @lightweight', function () {
       const curve = new elliptic_curves.Curve(oid);
       return elliptic_curves.ecdh.decrypt(
         new openpgp.OID(curve.oid),
-        cipher,
-        hash,
+        new openpgp.KDFParams({ cipher, hash }),
         new Uint8Array(ephemeral),
         data,
         new Uint8Array(pub),
@@ -136,8 +135,9 @@ describe('ECDH key exchange @lightweight', function () {
     );
     let cipher_algo = curveObj.cipher;
     const hash_algo = curveObj.hash;
+    const kdfParams = new openpgp.KDFParams({ cipher: cipher_algo, hash: hash_algo });
     const param = openpgp.crypto.publicKey.elliptic.ecdh.buildEcdhParam(
-      openpgp.enums.publicKey.ecdh, oid, cipher_algo, hash_algo, fingerprint
+      openpgp.enums.publicKey.ecdh, oid, kdfParams, fingerprint
     );
     cipher_algo = openpgp.enums.read(openpgp.enums.symmetric, cipher_algo);
     const Z = await openpgp.crypto.publicKey.elliptic.ecdh.kdf(
@@ -154,8 +154,9 @@ describe('ECDH key exchange @lightweight', function () {
     );
     let cipher_algo = curveObj.cipher;
     const hash_algo = curveObj.hash;
+    const kdfParams = new openpgp.KDFParams({ cipher: cipher_algo, hash: hash_algo });
     const param = openpgp.crypto.publicKey.elliptic.ecdh.buildEcdhParam(
-      openpgp.enums.publicKey.ecdh, oid, cipher_algo, hash_algo, fingerprint
+      openpgp.enums.publicKey.ecdh, oid, kdfParams, fingerprint
     );
     cipher_algo = openpgp.enums.read(openpgp.enums.symmetric, cipher_algo);
     const Z = await openpgp.crypto.publicKey.elliptic.ecdh.kdf(
@@ -186,8 +187,9 @@ describe('ECDH key exchange @lightweight', function () {
     const sharedKey = result.sharedKey;
     let cipher_algo = curveObj.cipher;
     const hash_algo = curveObj.hash;
+    const kdfParams = new openpgp.KDFParams({ cipher: cipher_algo, hash: hash_algo });
     const param = openpgp.crypto.publicKey.elliptic.ecdh.buildEcdhParam(
-      openpgp.enums.publicKey.ecdh, oid, cipher_algo, hash_algo, fingerprint
+      openpgp.enums.publicKey.ecdh, oid, kdfParams, fingerprint
     );
     cipher_algo = openpgp.enums.read(openpgp.enums.symmetric, cipher_algo);
     const Z = await openpgp.crypto.publicKey.elliptic.ecdh.kdf(


### PR DESCRIPTION
Pass the KDF param object around, avoiding de-/re-constructing it