### PR TITLE
[v5] Revert to using CFB encryption by default

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -47,11 +47,12 @@ export default {
   /**
    * Use Authenticated Encryption with Additional Data (AEAD) protection for symmetric encryption.
    * Note: not all OpenPGP implementations are compatible with this option.
+   * **FUTURE OPENPGP.JS VERSIONS MAY BREAK COMPATIBILITY WHEN USING THIS OPTION**
    * @see {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-07|RFC4880bis-07}
    * @memberof module:config
    * @property {Boolean} aeadProtect
    */
-  aeadProtect: true,
+  aeadProtect: false,
   /**
    * Default Authenticated Encryption with Additional Data (AEAD) encryption mode
    * Only has an effect when aeadProtect is set to true.


### PR DESCRIPTION
Revert #1062: AEAD encryption hasn't been standardised yet, and we are planning to release openpgpjs v5 quite soon, hence we restore standard-compatible defaults.