### PR TITLE
[v5] Use higher level functions in key validation tests

### DIFF
--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -65,7 +65,7 @@ async function sign(oid, hash_algo, message, publicKey, privateKey, hashed) {
           if (curve.name !== 'p521' && (err.name === 'DataError' || err.name === 'OperationError')) {
             throw err;
           }
-          util.print_debug_error("Browser did not support signing: " + err.message);
+          util.printDebugError("Browser did not support signing: " + err.message);
         }
         break;
       }
@@ -108,7 +108,7 @@ async function verify(oid, hash_algo, signature, message, publicKey, hashed) {
           if (curve.name !== 'p521' && (err.name === 'DataError' || err.name === 'OperationError')) {
             throw err;
           }
-          util.print_debug_error("Browser did not support verifying: " + err.message);
+          util.printDebugError("Browser did not support verifying: " + err.message);
         }
         break;
       case 'node':

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -426,7 +426,6 @@ class Key {
    * Decrypts all secret key and subkey packets matching keyId
    * @param  {String|Array<String>} passphrases
    * @param  {module:type/keyid} keyId
-   * @returns {Promise<Boolean>} true if all matching key and subkey packets decrypted successfully
    * @throws {Error} if any matching key or subkey packets did not decrypt successfully
    * @async
    */
@@ -436,7 +435,7 @@ class Key {
     }
     passphrases = util.isArray(passphrases) ? passphrases : [passphrases];
 
-    const results = await Promise.all(this.getKeys(keyId).map(async function(key) {
+    await Promise.all(this.getKeys(keyId).map(async function(key) {
       let decrypted = false;
       let error = null;
       await Promise.all(passphrases.map(async function(passphrase) {
@@ -459,8 +458,6 @@ class Key {
       // The full key should be decrypted and we can validate it all
       await this.validate();
     }
-
-    return results.every(result => result === true);
   }
 
   /**

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -166,7 +166,7 @@ class Key {
 
   /**
    * Clones the key object
-   * @param  {type/keyid} deep Whether to clone each packet, in addition to the list of packets
+   * @param  {Boolean} deep Whether to clone each packet, in addition to the list of packets
    * @returns {Promise<module:key.Key>} cloned key
    * @async
    */

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -184,7 +184,7 @@ EJ4QcD/oQ6x1M/8X/iKQCtxZP8RnlrbH7ExkNON5s5g=
     const pk = await openpgp.key.readArmored(data[name].priv);
     expect(pk).to.exist;
     expect(pk.getKeyId().toHex()).to.equal(data[name].id);
-    expect(await pk.decrypt(data[name].pass)).to.be.true;
+    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -154,7 +154,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     const pk = await openpgp.key.readArmored(data[name].priv);
     expect(pk).to.exist;
     expect(pk.getKeyId().toHex()).to.equal(data[name].id);
-    expect(await pk.decrypt(data[name].pass)).to.be.true;
+    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2203,13 +2203,13 @@ function versionSpecificTests() {
     const armor1 = key.armor();
     const armor2 = key.armor();
     expect(armor1).to.equal(armor2);
-    expect(await key.decrypt('passphrase')).to.be.true;
+    await expect(key.decrypt('passphrase')).to.not.be.rejected;
     expect(key.isDecrypted()).to.be.true;
     await key.encrypt('new_passphrase');
     expect(key.isDecrypted()).to.be.false;
-    await expect(key.decrypt('passphrase')).to.eventually.be.rejectedWith('Incorrect key passphrase');
+    await expect(key.decrypt('passphrase')).to.be.rejectedWith('Incorrect key passphrase');
     expect(key.isDecrypted()).to.be.false;
-    expect(await key.decrypt('new_passphrase')).to.be.true;
+    await expect(key.decrypt('new_passphrase')).to.not.be.rejected;
     expect(key.isDecrypted()).to.be.true;
     const armor3 = key.armor();
     expect(armor3).to.not.equal(armor1);

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2203,13 +2203,13 @@ function versionSpecificTests() {
     const armor1 = key.armor();
     const armor2 = key.armor();
     expect(armor1).to.equal(armor2);
-    await expect(key.decrypt('passphrase')).to.not.be.rejected;
+    await key.decrypt('passphrase');
     expect(key.isDecrypted()).to.be.true;
     await key.encrypt('new_passphrase');
     expect(key.isDecrypted()).to.be.false;
     await expect(key.decrypt('passphrase')).to.be.rejectedWith('Incorrect key passphrase');
     expect(key.isDecrypted()).to.be.false;
-    await expect(key.decrypt('new_passphrase')).to.not.be.rejected;
+    await key.decrypt('new_passphrase');
     expect(key.isDecrypted()).to.be.true;
     const armor3 = key.armor();
     expect(armor3).to.not.equal(armor1);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -709,8 +709,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       await expect(privateKey.decrypt('wrong passphrase')).to.eventually.be.rejectedWith('Incorrect key passphrase');
     });
 
-    it('Decrypting key with correct passphrase returns true', async function () {
-      expect(await privateKey.decrypt(passphrase)).to.be.true;
+    it('Decrypting key with correct passphrase does not throw', async function () {
+      await expect(privateKey.decrypt(passphrase)).to.not.be.rejected;
     });
 
     describe('decryptKey', function() {
@@ -815,7 +815,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         let decryptedPrivateKey;
         beforeEach(async function() {
           if (!decryptedPrivateKey) {
-            expect(await privateKey.decrypt(passphrase)).to.be.true;
+            await privateKey.decrypt(passphrase);
             decryptedPrivateKey = privateKey;
           }
           privateKey = decryptedPrivateKey;
@@ -975,7 +975,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         let decryptedPrivateKey;
         beforeEach(async function() {
           if (!decryptedPrivateKey) {
-            expect(await privateKey.decrypt(passphrase)).to.be.true;
+            await privateKey.decrypt(passphrase);
             decryptedPrivateKey = privateKey;
           }
           privateKey = decryptedPrivateKey;
@@ -1784,7 +1784,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       let decryptedPrivateKey;
       beforeEach(async function() {
         if (!decryptedPrivateKey) {
-          expect(await privateKey.decrypt(passphrase)).to.be.true;
+          privateKey.decrypt(passphrase);
           decryptedPrivateKey = privateKey;
         }
         privateKey = decryptedPrivateKey;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -374,7 +374,6 @@ EQr2Mx42THr260IFYp5E/rIA
 =oA0b
 -----END PGP PRIVATE KEY BLOCK-----`;
 
-
 const mismatchingKeyParams = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 Version: OpenPGP.js v4.7.0
 Comment: https://openpgpjs.org
@@ -709,8 +708,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       await expect(privateKey.decrypt('wrong passphrase')).to.eventually.be.rejectedWith('Incorrect key passphrase');
     });
 
-    it('Decrypting key with correct passphrase does not throw', async function () {
-      await expect(privateKey.decrypt(passphrase)).to.not.be.rejected;
+    it('Can decrypt key with correct passphrase', async function () {
+      expect(privateKey.isDecrypted()).to.be.false;
+      await privateKey.decrypt(passphrase);
+      expect(privateKey.isDecrypted()).to.be.true;
     });
 
     describe('decryptKey', function() {
@@ -1784,7 +1785,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       let decryptedPrivateKey;
       beforeEach(async function() {
         if (!decryptedPrivateKey) {
-          privateKey.decrypt(passphrase);
+          await privateKey.decrypt(passphrase);
           decryptedPrivateKey = privateKey;
         }
         privateKey = decryptedPrivateKey;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -374,6 +374,72 @@ EQr2Mx42THr260IFYp5E/rIA
 =oA0b
 -----END PGP PRIVATE KEY BLOCK-----`;
 
+
+const mismatchingKeyParams = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+Version: OpenPGP.js v4.7.0
+Comment: https://openpgpjs.org
+
+xcMGBF3ey50BCADaTsujZxXLCYBeaGd9qXqHc+oWtQF2BZdYWPvguljrYgrK
+WwyoFy8cHaQyi3OTccFXVhFNDG+TgYUG9nk/jvsgOKiu4HugJR5/UPXapBwp
+UooVtp9+0ppOJr9GWKeFNXP8tLLFHXSvApnRntbbHeYJoSEa4Ct2suStq/QU
+NuO3ov9geiNo+BKIf8btm+urRN1jU2QAh9vkB8m3ZiNJhgR6Yoh5omwASLUz
+qPQpuJmfTEnfA9EsaosrrJ2wzvA7enCHdsUFkhsKARCfCqy5sb90PkNXu3Vo
+CybN9h0C801wrkYCBo2SW6mscd4I6Dk7FEoAD1bo5MJfGT96H059Ca9TABEB
+AAH+CQMIZP38MpAOKygADY2D7fzhN5OxQe3vpprtJeqQ/BZ6g7VOd7Sdic2m
+9MTTo/A0XTJxkxf9Rwakcgepm7KwyXE1ntWD9m/XqBzvagTiT4pykvTgm446
+hB/9zileZjp2vmQH+a0Q3X9jXSh0iHQmLTUWGu3Jd/iscGLUGgDPquKNa5Gr
+cfjkxf0tG0JjS+mrdR836UOfHvLWbhbrAgrbCuOEC6ziQe+uFgktqWJPTurP
+Op4fvFD9hggN+lVVLlFwa5N0gaX6GdQHfsktKw6/WTomdjTfWZi87SCz1sXD
+o8Ob/679IjPwvl6gqVlr8iBhpYX3K3NyExRh4DQ2xYhGNtygtyiqSuYYGarm
+lieJuRbx+sm6N4nwJgrvPx9h0MzX86X3n6RNZa7SppJQJ4Z7OrObvRbGsbOc
+hY97shxWT7I7a9KUcmCxSf49GUsKJ5a9z/GS3QpCLxG0rZ3fDQ0sKEVSv+KP
+OJyIiyPyvmlkblJCr83uqrVzJva6/vjZeQa0Wfp2ngh6sE4q+KE+tog0a989
+cuTBZwO2Pl9F9iGVKvL+I/PrBq5UFOk/F3mk8GsS2OuInm5gTcOhIDH6Blhz
+WwLZIfNulozA8Ug2A8C0ntIQsL1Ie/1Yr14mdVk7xMuM7bgwQtQ4pAQcVI3e
+CqyosP7L05ZQKV3FpI2jm+VxfzqsxqMuLwamrS0dB+Jm0KllwwS+Yr84W68S
+v4w258HPRDFDdLveVj3wh7nh/PL4KVXjfR5rz1JNxsgKau/O5ipNcw6CDAQX
+5eI3hAl+YfJs8fRPkvVuf3Nzw/Gs82Zvs6iZxgTqSCyJ/QAHmO+riEukblw2
+Y8EIAaq8QV4WYJs/3Ag3v+FY9x3G/Sf+NKXwnAH9mT+3J8k0JFY4tIXmOunB
+6nWJReZvW5SVu4j2S3dDCX8pTwIPKok8zQDCwHUEEAEIAB8FAl3ey50GCwkH
+CAMCBBUICgIDFgIBAhkBAhsDAh4BAAoJEMNNmgUbCqiXu74IAIzIFeCsco52
+FF2JBf1qffxveLB//lwaAqyAJDFHvrAjmHNFCrwNLmnnP4no7U4P6Zq9aQeK
+ZCj9YMxykpO2tArcjSTCUklDjPj2IPe13vg4giiF9hwtlAKhPhrytqjgNwLF
+ET/9hFtVWZtwaxx8PXXq8E48yOavSk7smKi+z89NloJH7ePzMzV2GfXe6mtH
+qSkzjYJKy72YNvTStay5Tc/bt9zS3jbFv7QtUXRdudcLD0yZC//p3PPrAsaV
+uCAPwz3fvKYX9kdWWrj98FvzzMxx3Lvh3zcEPaWLDOHOdJKHU/YxmrO0+Jxo
+n9uUuQegJMKuiQ4G785Yo+zPjpTpXMTHwwYEXd7LnQEIAJ8lLko4nvEE3x+5
+M4sFNyIYdYK7qvETu9Sz7AOxbeOWiUY8Na2lDuwAmuYDEQcnax9Kh0D6gp1i
+Z86WQwt3uCmLKATahlGolwbn47ztA0Ac8IbbswSr7OJNNJ1byS8h0udmc/SY
+WSWVBeGAmj1Bat8X9nOakwskI8Sm44F/vAvZSIIQ7atzUQbSn9LHftfzWbAX
+wX6LZGnLVn/E7e/YzULuvry7xmqiH/DmsfLLGn04HkcWeBweVo0QvPCETNgR
+MUIL4o84Fo8MQPkPQafUO4uSkFHyixN3YnFwDRHYpn24R3dePLELXUblGANv
+mtOubWvAkFhLVg2HkWJN9iwhLs8AEQEAAf4JAwjXnNHwEu9CWQDc+bM3IwYt
+SUIwwdt7hT9C2FX3nrCPnzsKwI1jUrZOGe0LMSSIJNf5TyWAw6LNUrjnD4hg
+UzIGvgZJDcRl8Ms3LMVaUZMFK/6XE5sdpD7cEgtxY1aGTAitOZ49hClaevnk
+RCRqxT2C2A+GqyvIhr1w3i+AD+zYL1ygLiXpKad82Gbk2axJxcH/hljIKlqr
+v114iGKMHVnqP5L+hM9am2Qu3M+BMROiE/XG82d8r1oAEpQZEXJNBuKSDtL+
+8256OQW1fSQTqkCSIPGVxejrb3TyeAklyQXtGD39rN2qYZcKecUGc2zB85zi
+upoSSYdEfQWoNs/8Z26+17oqKMSl85mWtztz63OEWR7fGfmofiiU+tQw/ndz
+cyvxSc/fIih3adJmFrTtX+nI6hbEVeBZCNhHSQE0I0YoQBfuAmAiNzeV1ISV
+XgjuKHENPPY2bTZZ4Fxmua/OLE+3/nlIuw3LnfGDflv3HVzLJIzlOi5+t58Z
+UMLKesj6Wv1+AW9J1qYEK7/sdpI1LNtde5YRK//gUM6AvvTgcYSWv0FnGYkr
+xKFyYCTztOT4NbywTZNtIqVuHkmkV93PkW/lzR5rK7Hk7ec9lBYGcEOwlGAd
+27fvkTAYLx5S3Qkce0Um3m36TMJ5sCJnZZJ/U/tETiZoq+fbi0Rh4WMNdHu/
+tdckiovkQtSRIJJT1tLY6DvssPGIh1oTyb2Lj9vw/BVFQkgLrpuSMtnJbStt
+cJNpQZfmn2V85Z06qoH/WekQ404xX6+gVw+DetJc2fI4JEKYocUs8R406jRp
+iBndPeORg3fw7C4BLavN6bvUF8qNIEfBNm6/gD5nCU1xflm+a/3dLWFH1R1g
+tjO+0UCRVN7ExVq0m3hhQS2ETi8t3BbZCliMQ1J4k71GGwdA6e6Pu6Q86m4b
+7PrCwF8EGAEIAAkFAl3ey50CGwwACgkQw02aBRsKqJdVvwf/UICpq9O09uuQ
+MFKYevMLfEGF896TCe6sKtwpvyU5QX0xlODI554uJhIxUew6HPzafCO9SWfP
+tas+15nI43pEc0VEnd31g3pqiKSd+PYolw4NfYI0jrcRabebGlGcprvoj2fD
+C/wSMmcnvJkjFzUoDkRX3bMV1C7birw9C1QYOpEj8c0KGIsiVI45sGwFlclD
+AxMSJy5Dv9gcVPq6V8fuPw05ODSpbieoIF3d3WuaI39lAZpfuhNaSNAQmzA7
+6os1UTIywR2rDFRWbh2IrviZ9BVkV6NXa9+gT+clr3PsE4XeADacVAa2MZNR
+0NubenKyljKtyHyoU+S+TqUyx7gf5A==
+=Lj9k
+-----END PGP PRIVATE KEY BLOCK-----
+`;
+
 function withCompression(tests) {
   const compressionTypes = Object.keys(openpgp.enums.compression).map(k => openpgp.enums.compression[k]);
 
@@ -599,6 +665,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     let aeadModeVal;
     let aeadChunkSizeByteVal;
     let v5KeysVal;
+    let privateKeyMismatchingParams;
 
     beforeEach(async function() {
       publicKey = await openpgp.key.readArmored(pub_key);
@@ -610,6 +677,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       publicKey_2038_2045 = privateKey_2038_2045.toPublic();
       privateKey_1337 = await openpgp.key.readArmored(priv_key_expires_1337);
       publicKey_1337 = privateKey_1337.toPublic();
+      privateKeyMismatchingParams = await openpgp.key.readArmored(mismatchingKeyParams);
+
       useNativeVal = openpgp.config.useNative;
       aeadProtectVal = openpgp.config.aeadProtect;
       aeadModeVal = openpgp.config.aeadMode;
@@ -664,6 +733,17 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           throw new Error('Should not decrypt with incorrect passphrase');
         }).catch(function(error){
           expect(error.message).to.match(/Incorrect key passphrase/);
+        });
+      });
+
+      it('should fail for corrupted key', function() {
+        return openpgp.decryptKey({
+          privateKey: privateKeyMismatchingParams,
+          passphrase: 'userpass'
+        }).then(function() {
+          throw new Error('Should not decrypt corrupted key');
+        }).catch(function(error){
+          expect(error.message).to.match(/Key is invalid/);
         });
       });
     });

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -136,7 +136,7 @@ module.exports = () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cr
     const pk = await openpgp.key.readArmored(data[name].priv);
     expect(pk).to.exist;
     expect(pk.getKeyId().toHex()).to.equal(data[name].id);
-    expect(await pk.decrypt(data[name].pass)).to.be.true;
+    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }


### PR DESCRIPTION
- Use `key.keyPacket.validate` instead of `crypto.publicKey.validateParams`, see https://github.com/openpgpjs/openpgpjs/pull/1116#discussion_r447781386

- `key.decrypt` now only throws on error, no other value is returned

- Fix typo (rebase error) that caused tests to fail in Safari for p521