### PR TITLE
Handle message.fromStream when cloning & restoring Messages

### DIFF
--- a/src/packet/clone.js
+++ b/src/packet/clone.js
@@ -63,7 +63,7 @@ export function clonePackets(options) {
   if (options.message) {
     //could be either a Message or CleartextMessage object
     if (options.message instanceof Message) {
-      options.message = options.message.packets;
+      options.message = { packets: options.message.packets, fromStream: options.message.fromStream };
     } else if (options.message instanceof CleartextMessage) {
       options.message = { text: options.message.text, signature: options.message.signature.packets };
     }
@@ -151,8 +151,10 @@ function packetlistCloneToKey(clone) {
 }
 
 function packetlistCloneToMessage(clone) {
-  const packetlist = List.fromStructuredClone(clone);
-  return new Message(packetlist);
+  const packetlist = List.fromStructuredClone(clone.packets);
+  const message = new Message(packetlist);
+  message.fromStream = clone.fromStream;
+  return message;
 }
 
 function packetlistCloneToCleartextMessage(clone) {


### PR DESCRIPTION
This should fix #1109. 
Previously, signing & encrypting a message created from a stream would hang in the worker, because `Message.fromStream` is undefined in the worker. This is because the `fromStream` property is not properly cloned/restored when passing options to a worker.

The proposed solution changes the `clonePackets` function to wrap the `Message` packets in an object (similar to how it is done for `CleartextMessage`), while including the `fromStream` property. The `packetlistCloneToMessage` is modified accordingly, such that the property is restored afterwards.

See #1109 for more details.

Changes:

- Include fromStream property when cloning a Message
- Restore fromStream property in packetlistCloneToMessage