### PR TITLE
[v5] Unexport low-level key functions

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -629,20 +629,6 @@ export interface KeyOptions {
   subkeys?: KeyOptions[];
 }
 
-/**
- * Intended for internal use with openpgp.generate()
- * It's recommended that users choose openpgp.generateKey() that requires KeyOptions instead
- */
-export interface FullKeyOptions {
-  userIds: UserId[];
-  passphrase?: string;
-  numBits?: number;
-  keyExpirationTime?: number;
-  curve?: EllipticCurveName;
-  date?: Date;
-  subkeys: KeyOptions[]; // required unlike KeyOptions.subkeys
-}
-
 export interface Keyid {
   bytes: string;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,11 @@ export {
  * @see module:key
  * @name module:openpgp.key
  */
-export * from './key';
+export {
+  readKey, readArmoredKey,
+  readKeys, readArmoredKeys,
+  Key
+} from './key';
 
 /**
  * @see module:signature

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2,6 +2,7 @@
 
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const util = require('../../src/util');
+const key = require('../../src/key');
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
@@ -3104,7 +3105,7 @@ module.exports = () => describe('Key', function() {
 
   it("getPreferredAlgo('symmetric') - one key - AES256", async function() {
     const [key1] = await openpgp.readArmoredKeys(twoKeys);
-    const prefAlgo = await openpgp.getPreferredAlgo('symmetric', [key1]);
+    const prefAlgo = await key.getPreferredAlgo('symmetric', [key1]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes256);
   });
 
@@ -3114,7 +3115,7 @@ module.exports = () => describe('Key', function() {
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = [6,8,3];
-    const prefAlgo = await openpgp.getPreferredAlgo('symmetric', [key1, key2]);
+    const prefAlgo = await key.getPreferredAlgo('symmetric', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes192);
   });
 
@@ -3124,7 +3125,7 @@ module.exports = () => describe('Key', function() {
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = null;
-    const prefAlgo = await openpgp.getPreferredAlgo('symmetric', [key1, key2]);
+    const prefAlgo = await key.getPreferredAlgo('symmetric', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes128);
   });
 
@@ -3133,9 +3134,9 @@ module.exports = () => describe('Key', function() {
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
-    const prefAlgo = await openpgp.getPreferredAlgo('aead', [key1]);
+    const prefAlgo = await key.getPreferredAlgo('aead', [key1]);
     expect(prefAlgo).to.equal(openpgp.enums.aead.ocb);
-    const supported = await openpgp.isAeadSupported([key1]);
+    const supported = await key.isAeadSupported([key1]);
     expect(supported).to.be.true;
   });
 
@@ -3148,9 +3149,9 @@ module.exports = () => describe('Key', function() {
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
     const primaryUser2 = await key2.getPrimaryUser();
     primaryUser2.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    const prefAlgo = await openpgp.getPreferredAlgo('aead', [key1, key2]);
+    const prefAlgo = await key.getPreferredAlgo('aead', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.enums.aead.eax);
-    const supported = await openpgp.isAeadSupported([key1, key2]);
+    const supported = await key.isAeadSupported([key1, key2]);
     expect(supported).to.be.true;
   });
 
@@ -3161,9 +3162,9 @@ module.exports = () => describe('Key', function() {
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
-    const prefAlgo = await openpgp.getPreferredAlgo('aead', [key1, key2]);
+    const prefAlgo = await key.getPreferredAlgo('aead', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.enums.aead.eax);
-    const supported = await openpgp.isAeadSupported([key1, key2]);
+    const supported = await key.isAeadSupported([key1, key2]);
     expect(supported).to.be.false;
   });
 

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -1,7 +1,8 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const util = require('../../src/util');
 
-const { readArmoredKey, generate, Key, readArmoredCleartextMessage, CleartextMessage, enums, PacketList, SignaturePacket } = openpgp;
+const { readArmoredKey, Key, readArmoredCleartextMessage, CleartextMessage, enums, PacketList, SignaturePacket } = openpgp;
+const key = require('../../src/key');
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
@@ -9,7 +10,7 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 async function generateTestData() {
-  const victimPrivKey = await generate({
+  const victimPrivKey = await key.generate({
     userIds: ['Victim <victim@example.com>'],
     rsaBits: util.getWebCryptoAll() ? 2048 : 1024,
     subkeys: [{
@@ -18,7 +19,7 @@ async function generateTestData() {
   });
   victimPrivKey.revocationSignatures = [];
 
-  const attackerPrivKey = await generate({
+  const attackerPrivKey = await key.generate({
     userIds: ['Attacker <attacker@example.com>'],
     rsaBits: util.getWebCryptoAll() ? 2048 : 1024,
     subkeys: [],


### PR DESCRIPTION
No longer exported under `openpgp` namespace:
- `getPreferredAlgo`	
- `isAeadSupported`	
- `getPreferredHashAlgo`	
- `createSignaturePacket`
- `generate` (use `openpgp.generateKey` instead)
- `reformat` (use `openpgp.reformatKey` instead)