### PR TITLE
Add support for advanced wkd links

### DIFF
--- a/src/wkd.js
+++ b/src/wkd.js
@@ -57,11 +57,22 @@ WKD.prototype.lookup = async function(options) {
   const [, localPart, domain] = /(.*)@(.*)/.exec(options.email);
   const localEncoded = util.encodeZBase32(await crypto.hash.sha1(util.str_to_Uint8Array(localPart.toLowerCase())));
 
-  const url = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
+  const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localEncoded}`;
+  const urlBasic = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
 
-  return fetch(url).then(function(response) {
+  return fetch(urlAdvanced).then(function(response) {
     if (response.status === 200) {
       return response.arrayBuffer();
+    }
+  }).then(function(publicKey) {
+    if (publicKey) {
+      return publicKey;
+    } else {
+      return fetch(urlBasic).then(function(response) {
+        if (response.status === 200) {
+          return response.arrayBuffer();
+        }
+      });
     }
   }).then(function(publicKey) {
     if (publicKey) {

--- a/src/wkd.js
+++ b/src/wkd.js
@@ -58,7 +58,7 @@ WKD.prototype.lookup = async function(options) {
   const localEncoded = util.encodeZBase32(await crypto.hash.sha1(util.str_to_Uint8Array(localPart.toLowerCase())));
 
   const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localEncoded}`;
-  const urlBasic = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
+  const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
 
   return fetch(urlAdvanced).then(function(response) {
     if (response.status === 200) {
@@ -68,7 +68,7 @@ WKD.prototype.lookup = async function(options) {
     if (publicKey) {
       return publicKey;
     } else {
-      return fetch(urlBasic).then(function(response) {
+      return fetch(urlDirect).then(function(response) {
         if (response.status === 200) {
           return response.arrayBuffer();
         }


### PR DESCRIPTION
As per the spec[0], web key directory implementations must first try the advanced URL and fall back to the basic URL. This small  PR aims to implement this mechanism in openpgpjs.

There must be more than one way of allowing a fetch statement to fall back to a different URL. This is the cleanest way I could find and hope it's up to the standards of the main devs. Open to suggestions!

[0] https://tools.ietf.org/html/draft-koch-openpgp-webkey-service-10