### PR TITLE
Fix pushing of humanReadable notations

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -455,7 +455,7 @@ Signature.prototype.read_sub_packet = function (bytes, trusted = true) {
       this.rawNotations.push({ name, humanReadable, value });
 
       if (humanReadable) {
-        this.notations[name] = util.Uint8Array_to_str(value);
+        this.notations[name].push(util.Uint8Array_to_str(value));
       }
 
       if (critical && (config.known_notations.indexOf(name) === -1)) {


### PR DESCRIPTION
This PR aims to fix what I believe to be an unintended bug introduced in the 4.10.8 release.

## Observation

No matter how many human-readable notations are stored in a key, only a handful will be extracted by OpenPGP.js. To be precise, only one notation per unique "notation name".

## Cause

Release 4.10.8 had the following code for adding individual notations to an array of notations.

```
      if (humanReadable) {
        this.notations[name] = util.Uint8Array_to_str(value);
      }
```

Unfortunately, as multiple notations may share the same name, this will overwrite each previous notation that shared its name.

## Solution 1 (this PR)

There is an [interesting line in the tests](https://github.com/openpgpjs/openpgpjs/blob/aa89893773c2ff97e85846ad5b0a184a89dc1688/test/general/signature.js#L904):

```
expect(signature.notations['test@key.com']).to.equal(undefined);
```

This clearly shows the intentions of the contributor: make notations more accessible using keys instead of iterating over a large array of notations. An improvement to the current situation could be to push the value of each notation to a key corresponding to the name of said notation. Assuming this was the original intent, this PR applies that solution.

```
      if (humanReadable) {
        this.notations[name].push(util.Uint8Array_to_str(value));
      }
```

## Solution 2 (alternative)

This would simply revert to the "array of all notations" solution, as it was before. Opting for this solution would also require a minor change to the test.

```
      if (humanReadable) {
        this.notations.push([name, util.Uint8Array_to_str(value)]);
      }
```

## Additional info

Unless solution 2 is opted for, we are dealing with a breaking change. Code currently iterating over arrays of all notations will now have to specify a notation name for which to iterate over. 