### PR TITLE
[v5] Drop inconsistent return types and fix type definitions

### DIFF
--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -62,10 +62,10 @@ export async function getLatestValidSignature(signatures, primaryKey, signatureT
       if (
         (!signature || signatures[i].created >= signature.created) &&
         // check binding signature is not expired (ie, check for V4 expiration time)
-        !signatures[i].isExpired(date) &&
-        // check binding signature is verified
-        (signatures[i].verified || await signatures[i].verify(primaryKey, signatureType, dataToVerify))
+        !signatures[i].isExpired(date)
       ) {
+        // check binding signature is verified
+        signatures[i].verified || await signatures[i].verify(primaryKey, signatureType, dataToVerify);
         signature = signatures[i];
       }
     } catch (e) {
@@ -278,9 +278,10 @@ export async function isDataRevoked(primaryKey, signatureType, dataToVerify, rev
         // third-party key certification, which should only affect
         // `verifyAllCertifications`.)
         (!signature || revocationSignature.issuerKeyId.equals(signature.issuerKeyId)) &&
-        !(config.revocationsExpire && revocationSignature.isExpired(normDate)) &&
-        (revocationSignature.verified || await revocationSignature.verify(key, signatureType, dataToVerify))
+        !(config.revocationsExpire && revocationSignature.isExpired(normDate))
       ) {
+        revocationSignature.verified || await revocationSignature.verify(key, signatureType, dataToVerify);
+
         // TODO get an identifier of the revoked object instead
         revocationKeyIds.push(revocationSignature.issuerKeyId);
       }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -398,7 +398,7 @@ class Key {
    * Encrypts all secret key and subkey packets matching keyId
    * @param  {String|Array<String>} passphrases - if multiple passphrases, then should be in same order as packets each should encrypt
    * @param  {module:type/keyid} keyId
-   * @returns {Promise<Array<SecretKeyPacket|SecretSubkeyPacket>>}
+   * @throws {Error} if encryption failed for any key or subkey
    * @async
    */
   async encrypt(passphrases, keyId = null) {
@@ -412,11 +412,10 @@ class Key {
       throw new Error("Invalid number of passphrases for key");
     }
 
-    return Promise.all(keys.map(async function(key, i) {
+    await Promise.all(keys.map(async function(key, i) {
       const { keyPacket } = key;
       await keyPacket.encrypt(passphrases[i]);
       keyPacket.clearPrivateParams();
-      return keyPacket;
     }));
   }
 
@@ -449,7 +448,6 @@ class Key {
       if (!decrypted) {
         throw error;
       }
-      return decrypted;
     }));
 
     if (!keyId) {
@@ -536,7 +534,7 @@ class Key {
    * and valid self signature. Throws if the primary key is invalid.
    * @param {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId (optional) user ID
-   * @returns {Promise<true>} The status of the primary key
+   * @throws {Error} If key verification failed
    * @async
    */
   async verifyPrimaryKey(date = new Date(), userId = {}) {

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -139,7 +139,7 @@ class SubKey {
       try {
         srcBindSig.verified || await srcBindSig.verify(primaryKey, enums.signature.subkeyBinding, dataToVerify);
         return true;
-      } catch {
+      } catch (e) {
         return false;
       }
     });

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -64,11 +64,11 @@ class SubKey {
 
   /**
    * Verify subkey. Checks for revocation signatures, expiration time
-   * and valid binding signature. Throws if the subkey is invalid.
+   * and valid binding signature.
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket} primaryKey The primary key packet
    * @param  {Date}            date       Use the given date instead of the current time
-   * @returns {Promise<undefined>}
+   * @throws {Error}           if the subkey is invalid.
    * @async
    */
   async verify(primaryKey, date = new Date()) {
@@ -112,7 +112,7 @@ class SubKey {
    * @param  {module:key~SubKey}  subKey     Source subkey to merge
    * @param  {SecretKeyPacket|
               SecretSubkeyPacket} primaryKey primary key used for validation
-   * @returns {Promise<undefined>}
+   * @throws {Error} if update failed
    * @async
    */
   async update(subKey, primaryKey) {
@@ -137,8 +137,9 @@ class SubKey {
         }
       }
       try {
-        return srcBindSig.verified || await srcBindSig.verify(primaryKey, enums.signature.subkeyBinding, dataToVerify);
-      } catch (e) {
+        srcBindSig.verified || await srcBindSig.verify(primaryKey, enums.signature.subkeyBinding, dataToVerify);
+        return true;
+      } catch {
         return false;
       }
     });

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -218,7 +218,7 @@ class User {
       try {
         srcSelfSig.verified || await srcSelfSig.verify(primaryKey, enums.signature.certGeneric, dataToVerify);
         return true;
-      } catch {
+      } catch (e) {
         return false;
       }
     });

--- a/src/message.js
+++ b/src/message.js
@@ -730,7 +730,7 @@ export async function createSignaturePackets(literalDataPacket, privateKeys, sig
  *                    i.e. check signature creation time < date < expiration time
  * @param {Boolean} detached (optional) whether to verify detached signature packets
  * @returns {Promise<Array<{keyid: module:type/keyid,
- *                          valid: Boolean}>>} list of signer's keyid and validity of signature
+ *                          valid: Boolean|null}>>} list of signer's keyid and validity of signature
  * @async
  */
 async function createVerificationObject(signature, literalDataList, keys, date = new Date(), detached = false, streaming = false) {
@@ -751,7 +751,7 @@ async function createVerificationObject(signature, literalDataList, keys, date =
       if (!signingKey) {
         return null;
       }
-      const verified = await signature.verify(signingKey.keyPacket, signature.signatureType, literalDataList[0], detached, streaming);
+      await signature.verify(signingKey.keyPacket, signature.signatureType, literalDataList[0], detached, streaming);
       const sig = await signaturePacket;
       if (sig.isExpired(date) || !(
         sig.created >= signingKey.getCreationTime() &&
@@ -762,7 +762,7 @@ async function createVerificationObject(signature, literalDataList, keys, date =
       )) {
         throw new Error('Signature is expired');
       }
-      return verified;
+      return true;
     })(),
     signature: (async () => {
       const sig = await signaturePacket;

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -90,7 +90,7 @@ class AEADEncryptedDataPacket {
    * @param  {String} sessionKeyAlgorithm   The session key's cipher algorithm e.g. 'aes128'
    * @param  {Uint8Array} key               The session key used to encrypt the payload
    * @param  {Boolean} streaming            Whether the top-level function will return a stream
-   * @returns {Boolean}
+   * @throws {Error} if decryption was not successful
    * @async
    */
   async decrypt(sessionKeyAlgorithm, key, streaming) {
@@ -100,7 +100,6 @@ class AEADEncryptedDataPacket {
       OnePassSignaturePacket,
       SignaturePacket
     }, streaming);
-    return true;
   }
 
   /**
@@ -108,6 +107,7 @@ class AEADEncryptedDataPacket {
    * @param  {String} sessionKeyAlgorithm   The session key's cipher algorithm e.g. 'aes128'
    * @param  {Uint8Array} key               The session key used to encrypt the payload
    * @param  {Boolean} streaming            Whether the top-level function will return a stream
+   * @throws {Error} if encryption was not successful
    * @async
    */
   async encrypt(sessionKeyAlgorithm, key, streaming) {

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -269,12 +269,12 @@ class SecretKeyPacket extends PublicKeyPacket {
    * and the passphrase is empty or undefined, the key will be set as not encrypted.
    * This can be used to remove passphrase protection after calling decrypt().
    * @param {String} passphrase
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if encryption was not successful
    * @async
    */
   async encrypt(passphrase) {
     if (this.isDummy()) {
-      return false;
+      return;
     }
 
     if (!this.isDecrypted()) {
@@ -283,7 +283,7 @@ class SecretKeyPacket extends PublicKeyPacket {
 
     if (this.isDecrypted() && !passphrase) {
       this.s2k_usage = 0;
-      return false;
+      return;
     } else if (!passphrase) {
       throw new Error('The key must be decrypted before removing passphrase protection.');
     }
@@ -310,7 +310,6 @@ class SecretKeyPacket extends PublicKeyPacket {
         await crypto.hash.sha1(cleartext)
       ]), this.iv);
     }
-    return true;
   }
 
   /**
@@ -318,13 +317,13 @@ class SecretKeyPacket extends PublicKeyPacket {
    * {@link SecretKeyPacket.isDecrypted} should be false, as
    * otherwise calls to this function will throw an error.
    * @param {String} passphrase The passphrase for this private key as string
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if decryption was not successful
    * @async
    */
   async decrypt(passphrase) {
     if (this.isDummy()) {
       this.isEncrypted = false;
-      return false;
+      return;
     }
 
     if (this.isDecrypted()) {
@@ -373,8 +372,6 @@ class SecretKeyPacket extends PublicKeyPacket {
     this.isEncrypted = false;
     this.keyMaterial = null;
     this.s2k_usage = 0;
-
-    return true;
   }
 
   /**

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -161,7 +161,7 @@ class SignaturePacket {
    * @param {Object} data Contains packets to be signed.
    * @param {Boolean} detached (optional) whether to create a detached signature
    * @param {Boolean} streaming (optional) whether to process data as a stream
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if signing failed
    * @async
    */
   async sign(key, data, detached = false, streaming = false) {
@@ -201,7 +201,6 @@ class SignaturePacket {
       // same as the ones passed to sign.
       this.verified = true;
     }
-    return true;
   }
 
   /**
@@ -672,7 +671,7 @@ class SignaturePacket {
    * @param {String|Object} data data which on the signature applies
    * @param {Boolean} detached (optional) whether to verify a detached signature
    * @param {Boolean} streaming (optional) whether to process data as a stream
-   * @returns {Promise<Boolean>} True if message is verified, else false.
+   * @throws {Error} if signature validation failed
    * @async
    */
   async verify(key, signatureType, data, detached = false, streaming = false) {
@@ -718,7 +717,6 @@ class SignaturePacket {
       throw new Error('This key is intended to be revoked with an authorized key, which OpenPGP.js does not support.');
     }
     this.verified = true;
-    return true;
   }
 
   /**

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -125,7 +125,7 @@ class SymEncryptedSessionKeyPacket {
   /**
    * Decrypts the session key
    * @param {String} passphrase The passphrase in string form
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if decryption was not successful
    * @async
    */
   async decrypt(passphrase) {
@@ -149,14 +149,12 @@ class SymEncryptedSessionKeyPacket {
     } else {
       this.sessionKey = key;
     }
-
-    return true;
   }
 
   /**
    * Encrypts the session key
    * @param {String} passphrase The passphrase in string form
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if encryption was not successful
    * @async
    */
   async encrypt(passphrase) {
@@ -187,8 +185,6 @@ class SymEncryptedSessionKeyPacket {
       const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
       this.encrypted = await crypto.cfb.encrypt(algo, key, private_key, new Uint8Array(crypto.cipher[algo].blockSize));
     }
-
-    return true;
   }
 }
 

--- a/src/packet/symmetrically_encrypted_data.js
+++ b/src/packet/symmetrically_encrypted_data.js
@@ -83,7 +83,7 @@ class SymmetricallyEncryptedDataPacket {
    * See {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC 4880 9.2} for algorithms.
    * @param {module:enums.symmetric} sessionKeyAlgorithm Symmetric key algorithm to use
    * @param {Uint8Array} key    The key of cipher blocksize length to be used
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if decryption was not successful
    * @async
    */
   async decrypt(sessionKeyAlgorithm, key, streaming) {
@@ -104,8 +104,6 @@ class SymmetricallyEncryptedDataPacket {
       OnePassSignaturePacket,
       SignaturePacket
     }, streaming);
-
-    return true;
   }
 
   /**
@@ -113,7 +111,7 @@ class SymmetricallyEncryptedDataPacket {
    * See {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC 4880 9.2} for algorithms.
    * @param {module:enums.symmetric} sessionKeyAlgorithm Symmetric key algorithm to use
    * @param {Uint8Array} key    The key of cipher blocksize length to be used
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if encryption was not successful
    * @async
    */
   async encrypt(algo, key) {
@@ -123,8 +121,6 @@ class SymmetricallyEncryptedDataPacket {
     const FRE = await crypto.cfb.encrypt(algo, key, prefix, new Uint8Array(crypto.cipher[algo].blockSize));
     const ciphertext = await crypto.cfb.encrypt(algo, key, data, FRE.subarray(2));
     this.encrypted = util.concat([FRE, ciphertext]);
-
-    return true;
   }
 }
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3023,17 +3023,21 @@ module.exports = () => describe('Key', function() {
     source.subKeys = [];
     dest.subKeys = [];
     expect(dest.isPublic()).to.be.true;
-    return dest.update(source).then(() => {
-      expect(dest.isPrivate()).to.be.true;
-      return Promise.all([
-        dest.verifyPrimaryKey().then(result => {
-          expect(source.verifyPrimaryKey()).to.eventually.equal(result);
-        }),
-        dest.users[0].verify(dest.primaryKey).then(result => {
-          expect(source.users[0].verify(source.primaryKey)).to.eventually.equal(result);
-        })
-      ]);
-    });
+
+    await dest.update(source);
+    expect(dest.isPrivate()).to.be.true;
+
+    const { selfCertification: destCertification } = await dest.getPrimaryUser();
+    const { selfCertification: sourceCertification } = await source.getPrimaryUser();
+    destCertification.verified = null;
+    sourceCertification.verified = null;
+    await dest.verifyPrimaryKey().then(async () => expect(destCertification.verified).to.be.true);
+    await source.verifyPrimaryKey().then(async () => expect(sourceCertification.verified).to.be.true);
+
+    destCertification.verified = null;
+    sourceCertification.verified = null;
+    await dest.users[0].verify(dest.primaryKey).then(async () => expect(destCertification.verified).to.be.true);
+    await source.users[0].verify(source.primaryKey).then(async () => expect(sourceCertification.verified).to.be.true);
   });
 
   it('update() - merge private key into public key - mismatch throws error', async function() {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1521,17 +1521,21 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
   // TODO add test with multiple revocation signatures
   it('Verify primary key revocation signatures', async function() {
     const pubKey = await openpgp.readArmoredKey(pub_revoked);
-    await expect(pubKey.revocationSignatures[0].verify(
-      pubKey.primaryKey, openpgp.enums.signature.keyRevocation, {key: pubKey.primaryKey}
-    )).to.eventually.be.true;
+    const revSig = pubKey.revocationSignatures[0];
+    revSig.verified = null;
+    await pubKey.revocationSignatures[0].verify(
+      pubKey.primaryKey, openpgp.enums.signature.keyRevocation, { key: pubKey.primaryKey }
+    ).then(() => expect(revSig.verified).to.be.true);
   });
 
   // TODO add test with multiple revocation signatures
   it('Verify subkey revocation signatures', async function() {
     const pubKey = await openpgp.readArmoredKey(pub_revoked);
-    await expect(pubKey.subKeys[0].revocationSignatures[0].verify(
-      pubKey.primaryKey, openpgp.enums.signature.subkeyRevocation, {key: pubKey.primaryKey, bind: pubKey.subKeys[0].keyPacket}
-    )).to.eventually.be.true;
+    const revSig = pubKey.subKeys[0].revocationSignatures[0];
+    revSig.verified = null;
+    await revSig.verify(
+      pubKey.primaryKey, openpgp.enums.signature.subkeyRevocation, { key: pubKey.primaryKey, bind: pubKey.subKeys[0].keyPacket }
+    ).then(() => expect(revSig.verified).to.be.true);
   });
 
   it('Verify key expiration date', async function() {


### PR DESCRIPTION
- Change several internal `encrypt`, `decrypt`, `sign`, `verify` functions to throw on error, without returning anything on success (the returned value was unused anyway).
- Update and fix type definitions


