### PR TITLE
[v5] Use \n instead of \r\n for EOL when armoring

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -103,15 +103,15 @@ function getType(text) {
 function addheader(customComment) {
   let result = "";
   if (config.showVersion) {
-    result += "Version: " + config.versionString + '\r\n';
+    result += "Version: " + config.versionString + '\n';
   }
   if (config.showComment) {
-    result += "Comment: " + config.commentString + '\r\n';
+    result += "Comment: " + config.commentString + '\n';
   }
   if (customComment) {
-    result += "Comment: " + customComment + '\r\n';
+    result += "Comment: " + customComment + '\n';
   }
-  result += '\r\n';
+  result += '\n';
   return result;
 }
 
@@ -331,7 +331,7 @@ export function unarmor(input) {
         });
         const writer = stream.getWriter(writable);
         try {
-          const checksumVerifiedString = (await checksumVerified).replace('\r\n', '');
+          const checksumVerifiedString = (await checksumVerified).replace('\n', '');
           if (checksum !== checksumVerifiedString && (checksum || config.checksumRequired)) {
             throw new Error("Ascii armor integrity check on message failed: '" + checksum + "' should be '" +
                     checksumVerifiedString + "'");
@@ -371,56 +371,56 @@ export function armor(messagetype, body, partindex, parttotal, customComment) {
   const result = [];
   switch (messagetype) {
     case enums.armor.multipartSection:
-      result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\r\n");
+      result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\r\n");
+      result.push("-----END PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\n");
       break;
     case enums.armor.multipartLast:
-      result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "-----\r\n");
+      result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP MESSAGE, PART " + partindex + "-----\r\n");
+      result.push("-----END PGP MESSAGE, PART " + partindex + "-----\n");
       break;
     case enums.armor.signed:
-      result.push("\r\n-----BEGIN PGP SIGNED MESSAGE-----\r\n");
-      result.push("Hash: " + hash + "\r\n\r\n");
+      result.push("\n-----BEGIN PGP SIGNED MESSAGE-----\n");
+      result.push("Hash: " + hash + "\n\n");
       result.push(text.replace(/^-/mg, "- -"));
-      result.push("\r\n-----BEGIN PGP SIGNATURE-----\r\n");
+      result.push("\n-----BEGIN PGP SIGNATURE-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP SIGNATURE-----\r\n");
+      result.push("-----END PGP SIGNATURE-----\n");
       break;
     case enums.armor.message:
-      result.push("-----BEGIN PGP MESSAGE-----\r\n");
+      result.push("-----BEGIN PGP MESSAGE-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP MESSAGE-----\r\n");
+      result.push("-----END PGP MESSAGE-----\n");
       break;
     case enums.armor.publicKey:
-      result.push("-----BEGIN PGP PUBLIC KEY BLOCK-----\r\n");
+      result.push("-----BEGIN PGP PUBLIC KEY BLOCK-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP PUBLIC KEY BLOCK-----\r\n");
+      result.push("-----END PGP PUBLIC KEY BLOCK-----\n");
       break;
     case enums.armor.privateKey:
-      result.push("-----BEGIN PGP PRIVATE KEY BLOCK-----\r\n");
+      result.push("-----BEGIN PGP PRIVATE KEY BLOCK-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP PRIVATE KEY BLOCK-----\r\n");
+      result.push("-----END PGP PRIVATE KEY BLOCK-----\n");
       break;
     case enums.armor.signature:
-      result.push("-----BEGIN PGP SIGNATURE-----\r\n");
+      result.push("-----BEGIN PGP SIGNATURE-----\n");
       result.push(addheader(customComment));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
-      result.push("-----END PGP SIGNATURE-----\r\n");
+      result.push("-----END PGP SIGNATURE-----\n");
       break;
   }
 

--- a/src/encoding/base64.js
+++ b/src/encoding/base64.js
@@ -52,11 +52,11 @@ export function encode(data) {
     const encoded = encodeChunk(buf.subarray(0, bytes));
     for (let i = 0; i < lines; i++) {
       r.push(encoded.substr(i * 60, 60));
-      r.push('\r\n');
+      r.push('\n');
     }
     buf = buf.subarray(bytes);
     return r.join('');
-  }, () => (buf.length ? encodeChunk(buf) + '\r\n' : ''));
+  }, () => (buf.length ? encodeChunk(buf) + '\n' : ''));
 }
 
 /**

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -381,11 +381,11 @@ NJCB6+LWtabSoVIjNVgKwyKqyTLaESNwC2ogZwkdE8qPGiDFEHo4Gg9zuRof
     const armor = await openpgp.stream.readToEnd(openpgp.armor(type, data));
     expect(
       armor
-        .replace(/^(Version|Comment): .*$\r\n/mg, '')
+        .replace(/^(Version|Comment): .*$\n/mg, '')
     ).to.equal(
       pubKey
         .replace('\n=', '=')
-        .replace(/\n/g, '\r\n')
+        .replace(/\n\r/g, '\n')
     );
   });
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3091,7 +3091,7 @@ module.exports = () => describe('Key', function() {
     await packetlist.read(input.data, { SignaturePacket: openpgp.SignaturePacket });
     const armored = openpgp.armor(openpgp.enums.armor.publicKey, packetlist.write());
 
-    expect(revocationCertificate.replace(/^Comment: .*$\r\n/mg, '')).to.equal(armored.replace(/^Comment: .*$\r\n/mg, ''));
+    expect(revocationCertificate.replace(/^Comment: .*$\n/mg, '')).to.equal(armored.replace(/^Comment: .*$\n/mg, ''));
   });
 
   it('getRevocationCertificate() should have an appropriate comment', async function() {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -894,7 +894,7 @@ hUhMKMuiM3pRwdIyDOItkUWQmjEEw7/XmhgInkXsCw==
     const priv_key_gnupg_ext = await openpgp.readArmoredKey(flowcrypt_stripped_key);
     await priv_key_gnupg_ext.decrypt('FlowCrypt');
     const sig = await openpgp.sign({ message: openpgp.Message.fromText('test'), privateKeys: [priv_key_gnupg_ext], date: new Date('2018-12-17T03:24:00') });
-    expect(sig).to.match(/-----END PGP MESSAGE-----\r\n$/);
+    expect(sig).to.match(/-----END PGP MESSAGE-----\n$/);
   });
 
   it('Supports non-human-readable notations', async function() {

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -196,7 +196,7 @@ function tests() {
       passwords: ['test'],
     });
     const reader = openpgp.stream.getReader(encrypted);
-    expect(await reader.peekBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\r\n/);
+    expect(await reader.peekBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
     const msgAsciiArmored = await openpgp.stream.readToEnd(encrypted);
@@ -215,7 +215,7 @@ function tests() {
       passwords: ['test'],
     });
     const reader = openpgp.stream.getReader(encrypted);
-    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\r\n/);
+    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
     await openpgp.stream.cancel(encrypted);
@@ -228,7 +228,7 @@ function tests() {
       privateKeys: privKey
     });
     const reader = openpgp.stream.getReader(signed);
-    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\r\n/);
+    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
     await openpgp.stream.cancel(signed);
@@ -658,7 +658,7 @@ function tests() {
     expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
     const reader = openpgp.stream.getReader(encrypted);
-    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\r\n/);
+    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
     expect(i).to.be.lessThan(expectedType === 'web' ? 50 : 100);
@@ -672,7 +672,7 @@ function tests() {
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
     const reader = openpgp.stream.getReader(signed);
-    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\r\n/);
+    expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
     expect(i).to.be.lessThan(expectedType === 'web' ? 50 : 100);
@@ -860,7 +860,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);
-    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\r\n');
+    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n\n');
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
     expect(i).to.be.greaterThan(100);
@@ -874,7 +874,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);
-    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\r\n');
+    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n\n');
     dataArrived();
     reader.releaseLock();
     await openpgp.stream.cancel(signed, new Error('canceled by test'));

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -860,7 +860,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);
-    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n\n');
+    expect((await reader.readBytes(30)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n');
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
     expect(i).to.be.greaterThan(100);
@@ -874,7 +874,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);
-    expect((await reader.readBytes(31)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n\n');
+    expect((await reader.readBytes(30)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n');
     dataArrived();
     reader.releaseLock();
     await openpgp.stream.cancel(signed, new Error('canceled by test'));


### PR DESCRIPTION
Armoring now uses `\n` instead of `\r\n` for new lines.