### PR TITLE
[v5] Revert to using v4 keys by default

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -69,11 +69,12 @@ export default {
   aeadChunkSizeByte: 12,
   /**
    * Use V5 keys.
-   * Note: not all OpenPGP implementations are compatible with this option
+   * Note: not all OpenPGP implementations are compatible with this option.
+   * **FUTURE OPENPGP.JS VERSIONS MAY BREAK COMPATIBILITY WHEN USING THIS OPTION**
    * @memberof module:config
    * @property {Boolean} v5Keys
    */
-  v5Keys: true,
+  v5Keys: false,
   /**
    * {@link https://tools.ietf.org/html/rfc4880#section-3.7.1.3|RFC4880 3.7.1.3}:
    * Iteration Count Byte for S2K (String to Key)

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -124,7 +124,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   const fingerprint1 = new Uint8Array([
     177, 183,
     116, 123, 76, 133, 245, 212, 151, 243, 236,
-    71, 245, 86, 3, 168, 101, 74, 209, 105
+    71, 245, 86, 3, 168, 101, 56, 209, 105
   ]);
   const fingerprint2 = new Uint8Array([
     177, 83,


### PR DESCRIPTION
Revert #1063 : V5 keys haven't been standardised yet, and we are planning to release openpgpjs v5 quite soon, hence we restore standard-compatible defaults.