### PR TITLE
Fix "TypeError: fetch is not a function" in Node.js environment

### DIFF
--- a/src/wkd.js
+++ b/src/wkd.js
@@ -31,7 +31,7 @@ import * as keyMod from './key';
  * @constructor
  */
 function WKD() {
-  this._fetch = typeof global !== 'undefined' ? global.fetch : require('node-fetch');
+  this._fetch = typeof global.fetch === 'function' ? global.fetch : require('node-fetch');
 }
 
 /**


### PR DESCRIPTION
What PR #1052 fixed for HKP lookup, this PR fixes WKD. Uses the exact same code as the other fix for consistency.