### PR TITLE
Prevent CORS errors from stopping code execution

### DIFF
--- a/src/wkd.js
+++ b/src/wkd.js
@@ -60,10 +60,16 @@ WKD.prototype.lookup = async function(options) {
   const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localEncoded}`;
   const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
 
-  let response = await fetch(urlAdvanced);
-  if (response.status !== 200) {
-    response = await fetch(urlDirect);
-    if (response.status !== 200) {
+  let response = await fetch(urlAdvanced)
+  .catch(function(err) {
+    return null;
+  });
+  if (!response || response.status !== 200) {
+    response = await fetch(urlDirect)
+    .catch(function(err) {
+      return null;
+    });
+    if (!response || response.status !== 200) {
       return;
     }
   }

--- a/src/wkd.js
+++ b/src/wkd.js
@@ -60,13 +60,13 @@ WKD.prototype.lookup = async function(options) {
   const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localEncoded}`;
   const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
 
-  let response = await fetch(urlAdvanced)
-  .catch(function(err) {
+  let response = await fetch(urlAdvanced).catch(function(err) {
+    console.warn(err);
     return null;
   });
   if (!response || response.status !== 200) {
-    response = await fetch(urlDirect)
-    .catch(function(err) {
+    response = await fetch(urlDirect).catch(function(err) {
+      console.warn(err);
       return null;
     });
     if (!response || response.status !== 200) {

--- a/src/wkd.js
+++ b/src/wkd.js
@@ -60,17 +60,17 @@ WKD.prototype.lookup = async function(options) {
   const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localEncoded}`;
   const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
 
-  let response = await fetch(urlAdvanced).catch(function(err) {
-    console.warn(err);
-    return null;
-  });
-  if (!response || response.status !== 200) {
-    response = await fetch(urlDirect).catch(function(err) {
-      console.warn(err);
-      return null;
-    });
-    if (!response || response.status !== 200) {
-      return;
+  let response;
+  try {
+    response = await fetch(urlAdvanced);
+    if (response.status !== 200) {
+      throw new Error('Advanced WKD lookup failed: ' + response.statusText);
+    }
+  } catch (err) {
+    util.print_debug_error(err);
+    response = await fetch(urlDirect);
+    if (response.status !== 200) {
+      throw new Error('Direct WKD lookup failed: ' + response.statusText);
     }
   }
 


### PR DESCRIPTION
This PR prevents the fetch statements from stopping the execution of further code when a CORS error is thrown. The issue was that when a CORS related error prevented the advanced URL from fetching, it would also no longer try the direct URL.