### PR TITLE
Consolidate read* functions

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -9,10 +9,10 @@
 
 /* ############## v5 KEY #################### */
 
-export function readArmoredKey(armoredText: string): Promise<Key>;
-export function readKey(data: Uint8Array): Promise<Key>;
-export function readArmoredKeys(armoredText: string): Promise<Key[]>;
-export function readKeys(data: Uint8Array): Promise<Key[]>;
+export function readKey(options: { armoredKey: string }): Promise<Key>;
+export function readKey(options: { binaryKey: Uint8Array }): Promise<Key>;
+export function readKeys(options: { armoredKeys: string }): Promise<Key[]>;
+export function readKeys(options: { binaryKeys: Uint8Array }): Promise<Key[]>;
 export function generateKey(options: KeyOptions): Promise<KeyPair>;
 export function generateSessionKey(options: { publicKeys: Key[], date?: Date, toUserIds?: UserID[] }): Promise<SessionKey>;
 export function decryptKey(options: { privateKey: Key; passphrase?: string | string[]; }): Promise<Key>;
@@ -85,8 +85,8 @@ type AlgorithmInfo = {
 
 /* ############## v5 SIG #################### */
 
-export function readArmoredSignature(armoredText: string): Promise<Signature>;
-export function readSignature(input: Uint8Array): Promise<Signature>;
+export function readSignature(options: { armoredSignature: string }): Promise<Signature>;
+export function readSignature(options: { binarySignature: Uint8Array }): Promise<Signature>;
 
 export class Signature {
   public packets: PacketList<SignaturePacket>;
@@ -102,7 +102,7 @@ interface VerificationResult {
 
 /* ############## v5 CLEARTEXT #################### */
 
-export function readArmoredCleartextMessage(armoredText: string): Promise<CleartextMessage>;
+export function readCleartextMessage(options: { cleartextMessage: string }): Promise<CleartextMessage>;
 
 /** Class that represents an OpenPGP cleartext signed message.
  */
@@ -135,8 +135,8 @@ export class CleartextMessage {
 
 /* ############## v5 MSG #################### */
 
-export function readArmoredMessage<T extends MaybeStream<string>>(armoredText: T): Promise<Message<T>>;
-export function readMessage<T extends MaybeStream<Uint8Array>>(input: T): Promise<Message<T>>;
+export function readMessage<T extends MaybeStream<string>>(options: { armoredMessage: T }): Promise<Message<T>>;
+export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binaryMessage: T }): Promise<Message<T>>;
 
 export function encrypt<T extends 'web' | 'node' | false>(options: EncryptOptions & { streaming: T, armor: false }): Promise<
   T extends 'web' ? WebStream<Uint8Array> :

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -157,14 +157,17 @@ export class CleartextMessage {
 
 
 /**
- * reads an OpenPGP cleartext signed message and returns a CleartextMessage object
- * @param {String | ReadableStream<String>} armoredText text to be parsed
+ * Reads an OpenPGP cleartext signed message and returns a CleartextMessage object
+ * @param {String | ReadableStream<String>} cleartextMessage text to be parsed
  * @returns {module:cleartext.CleartextMessage} new cleartext message object
  * @async
  * @static
  */
-export async function readArmoredCleartextMessage(armoredText) {
-  const input = await unarmor(armoredText);
+export async function readCleartextMessage({ cleartextMessage }) {
+  if (!cleartextMessage) {
+    throw new Error('readCleartextMessage: must pass options object containing `cleartextMessage`');
+  }
+  const input = await unarmor(cleartextMessage);
   if (input.type !== enums.armor.signed) {
     throw new Error('No cleartext signed message.');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,32 +15,25 @@ export {
  * @see module:key
  * @name module:openpgp.key
  */
-export {
-  readKey, readArmoredKey,
-  readKeys, readArmoredKeys,
-  Key
-} from './key';
+export { Key, readKey, readKeys } from './key';
 
 /**
  * @see module:signature
  * @name module:openpgp.signature
  */
-export * from './signature';
+export { Signature, readSignature } from './signature';
 
 /**
  * @see module:message
  * @name module:openpgp.message
  */
-export {
-  readMessage, readArmoredMessage,
-  Message
-} from './message';
+export { Message, readMessage } from './message';
 
 /**
  * @see module:cleartext
  * @name module:openpgp.cleartext
  */
-export * from './cleartext';
+export { CleartextMessage, readCleartextMessage } from './cleartext';
 
 /**
  * @see module:packet

--- a/src/key/index.js
+++ b/src/key/index.js
@@ -4,8 +4,8 @@
  */
 
 import {
-  readKey, readArmoredKey,
-  readKeys, readArmoredKeys,
+  readKey,
+  readKeys,
   generate,
   reformat
 } from './factory';
@@ -20,8 +20,8 @@ import {
 import Key from './key.js';
 
 export {
-  readKey, readArmoredKey,
-  readKeys, readArmoredKeys,
+  readKey,
+  readKeys,
   generate,
   reformat,
   getPreferredAlgo,

--- a/src/keyring/keyring.js
+++ b/src/keyring/keyring.js
@@ -22,7 +22,7 @@
  * @module keyring/keyring
  */
 
-import { readArmoredKeys } from '../key';
+import { readKeys } from '../key';
 import LocalStore from './localstore';
 
 /**
@@ -80,7 +80,7 @@ class KeyArray {
    * @async
    */
   async importKey(armored) {
-    const imported = await readArmoredKeys(armored);
+    const imported = await readKeys({ armoredKeys: armored });
     for (let i = 0; i < imported.length; i++) {
       const key = imported[i];
       // check if key already in key array

--- a/src/keyring/localstore.js
+++ b/src/keyring/localstore.js
@@ -25,7 +25,7 @@
 
 import stream from 'web-stream-tools';
 import config from '../config';
-import { readArmoredKey } from '../key';
+import { readKey } from '../key';
 
 /**
  * The class that deals with storage of the keyring.
@@ -97,7 +97,7 @@ async function loadKeys(storage, itemname) {
   if (armoredKeys !== null && armoredKeys.length !== 0) {
     let key;
     for (let i = 0; i < armoredKeys.length; i++) {
-      key = await readArmoredKey(armoredKeys[i]);
+      key = await readKey({ armoredKey: armoredKeys[i] });
       keys.push(key);
     }
   }

--- a/src/wkd.js
+++ b/src/wkd.js
@@ -78,7 +78,7 @@ class WKD {
     if (options.rawBytes) {
       return rawBytes;
     }
-    return readKeys(rawBytes);
+    return readKeys({ binaryKeys: rawBytes });
   }
 }
 

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -152,9 +152,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = Q2;
       privateKey.subKeys[0].keyPacket.privateParams.d = d2;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).to.be.rejectedWith('Error decrypting message: Key Data Integrity failed');
     });
     it('Invalid fingerprint', async function () {
@@ -165,9 +165,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = Q2;
       privateKey.subKeys[0].keyPacket.privateParams.d = d2;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint2;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).to.be.rejectedWith('Error decrypting message: Session key decryption failed');
     });
     it('Different keys', async function () {
@@ -178,9 +178,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = Q1;
       privateKey.subKeys[0].keyPacket.privateParams.d = d1;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).to.be.rejectedWith('Error decrypting message: Key Data Integrity failed');
     });
     it('Successful exchange curve25519', async function () {
@@ -191,9 +191,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = Q1;
       privateKey.subKeys[0].keyPacket.privateParams.d = d1;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).data).to.equal('test');
     });
     it('Successful exchange NIST P256', async function () {
@@ -204,9 +204,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p256.pub;
       privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p256.priv;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).data).to.equal('test');
     });
     it('Successful exchange NIST P384', async function () {
@@ -217,9 +217,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p384.pub;
       privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p384.priv;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).data).to.equal('test');
     });
     it('Successful exchange NIST P521', async function () {
@@ -230,9 +230,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p521.pub;
       privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p521.priv;
       privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
       expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
       ).data).to.equal('test');
     });
 
@@ -246,15 +246,15 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
         privateKey.subKeys[0].keyPacket.publicParams.Q = key_data[name].pub;
         privateKey.subKeys[0].keyPacket.privateParams.d = key_data[name].priv;
         privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-        const message = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+        const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
         expect((
-          await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+          await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
         ).data).to.equal('test');
         const useNative = openpgp.config.useNative;
         openpgp.config.useNative = !useNative;
         try {
           expect((
-            await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readArmoredMessage(message) })
+            await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
           ).data).to.equal('test');
         } finally {
           openpgp.config.useNative = useNative;

--- a/test/crypto/validate.js
+++ b/test/crypto/validate.js
@@ -269,7 +269,7 @@ module.exports = () => {
   describe('DSA parameter validation', function() {
     let dsaKey;
     before(async () => {
-      dsaKey = await openpgp.readArmoredKey(armoredDSAKey);
+      dsaKey = await openpgp.readKey({ armoredKey: armoredDSAKey });
     });
 
     it('DSA params should be valid', async function() {
@@ -306,7 +306,7 @@ module.exports = () => {
   describe('ElGamal parameter validation', function() {
     let egKey;
     before(async () => {
-      egKey = (await openpgp.readArmoredKey(armoredElGamalKey)).subKeys[0];
+      egKey = (await openpgp.readKey({ armoredKey: armoredElGamalKey })).subKeys[0];
     });
 
     it('params should be valid', async function() {

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -28,55 +28,55 @@ module.exports = () => describe("ASCII armor", function() {
 
   it('Parse cleartext signed message', async function () {
     let msg = getArmor(['Hash: SHA1']);
-    msg = await openpgp.readArmoredCleartextMessage(msg);
+    msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg).to.be.an.instanceof(openpgp.CleartextMessage);
   });
 
   it('Exception if mismatch in armor header and signature', async function () {
     let msg = getArmor(['Hash: SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
   });
 
   it('Exception if no header and non-MD5 signature', async function () {
     let msg = getArmor(null);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /If no "Hash" header in cleartext signed message, then only MD5 signatures allowed/);
   });
 
   it('Exception if unknown hash algorithm', async function () {
     let msg = getArmor(['Hash: LAV750']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Unknown hash algorithm in armor header/);
   });
 
   it('Multiple hash values', async function () {
     let msg = getArmor(['Hash: SHA1, SHA256']);
-    msg = await openpgp.readArmoredCleartextMessage(msg);
+    msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg).to.be.an.instanceof(openpgp.CleartextMessage);
   });
 
   it('Multiple hash header lines', async function () {
     let msg = getArmor(['Hash: SHA1', 'Hash: SHA256']);
-    msg = await openpgp.readArmoredCleartextMessage(msg);
+    msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg).to.be.an.instanceof(openpgp.CleartextMessage);
   });
 
   it('Non-hash header line throws exception', async function () {
     let msg = getArmor(['Hash: SHA1', 'Comment: could be anything']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Only "Hash" header allowed in cleartext signed message/);
   });
 
   it('Multiple wrong hash values', async function () {
     let msg = getArmor(['Hash: SHA512, SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
   });
 
   it('Multiple wrong hash values', async function () {
     let msg = getArmor(['Hash: SHA512, SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
   });
 
@@ -97,33 +97,33 @@ module.exports = () => describe("ASCII armor", function() {
       '-----END PGP SIGNATURE-----'
     ].join('\n');
 
-    msg = await openpgp.readArmoredCleartextMessage(msg);
+    msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg).to.be.an.instanceof(openpgp.CleartextMessage);
   });
 
   it('Exception if improperly formatted armor header - plaintext section', async function () {
     let msg = getArmor(['Hash:SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Improperly formatted armor header/);
     msg = getArmor(['Ha sh: SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Only "Hash" header allowed in cleartext signed message/);
     msg = getArmor(['Hash SHA256']);
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Improperly formatted armor header/);
   });
 
   it('Exception if improperly formatted armor header - signature section', async function () {
     await Promise.all(['Space : trailing', 'Space :switched', ': empty', 'none', 'Space:missing'].map(async function (invalidHeader) {
-      await expect(openpgp.readArmoredCleartextMessage(getArmor(['Hash: SHA1'], [invalidHeader]))).to.be.rejectedWith(Error, /Improperly formatted armor header/);
+      await expect(openpgp.readCleartextMessage({ cleartextMessage: getArmor(['Hash: SHA1'], [invalidHeader]) })).to.be.rejectedWith(Error, /Improperly formatted armor header/);
     }));
   });
 
   it('Ignore unknown armor header - signature section', async function () {
     const validHeaders = ['Version: BCPG C# v1.7.4114.6375', 'Independent Reserve Pty. Ltd. 2017: 1.0.0.0'];
-    expect(await openpgp.readArmoredCleartextMessage(getArmor(['Hash: SHA1'], validHeaders))).to.be.an.instanceof(openpgp.CleartextMessage);
+    expect(await openpgp.readCleartextMessage({ cleartextMessage: getArmor(['Hash: SHA1'], validHeaders) })).to.be.an.instanceof(openpgp.CleartextMessage);
     await Promise.all(['A: Hello', 'Ab: 1.2.3', 'Abcd: #!/yah', 'Acd 123 5.6.$.8: Hello', '_: Hello', '*: Hello', '* & ## ?? ()(): Hello', '( ): Weird'].map(async function (validHeader) {
-      expect(await openpgp.readArmoredCleartextMessage(getArmor(['Hash: SHA1'], [validHeader]))).to.be.an.instanceof(openpgp.CleartextMessage);
+      expect(await openpgp.readCleartextMessage({ cleartextMessage: getArmor(['Hash: SHA1'], [validHeader]) })).to.be.an.instanceof(openpgp.CleartextMessage);
     }));
   });
 
@@ -143,7 +143,7 @@ module.exports = () => describe("ASCII armor", function() {
       '-----END PGP SIGNNATURE-----'
     ].join('\n');
 
-    msg = openpgp.readArmoredCleartextMessage(msg);
+    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
     await expect(msg).to.be.rejectedWith(Error, /Unknown ASCII armor type/);
   });
 
@@ -170,11 +170,11 @@ module.exports = () => describe("ASCII armor", function() {
     ].join('\n');
 
     // try with default config
-    await expect(openpgp.readArmoredKey(privKey)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
 
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    await expect(openpgp.readArmoredKey(privKey)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
 
     // back to default
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
@@ -202,11 +202,11 @@ module.exports = () => describe("ASCII armor", function() {
         '-----END PGP PRIVATE KEY BLOCK-----'].join('\n');
 
     // try with default config
-    await openpgp.readArmoredKey(privKey);
+    await openpgp.readKey({ armoredKey: privKey });
 
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    await openpgp.readArmoredKey(privKey);
+    await openpgp.readKey({ armoredKey: privKey });
 
     // back to default
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
@@ -234,17 +234,17 @@ module.exports = () => describe("ASCII armor", function() {
 
     // try with default config
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readArmoredKey(privKeyNoCheckSum)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
     } else {
-      await openpgp.readArmoredKey(privKeyNoCheckSum);
+      await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
     }
 
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readArmoredKey(privKeyNoCheckSum)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
     } else {
-      await openpgp.readArmoredKey(privKeyNoCheckSum);
+      await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
     }
 
     // back to default
@@ -274,17 +274,17 @@ module.exports = () => describe("ASCII armor", function() {
 
     // try with default config
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readArmoredKey(privKeyNoCheckSumWithTrailingNewline)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
     } else {
-      await openpgp.readArmoredKey(privKeyNoCheckSumWithTrailingNewline);
+      await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
     }
 
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readArmoredKey(privKeyNoCheckSumWithTrailingNewline)).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
     } else {
-      await openpgp.readArmoredKey(privKeyNoCheckSumWithTrailingNewline);
+      await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
     }
 
     // back to default
@@ -314,13 +314,13 @@ module.exports = () => describe("ASCII armor", function() {
       ''
     ].join('\t \r\n');
 
-    const result = await openpgp.readArmoredKey(privKey);
+    const result = await openpgp.readKey({ armoredKey: privKey });
     expect(result).to.be.an.instanceof(openpgp.Key);
   });
 
   it('Do not filter blank lines after header', async function () {
     let msg = getArmor(['Hash: SHA1', '']);
-    msg = await openpgp.readArmoredCleartextMessage(msg);
+    msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg.text).to.equal('\r\nsign this');
   });
 

--- a/test/general/decompression.js
+++ b/test/general/decompression.js
@@ -44,7 +44,7 @@ module.exports = () => describe('Decrypt and decompress message tests', function
 
   function runTest(key, test) {
     it(`Decrypts message compressed with ${key}`, async function () {
-      const message = await openpgp.readArmoredMessage(test.input);
+      const message = await openpgp.readMessage({ armoredMessage: test.input });
       const options = {
         passwords: password,
         message

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -140,7 +140,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     if (data[name].pub_key) {
       return data[name].pub_key;
     }
-    const pub = await openpgp.readArmoredKey(data[name].pub);
+    const pub = await openpgp.readKey({ armoredKey: data[name].pub });
     expect(pub).to.exist;
     expect(pub.getKeyId().toHex()).to.equal(data[name].id);
     data[name].pub_key = pub;
@@ -150,7 +150,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     if (data[name].priv_key) {
       return data[name].priv_key;
     }
-    const pk = await openpgp.readArmoredKey(data[name].priv);
+    const pk = await openpgp.readKey({ armoredKey: data[name].priv });
     expect(pk).to.exist;
     expect(pk.getKeyId().toHex()).to.equal(data[name].id);
     await pk.decrypt(data[name].pass);
@@ -174,7 +174,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   });
   it('Verify clear signed message', async function () {
     const pub = await load_pub_key('juliet');
-    const msg = await openpgp.readArmoredCleartextMessage(data.juliet.message_signed);
+    const msg = await openpgp.readCleartextMessage({ cleartextMessage: data.juliet.message_signed });
     return openpgp.verify({ publicKeys: [pub], message: msg }).then(function(result) {
       expect(result).to.exist;
       expect(result.data).to.equal(data.juliet.message);
@@ -186,7 +186,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     const romeoPrivate = await load_priv_key('romeo');
     const signed = await openpgp.sign({ privateKeys: [romeoPrivate], message: openpgp.CleartextMessage.fromText(data.romeo.message) });
     const romeoPublic = await load_pub_key('romeo');
-    const msg = await openpgp.readArmoredCleartextMessage(signed);
+    const msg = await openpgp.readCleartextMessage({ cleartextMessage: signed });
     const result = await openpgp.verify({ publicKeys: [romeoPublic], message: msg });
 
     expect(result).to.exist;
@@ -197,7 +197,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   it('Decrypt and verify message', async function () {
     const juliet = await load_pub_key('juliet');
     const romeo = await load_priv_key('romeo');
-    const msg = await openpgp.readArmoredMessage(data.juliet.message_encrypted);
+    const msg = await openpgp.readMessage({ armoredMessage: data.juliet.message_encrypted });
     const result = await openpgp.decrypt({ privateKeys: romeo, publicKeys: [juliet], message: msg });
 
     expect(result).to.exist;
@@ -210,7 +210,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     const julietPublic = await load_pub_key('juliet');
     const encrypted = await openpgp.encrypt({ publicKeys: [julietPublic], privateKeys: [romeoPrivate], message: openpgp.Message.fromText(data.romeo.message) });
 
-    const message = await openpgp.readArmoredMessage(encrypted);
+    const message = await openpgp.readMessage({ armoredMessage: encrypted });
     const romeoPublic = await load_pub_key('romeo');
     const julietPrivate = await load_priv_key('juliet');
     const result = await openpgp.decrypt({ privateKeys: julietPrivate, publicKeys: [romeoPublic], message: message });

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2107,7 +2107,7 @@ function versionSpecificTests() {
     const opt = { userIds: { name: 'test', email: 'a@b.com' }, passphrase: 'hello' };
     return openpgp.generateKey(opt).then(async function(key) {
       testPref(key.key);
-      testPref(await openpgp.readArmoredKey(key.publicKeyArmored));
+      testPref(await openpgp.readKey({ armoredKey: key.publicKeyArmored }));
     });
   });
 
@@ -2153,7 +2153,7 @@ function versionSpecificTests() {
     try {
       const key = await openpgp.generateKey(opt);
       testPref(key.key);
-      testPref(await openpgp.readArmoredKey(key.publicKeyArmored));
+      testPref(await openpgp.readKey({ armoredKey: key.publicKeyArmored }));
     } finally {
       openpgp.config.encryptionCipher = encryptionCipherVal;
       openpgp.config.preferHashAlgorithm = preferHashAlgorithmVal;
@@ -2325,7 +2325,7 @@ function versionSpecificTests() {
     const userId = { name: 'test', email: 'a@b.com' };
     const opt = { userIds: [userId], passphrase: '123', subkeys:[{}, { sign: true }] };
     return openpgp.generateKey(opt).then(async function({ privateKeyArmored }) {
-      const key = await openpgp.readArmoredKey(privateKeyArmored);
+      const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userId.userid).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2344,7 +2344,7 @@ function versionSpecificTests() {
       await key.decrypt('123');
       return openpgp.reformatKey({ privateKey: key, userIds: [userId] });
     }).then(async function({ privateKeyArmored }) {
-      const key = await openpgp.readArmoredKey(privateKeyArmored);
+      const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userId.userid).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2417,8 +2417,8 @@ function versionSpecificTests() {
   });
 
   it('Sign and verify key - primary user', async function() {
-    let publicKey = await openpgp.readArmoredKey(pub_sig_test);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    let publicKey = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signPrimaryUser([privateKey]);
     const signatures = await publicKey.verifyPrimaryUser([privateKey]);
@@ -2432,9 +2432,9 @@ function versionSpecificTests() {
   });
 
   it('Sign key and verify with wrong key - primary user', async function() {
-    let publicKey = await openpgp.readArmoredKey(pub_sig_test);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
-    const wrongKey = await openpgp.readArmoredKey(wrong_key);
+    let publicKey = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signPrimaryUser([privateKey]);
     const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
@@ -2448,8 +2448,8 @@ function versionSpecificTests() {
   });
 
   it('Sign and verify key - all users', async function() {
-    let publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    let publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signAllUsers([privateKey]);
     const signatures = await publicKey.verifyAllUsers([privateKey]);
@@ -2471,9 +2471,9 @@ function versionSpecificTests() {
   });
 
   it('Sign key and verify with wrong key - all users', async function() {
-    let publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
-    const wrongKey = await openpgp.readArmoredKey(wrong_key);
+    let publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signAllUsers([privateKey]);
     const signatures = await publicKey.verifyAllUsers([wrongKey]);
@@ -2516,7 +2516,7 @@ function versionSpecificTests() {
 
   it('Reformat key with no subkey with passphrase', async function() {
     const userId = { name: 'test', email: 'a@b.com' };
-    const key = await openpgp.readArmoredKey(key_without_subkey);
+    const key = await openpgp.readKey({ armoredKey: key_without_subkey });
     const opt = { privateKey: key, userIds: [userId], passphrase: "test" };
     return openpgp.reformatKey(opt).then(function(newKey) {
       newKey = newKey.key;
@@ -2550,7 +2550,7 @@ function versionSpecificTests() {
 
   it('Reformat key with no subkey without passphrase', async function() {
     const userId = { name: 'test', email: 'a@b.com' };
-    const key = await openpgp.readArmoredKey(key_without_subkey);
+    const key = await openpgp.readKey({ armoredKey: key_without_subkey });
     const opt = { privateKey: key, userIds: [userId] };
     return openpgp.reformatKey(opt).then(function(newKey) {
       newKey = newKey.key;
@@ -2559,7 +2559,7 @@ function versionSpecificTests() {
       expect(newKey.isDecrypted()).to.be.true;
       return openpgp.sign({ message: openpgp.CleartextMessage.fromText('hello'), privateKeys: newKey, armor: true }).then(async function(signed) {
         return openpgp.verify(
-          { message: await openpgp.readArmoredCleartextMessage(signed), publicKeys: newKey.toPublic() }
+          { message: await openpgp.readCleartextMessage({ cleartextMessage: signed }), publicKeys: newKey.toPublic() }
         ).then(async function(verified) {
           expect(verified.signatures[0].valid).to.be.true;
           const newSigningKey = await newKey.getSigningKey();
@@ -2602,7 +2602,7 @@ function versionSpecificTests() {
       return openpgp.reformatKey(opt).then(function(newKey) {
         newKey = newKey.key;
         return openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: newKey.toPublic(), privateKeys: newKey, armor: true }).then(async function(encrypted) {
-          return openpgp.decrypt({ message: await openpgp.readArmoredMessage(encrypted), privateKeys: newKey, publicKeys: newKey.toPublic() }).then(function(decrypted) {
+          return openpgp.decrypt({ message: await openpgp.readMessage({ armoredMessage: encrypted }), privateKeys: newKey, publicKeys: newKey.toPublic() }).then(function(decrypted) {
             expect(decrypted.data).to.equal('hello');
             expect(decrypted.signatures[0].valid).to.be.true;
           });
@@ -2653,7 +2653,7 @@ function versionSpecificTests() {
     // uid                      emma.goldman@example.net
     // ssb   cv25519 2019-03-20 [E]
     //       E4557C2B02FFBF4B04F87401EC336AF7133D0F85BE7FD09BAEFD9CAEB8C93965
-    const key = await openpgp.readArmoredKey(v5_sample_key);
+    const key = await openpgp.readKey({ armoredKey: v5_sample_key });
     expect(key.primaryKey.getFingerprint()).to.equal('19347bc9872464025f99df3ec2e0000ed9884892e1f7b3ea4c94009159569b54');
     expect(key.subKeys[0].getFingerprint()).to.equal('e4557c2b02ffbf4b04f87401ec336af7133d0f85be7fd09baefd9caeb8c93965');
     await key.verifyPrimaryKey();
@@ -2690,14 +2690,14 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Parsing armored text with RSA key and ECC subkey', async function() {
-    const pubKeys = await openpgp.readArmoredKeys(rsa_ecc_pub);
+    const pubKeys = await openpgp.readKeys({ armoredKeys: rsa_ecc_pub });
     expect(pubKeys).to.exist;
     expect(pubKeys).to.have.length(1);
     expect(pubKeys[0].getKeyId().toHex()).to.equal('b8e4105cc9dedc77');
   });
 
   it('Parsing armored text with two keys', async function() {
-    const pubKeys = await openpgp.readArmoredKeys(twoKeys);
+    const pubKeys = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(pubKeys).to.exist;
     expect(pubKeys).to.have.length(2);
     expect(pubKeys[0].getKeyId().toHex()).to.equal('4a63613a4d6e4094');
@@ -2705,12 +2705,12 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Parsing armored key with an authorized revocation key in a User ID self-signature', async function() {
-    const pubKey = await openpgp.readArmoredKey(key_with_authorized_revocation_key);
+    const pubKey = await openpgp.readKey({ armoredKey: key_with_authorized_revocation_key });
     await expect(pubKey.getPrimaryUser()).to.be.rejectedWith('This key is intended to be revoked with an authorized key, which OpenPGP.js does not support.');
   });
 
   it('Parsing armored key with an authorized revocation key in a direct-key signature', async function() {
-    const pubKey = await openpgp.readArmoredKey(key_with_authorized_revocation_key_in_separate_sig);
+    const pubKey = await openpgp.readKey({ armoredKey: key_with_authorized_revocation_key_in_separate_sig });
     const primaryUser = await pubKey.getPrimaryUser();
     expect(primaryUser).to.exist;
   });
@@ -2731,7 +2731,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Testing key ID and fingerprint for V4 keys', async function() {
-    const pubKeysV4 = await openpgp.readArmoredKeys(twoKeys);
+    const pubKeysV4 = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(pubKeysV4).to.exist;
     expect(pubKeysV4).to.have.length(2);
 
@@ -2743,14 +2743,14 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Create new key ID with fromId()', async function() {
-    const [pubKeyV4] = await openpgp.readArmoredKeys(twoKeys);
+    const [pubKeyV4] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const keyId = pubKeyV4.getKeyId();
     const newKeyId = keyId.constructor.fromId(keyId.toHex());
     expect(newKeyId.toHex()).to.equal(keyId.toHex());
   });
 
   it('Testing key method getSubkeys', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_sig_test);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(pubKey).to.exist;
 
     const packetlist = new openpgp.PacketList();
@@ -2765,12 +2765,12 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Verify status of revoked primary key', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_revoked_subkeys);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
     await expect(pubKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
   });
 
   it('Verify status of revoked subkey', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_sig_test);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(pubKey).to.exist;
     expect(pubKey.subKeys).to.exist;
     expect(pubKey.subKeys).to.have.length(2);
@@ -2781,13 +2781,13 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Verify status of key with non-self revocation signature', async function() {
-    const pubKey = await openpgp.readArmoredKey(key_with_revoked_third_party_cert);
+    const pubKey = await openpgp.readKey({ armoredKey: key_with_revoked_third_party_cert });
     const [selfCertification] = await pubKey.verifyPrimaryUser();
     const publicSigningKey = await pubKey.getSigningKey();
     expect(selfCertification.keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
     expect(selfCertification.valid).to.be.true;
 
-    const certifyingKey = await openpgp.readArmoredKey(certifying_key);
+    const certifyingKey = await openpgp.readKey({ armoredKey: certifying_key });
     const certifyingSigningKey = await certifyingKey.getSigningKey();
     const signatures = await pubKey.verifyPrimaryUser([certifyingKey]);
     expect(signatures.length).to.equal(2);
@@ -2801,7 +2801,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Verify certificate of key with future creation date', async function() {
-    const pubKey = await openpgp.readArmoredKey(key_created_2030);
+    const pubKey = await openpgp.readKey({ armoredKey: key_created_2030 });
     const user = pubKey.users[0];
     await user.verifyCertificate(pubKey.primaryKey, user.selfCertifications[0], [pubKey], pubKey.primaryKey.created);
     const verifyAllResult = await user.verifyAllCertifications(pubKey.primaryKey, [pubKey], pubKey.primaryKey.created);
@@ -2810,7 +2810,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Evaluate key flags to find valid encryption key packet', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_sig_test);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_sig_test });
     // remove subkeys
     pubKey.subKeys = [];
     // primary key has only key flags for signing
@@ -2818,7 +2818,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('should pad an ECDSA P-521 key with shorter secret key', async function() {
-    const key = await openpgp.readArmoredKey(shortP521Key);
+    const key = await openpgp.readKey({ armoredKey: shortP521Key });
     // secret key should be padded
     expect(key.keyPacket.privateParams.d.length === 66);
     // sanity check
@@ -2827,17 +2827,17 @@ module.exports = () => describe('Key', function() {
 
   it('should not decrypt using a sign-only RSA key, unless explicitly configured', async function () {
     const allowSigningKeyDecryption = openpgp.config.allowInsecureDecryptionWithSigningKeys;
-    const key = await openpgp.readArmoredKey(rsaSignOnly);
+    const key = await openpgp.readKey({ armoredKey: rsaSignOnly });
     try {
       openpgp.config.allowInsecureDecryptionWithSigningKeys = false;
       await expect(openpgp.decrypt({
-        message: await openpgp.readArmoredMessage(encryptedRsaSignOnly),
+        message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
         privateKeys: key
       })).to.be.rejectedWith(/Session key decryption failed/);
 
       openpgp.config.allowInsecureDecryptionWithSigningKeys = true;
       await expect(openpgp.decrypt({
-        message: await openpgp.readArmoredMessage(encryptedRsaSignOnly),
+        message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
         privateKeys: key
       })).to.be.fulfilled;
     } finally {
@@ -2846,7 +2846,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Method getExpirationTime V4 Key', async function() {
-    const [, pubKey] = await openpgp.readArmoredKeys(twoKeys);
+    const [, pubKey] = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(pubKey).to.exist;
     expect(pubKey).to.be.an.instanceof(openpgp.Key);
     const expirationTime = await pubKey.getExpirationTime();
@@ -2854,7 +2854,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Method getExpirationTime expired V4 Key', async function() {
-    const pubKey = await openpgp.readArmoredKey(expiredKey);
+    const pubKey = await openpgp.readKey({ armoredKey: expiredKey });
     expect(pubKey).to.exist;
     expect(pubKey).to.be.an.instanceof(openpgp.Key);
     const expirationTime = await pubKey.getExpirationTime();
@@ -2862,7 +2862,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Method getExpirationTime V4 SubKey', async function() {
-    const [, pubKey] = await openpgp.readArmoredKeys(twoKeys);
+    const [, pubKey] = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(pubKey).to.exist;
     expect(pubKey).to.be.an.instanceof(openpgp.Key);
     const expirationTime = await pubKey.subKeys[0].getExpirationTime(pubKey.primaryKey);
@@ -2870,7 +2870,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Method getExpirationTime V4 Key with capabilities', async function() {
-    const pubKey = await openpgp.readArmoredKey(priv_key_2000_2008);
+    const pubKey = await openpgp.readKey({ armoredKey: priv_key_2000_2008 });
     expect(pubKey).to.exist;
     expect(pubKey).to.be.an.instanceof(openpgp.Key);
     pubKey.users[0].selfCertifications[0].keyFlags = [1];
@@ -2881,7 +2881,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Method getExpirationTime V4 Key with capabilities - capable primary key', async function() {
-    const pubKey = await openpgp.readArmoredKey(priv_key_2000_2008);
+    const pubKey = await openpgp.readKey({ armoredKey: priv_key_2000_2008 });
     expect(pubKey).to.exist;
     expect(pubKey).to.be.an.instanceof(openpgp.Key);
     const expirationTime = await pubKey.getExpirationTime();
@@ -2891,12 +2891,12 @@ module.exports = () => describe('Key', function() {
   });
 
   it("decrypt() - throw if key parameters don't correspond", async function() {
-    const key = await openpgp.readArmoredKey(mismatchingKeyParams);
+    const key = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
     await expect(key.decrypt('userpass')).to.be.rejectedWith('Key is invalid');
   });
 
   it("decrypt(keyId) - throw if key parameters don't correspond", async function() {
-    const key = await openpgp.readArmoredKey(mismatchingKeyParams);
+    const key = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
     const subKeyId = key.subKeys[0].getKeyId();
     await expect(key.decrypt('userpass', subKeyId)).to.be.rejectedWith('Key is invalid');
   });
@@ -2907,22 +2907,22 @@ module.exports = () => describe('Key', function() {
   });
 
   it("validate() - throw if all-gnu-dummy key", async function() {
-    const key = await openpgp.readArmoredKey(gnuDummyKey);
+    const key = await openpgp.readKey({ armoredKey: gnuDummyKey });
     await expect(key.validate()).to.be.rejectedWith('Cannot validate an all-gnu-dummy key');
   });
 
   it("validate() - gnu-dummy primary key with signing subkey", async function() {
-    const key = await openpgp.readArmoredKey(gnuDummyKeySigningSubkey);
+    const key = await openpgp.readKey({ armoredKey: gnuDummyKeySigningSubkey });
     await expect(key.validate()).to.not.be.rejected;
   });
 
   it("validate() - gnu-dummy primary key with encryption subkey", async function() {
-    const key = await openpgp.readArmoredKey(dsaGnuDummyKeyWithElGamalSubkey);
+    const key = await openpgp.readKey({ armoredKey: dsaGnuDummyKeyWithElGamalSubkey });
     await expect(key.validate()).to.not.be.rejected;
   });
 
   it("validate() - curve ed25519 (eddsa) cannot be used for ecdsa", async function() {
-    const key = await openpgp.readArmoredKey(eddsaKeyAsEcdsa);
+    const key = await openpgp.readKey({ armoredKey: eddsaKeyAsEcdsa });
     await expect(key.validate()).to.be.rejectedWith('Key is invalid');
   });
 
@@ -2935,21 +2935,21 @@ module.exports = () => describe('Key', function() {
   });
 
   it("isDecrypted() - gnu-dummy primary key", async function() {
-    const key = await openpgp.readArmoredKey(gnuDummyKeySigningSubkey);
+    const key = await openpgp.readKey({ armoredKey: gnuDummyKeySigningSubkey });
     expect(key.isDecrypted()).to.be.true;
     await key.encrypt('12345678');
     expect(key.isDecrypted()).to.be.false;
   });
 
   it("isDecrypted() - all-gnu-dummy key", async function() {
-    const key = await openpgp.readArmoredKey(gnuDummyKey);
+    const key = await openpgp.readKey({ armoredKey: gnuDummyKey });
     expect(key.isDecrypted()).to.be.false;
   });
 
   it('makeDummy() - the converted key can be parsed', async function() {
     const { key } = await openpgp.generateKey({ userIds: { name: 'dummy', email: 'dummy@alice.com' } });
     key.primaryKey.makeDummy();
-    const parsedKeys = await openpgp.readArmoredKey(key.armor());
+    const parsedKeys = await openpgp.readKey({ armoredKey: key.armor() });
     expect(parsedKeys).to.not.be.empty;
   });
 
@@ -2965,7 +2965,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - the converted key is valid but can no longer sign', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await key.decrypt('hello world');
     expect(key.primaryKey.isDummy()).to.be.false;
     key.primaryKey.makeDummy();
@@ -2975,7 +2975,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - subkeys of the converted key can still sign', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await key.decrypt('hello world');
     expect(key.primaryKey.isDummy()).to.be.false;
     key.primaryKey.makeDummy();
@@ -2984,7 +2984,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - should work for encrypted keys', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     expect(key.primaryKey.isDummy()).to.be.false;
     expect(key.primaryKey.makeDummy()).to.not.throw;
     expect(key.primaryKey.isDummy()).to.be.true;
@@ -2998,19 +2998,18 @@ module.exports = () => describe('Key', function() {
     expect(key.primaryKey.isEncrypted === null);
     expect(key.primaryKey.isDecrypted()).to.be.false;
     // confirm that the converted key can be parsed
-    const parsedKeys = (await openpgp.readArmoredKey(key.armor())).keys;
-    expect(parsedKeys).to.be.undefined;
+    await openpgp.readKey({ armoredKey: key.armor() });
   });
 
   it('clearPrivateParams() - check that private key can no longer be used', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await key.decrypt('hello world');
     await key.clearPrivateParams();
     await expect(key.validate()).to.be.rejectedWith('Key is not decrypted');
   });
 
   it('clearPrivateParams() - detect that private key parameters were removed', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await key.decrypt('hello world');
     const signingKeyPacket = key.subKeys[0].keyPacket;
     const privateParams = signingKeyPacket.privateParams;
@@ -3023,7 +3022,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('clearPrivateParams() - detect that private key parameters were zeroed out', async function() {
-    const key = await openpgp.readArmoredKey(priv_key_rsa);
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await key.decrypt('hello world');
     const signingKeyPacket = key.subKeys[0].keyPacket;
     const privateParams = {};
@@ -3039,15 +3038,15 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - throw error if fingerprints not equal', async function() {
-    const keys = await openpgp.readArmoredKeys(twoKeys);
+    const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     await expect(keys[0].update.bind(
       keys[0], keys[1]
     )()).to.be.rejectedWith('Key update method: fingerprints of keys not equal');
   });
 
   it('update() - merge revocation signatures', async function() {
-    const source = await openpgp.readArmoredKey(pub_revoked_subkeys);
-    const dest = await openpgp.readArmoredKey(pub_revoked_subkeys);
+    const source = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
+    const dest = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
     expect(source.revocationSignatures).to.exist;
     dest.revocationSignatures = [];
     return dest.update(source).then(() => {
@@ -3056,8 +3055,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge user', async function() {
-    const source = await openpgp.readArmoredKey(pub_sig_test);
-    const dest = await openpgp.readArmoredKey(pub_sig_test);
+    const source = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const dest = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(source.users[1]).to.exist;
     dest.users.pop();
     return dest.update(source).then(() => {
@@ -3067,8 +3066,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge user - other and certification revocation signatures', async function() {
-    const source = await openpgp.readArmoredKey(pub_sig_test);
-    const dest = await openpgp.readArmoredKey(pub_sig_test);
+    const source = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const dest = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(source.users[1].otherCertifications).to.exist;
     expect(source.users[1].revocationSignatures).to.exist;
     dest.users[1].otherCertifications = [];
@@ -3082,8 +3081,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge subkey', async function() {
-    const source = await openpgp.readArmoredKey(pub_sig_test);
-    const dest = await openpgp.readArmoredKey(pub_sig_test);
+    const source = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const dest = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(source.subKeys[1]).to.exist;
     dest.subKeys.pop();
     return dest.update(source).then(() => {
@@ -3095,8 +3094,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge subkey - revocation signature', async function() {
-    const source = await openpgp.readArmoredKey(pub_sig_test);
-    const dest = await openpgp.readArmoredKey(pub_sig_test);
+    const source = await openpgp.readKey({ armoredKey: pub_sig_test });
+    const dest = await openpgp.readKey({ armoredKey: pub_sig_test });
     expect(source.subKeys[0].revocationSignatures).to.exist;
     dest.subKeys[0].revocationSignatures = [];
     return dest.update(source).then(() => {
@@ -3106,8 +3105,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge private key into public key', async function() {
-    const source = await openpgp.readArmoredKey(priv_key_rsa);
-    const [dest] = await openpgp.readArmoredKeys(twoKeys);
+    const source = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const [dest] = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(dest.isPublic()).to.be.true;
     return dest.update(source).then(() => {
       expect(dest.isPrivate()).to.be.true;
@@ -3126,8 +3125,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge private key into public key - no subkeys', async function() {
-    const source = await openpgp.readArmoredKey(priv_key_rsa);
-    const [dest] = await openpgp.readArmoredKeys(twoKeys);
+    const source = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const [dest] = await openpgp.readKeys({ armoredKeys: twoKeys });
     source.subKeys = [];
     dest.subKeys = [];
     expect(dest.isPublic()).to.be.true;
@@ -3149,8 +3148,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge private key into public key - mismatch throws error', async function() {
-    const source = await openpgp.readArmoredKey(priv_key_rsa);
-    const [dest] = await openpgp.readArmoredKeys(twoKeys);
+    const source = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const [dest] = await openpgp.readKeys({ armoredKeys: twoKeys });
     source.subKeys = [];
     expect(dest.subKeys).to.exist;
     expect(dest.isPublic()).to.be.true;
@@ -3159,8 +3158,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge subkey binding signatures', async function() {
-    const source = await openpgp.readArmoredKey(pgp_desktop_pub);
-    const dest = await openpgp.readArmoredKey(pgp_desktop_priv);
+    const source = await openpgp.readKey({ armoredKey: pgp_desktop_pub });
+    const dest = await openpgp.readKey({ armoredKey: pgp_desktop_priv });
     expect(source.subKeys[0].bindingSignatures[0]).to.exist;
     await source.subKeys[0].verify(source.primaryKey);
     expect(dest.subKeys[0].bindingSignatures[0]).to.not.exist;
@@ -3170,8 +3169,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('update() - merge multiple subkey binding signatures', async function() {
-    const source = await openpgp.readArmoredKey(multipleBindingSignatures);
-    const dest = await openpgp.readArmoredKey(multipleBindingSignatures);
+    const source = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
+    const dest = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
     // remove last subkey binding signature of destination subkey
     dest.subKeys[0].bindingSignatures.length = 1;
     expect((await source.subKeys[0].getExpirationTime(source.primaryKey)).toISOString()).to.equal('2015-10-18T07:41:30.000Z');
@@ -3184,7 +3183,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('revoke() - primary key', async function() {
-    const privKey = await openpgp.readArmoredKey(priv_key_arm2);
+    const privKey = await openpgp.readKey({ armoredKey: priv_key_arm2 });
     await privKey.decrypt('hello world');
 
     await privKey.revoke({
@@ -3202,8 +3201,8 @@ module.exports = () => describe('Key', function() {
   });
 
   it('revoke() - subkey', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_key_arm2);
-    const privKey = await openpgp.readArmoredKey(priv_key_arm2);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_key_arm2 });
+    const privKey = await openpgp.readKey({ armoredKey: priv_key_arm2 });
     await privKey.decrypt('hello world');
 
     const subKey = pubKey.subKeys[0];
@@ -3221,15 +3220,15 @@ module.exports = () => describe('Key', function() {
   });
 
   it('applyRevocationCertificate() should produce the same revoked key as GnuPG', async function() {
-    const pubKey = await openpgp.readArmoredKey(pub_key_arm4);
+    const pubKey = await openpgp.readKey({ armoredKey: pub_key_arm4 });
 
     return pubKey.applyRevocationCertificate(revocation_certificate_arm4).then(async revKey => {
-      expect(revKey.armor()).to.equal((await openpgp.readArmoredKey(revoked_key_arm4)).armor());
+      expect(revKey.armor()).to.equal((await openpgp.readKey({ armoredKey: revoked_key_arm4 })).armor());
     });
   });
 
   it('getRevocationCertificate() should produce the same revocation certificate as GnuPG', async function() {
-    const revKey = await openpgp.readArmoredKey(revoked_key_arm4);
+    const revKey = await openpgp.readKey({ armoredKey: revoked_key_arm4 });
     const revocationCertificate = await revKey.getRevocationCertificate();
 
     const input = await openpgp.unarmor(revocation_certificate_arm4);
@@ -3241,7 +3240,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it('getRevocationCertificate() should have an appropriate comment', async function() {
-    const revKey = await openpgp.readArmoredKey(revoked_key_arm4);
+    const revKey = await openpgp.readKey({ armoredKey: revoked_key_arm4 });
     const revocationCertificate = await revKey.getRevocationCertificate();
 
     expect(revocationCertificate).to.match(/Comment: This is a revocation certificate/);
@@ -3249,13 +3248,13 @@ module.exports = () => describe('Key', function() {
   });
 
   it("getPreferredAlgo('symmetric') - one key - AES256", async function() {
-    const [key1] = await openpgp.readArmoredKeys(twoKeys);
+    const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const prefAlgo = await key.getPreferredAlgo('symmetric', [key1]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes256);
   });
 
   it("getPreferredAlgo('symmetric') - two key - AES192", async function() {
-    const keys = await openpgp.readArmoredKeys(twoKeys);
+    const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
@@ -3265,7 +3264,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it("getPreferredAlgo('symmetric') - two key - one without pref", async function() {
-    const keys = await openpgp.readArmoredKeys(twoKeys);
+    const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
@@ -3275,7 +3274,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it("getPreferredAlgo('aead') - one key - OCB", async function() {
-    const [key1] = await openpgp.readArmoredKeys(twoKeys);
+    const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
@@ -3286,7 +3285,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it("getPreferredAlgo('aead') - two key - one without pref", async function() {
-    const keys = await openpgp.readArmoredKeys(twoKeys);
+    const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
@@ -3301,7 +3300,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it("getPreferredAlgo('aead') - two key - one with no support", async function() {
-    const keys = await openpgp.readArmoredKeys(twoKeys);
+    const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
@@ -3314,13 +3313,13 @@ module.exports = () => describe('Key', function() {
   });
 
   it('User attribute packet read & write', async function() {
-    const key = await openpgp.readArmoredKey(user_attr_key);
-    const key2 = await openpgp.readArmoredKey(key.armor());
+    const key = await openpgp.readKey({ armoredKey: user_attr_key });
+    const key2 = await openpgp.readKey({ armoredKey: key.armor() });
     expect(key.users[1].userAttribute).eql(key2.users[1].userAttribute);
   });
 
   it('getPrimaryUser()', async function() {
-    const key = await openpgp.readArmoredKey(pub_sig_test);
+    const key = await openpgp.readKey({ armoredKey: pub_sig_test });
     const primUser = await key.getPrimaryUser();
     expect(primUser).to.exist;
     expect(primUser.user.userId.userid).to.equal('Signature Test <signature@test.com>');
@@ -3343,13 +3342,13 @@ Vz/bMCJoAShgybW1r6kRWejybzIjFSLnx/YA/iLZeo5UNdlXRJco+15RbFiNSAbw
 VYGdb3eNlV8CfoEC
 =FYbP
 -----END PGP PRIVATE KEY BLOCK-----`;
-    const key = await openpgp.readArmoredKey(keyWithoutUserID);
+    const key = await openpgp.readKey({ armoredKey: keyWithoutUserID });
     await expect(key.getPrimaryUser()).to.be.rejectedWith('Could not find valid self-signature in key 3ce893915c44212f');
   });
 
   it('Generate session key - latest created user', async function() {
-    const publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
     // Set second user to prefer aes128. We should select this user by default, since it was created later.
     publicKey.users[1].selfCertifications[0].preferredSymmetricAlgorithms = [openpgp.enums.symmetric.aes128];
@@ -3358,8 +3357,8 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Generate session key - primary user', async function() {
-    const publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
     // Set first user to primary. We should select this user by default.
     publicKey.users[0].selfCertifications[0].isPrimaryUserID = true;
@@ -3370,8 +3369,8 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Generate session key - specific user', async function() {
-    const publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
     // Set first user to primary. We won't select this user, this is to test that.
     publicKey.users[0].selfCertifications[0].isPrimaryUserID = true;
@@ -3384,18 +3383,18 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Fails to encrypt to User ID-less key', async function() {
-    const publicKey = await openpgp.readArmoredKey(uidlessKey);
+    const publicKey = await openpgp.readKey({ armoredKey: uidlessKey });
     expect(publicKey.users.length).to.equal(0);
-    const privateKey = await openpgp.readArmoredKey(uidlessKey);
+    const privateKey = await openpgp.readKey({ armoredKey: uidlessKey });
     await privateKey.decrypt('correct horse battery staple');
     await expect(openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, armor: false })).to.be.rejectedWith('Could not find primary user');
   });
 
   it('Sign - specific user', async function() {
-    const publicKey = await openpgp.readArmoredKey(multi_uid_key);
-    const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+    const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
-    const privateKeyClone = await openpgp.readArmoredKey(priv_key_rsa);
+    const privateKeyClone = await openpgp.readKey({ armoredKey: priv_key_rsa });
     // Duplicate user
     privateKey.users.push(privateKeyClone.users[0]);
     // Set first user to primary. We won't select this user, this is to test that.
@@ -3405,46 +3404,46 @@ VYGdb3eNlV8CfoEC
     // Set second user to prefer aes128. We will select this user.
     privateKey.users[1].selfCertifications[0].preferredHashAlgorithms = [openpgp.enums.hash.sha512];
     const signed = await openpgp.sign({ message: openpgp.Message.fromText('hello'), privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false });
-    const signature = await openpgp.readMessage(signed);
+    const signature = await openpgp.readMessage({ binaryMessage: signed });
     expect(signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
     const encrypted = await openpgp.encrypt({ message: openpgp.Message.fromText('hello'), passwords: 'test', privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false });
-    const { signatures } = await openpgp.decrypt({ message: await openpgp.readMessage(encrypted), passwords: 'test' });
+    const { signatures } = await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), passwords: 'test' });
     expect(signatures[0].signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
     await expect(openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, fromUserIds: { name: 'Not Test McTestington', email: 'test@example.com' }, armor: false })).to.be.rejectedWith('Could not find user that matches that user ID');
   });
 
   it('Find a valid subkey binding signature among many invalid ones', async function() {
-    const key = await openpgp.readArmoredKey(valid_binding_sig_among_many_expired_sigs_pub);
+    const key = await openpgp.readKey({ armoredKey: valid_binding_sig_among_many_expired_sigs_pub });
     expect(await key.getEncryptionKey()).to.not.be.null;
   });
 
   it('Selects the most recent subkey binding signature', async function() {
-    const key = await openpgp.readArmoredKey(multipleBindingSignatures);
+    const key = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
     expect((await key.subKeys[0].getExpirationTime(key.primaryKey)).toISOString()).to.equal('2015-10-18T07:41:30.000Z');
   });
 
   it('Selects the most recent non-expired subkey binding signature', async function() {
-    const key = await openpgp.readArmoredKey(multipleBindingSignatures);
+    const key = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
     key.subKeys[0].bindingSignatures[1].signatureNeverExpires = false;
     key.subKeys[0].bindingSignatures[1].signatureExpirationTime = 0;
     expect((await key.subKeys[0].getExpirationTime(key.primaryKey)).toISOString()).to.equal('2018-09-07T06:03:37.000Z');
   });
 
   it('Selects the most recent valid subkey binding signature', async function() {
-    const key = await openpgp.readArmoredKey(multipleBindingSignatures);
+    const key = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
     key.subKeys[0].bindingSignatures[1].signatureData[0]++;
     expect((await key.subKeys[0].getExpirationTime(key.primaryKey)).toISOString()).to.equal('2018-09-07T06:03:37.000Z');
   });
 
   it('Handles a key with no valid subkey binding signatures gracefully', async function() {
-    const key = await openpgp.readArmoredKey(multipleBindingSignatures);
+    const key = await openpgp.readKey({ armoredKey: multipleBindingSignatures });
     key.subKeys[0].bindingSignatures[0].signatureData[0]++;
     key.subKeys[0].bindingSignatures[1].signatureData[0]++;
     expect(await key.subKeys[0].getExpirationTime(key.primaryKey)).to.be.null;
   });
 
   it('Reject encryption with revoked primary user', async function() {
-    const key = await openpgp.readArmoredKey(pub_revoked_subkeys);
+    const key = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
     return openpgp.encrypt({ publicKeys: [key], message: openpgp.Message.fromText('random data') }).then(() => {
       throw new Error('encryptSessionKey should not encrypt with revoked public key');
     }).catch(function(error) {
@@ -3453,7 +3452,7 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Reject encryption with revoked subkey', async function() {
-    const key = await openpgp.readArmoredKey(pub_revoked_subkeys);
+    const key = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
     key.revocationSignatures = [];
     key.users[0].revocationSignatures = [];
     return openpgp.encrypt({ publicKeys: [key], message: openpgp.Message.fromText('random data'), date: new Date(1386842743000) }).then(() => {
@@ -3464,7 +3463,7 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Reject encryption with key revoked with appended revocation cert', async function() {
-    const key = await openpgp.readArmoredKey(pub_revoked_with_cert);
+    const key = await openpgp.readKey({ armoredKey: pub_revoked_with_cert });
     return openpgp.encrypt({ publicKeys: [key], message: openpgp.Message.fromText('random data') }).then(() => {
       throw new Error('encryptSessionKey should not encrypt with revoked public key');
     }).catch(function(error) {
@@ -3473,8 +3472,8 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Merge key with another key with non-ID user attributes', async function() {
-    const key = await openpgp.readArmoredKey(mergeKey1);
-    const updateKey = await openpgp.readArmoredKey(mergeKey2);
+    const key = await openpgp.readKey({ armoredKey: mergeKey1 });
+    const updateKey = await openpgp.readKey({ armoredKey: mergeKey2 });
     expect(key).to.exist;
     expect(updateKey).to.exist;
     expect(key.users).to.have.length(1);
@@ -3489,7 +3488,7 @@ VYGdb3eNlV8CfoEC
   it("Should throw when trying to encrypt a key that's already encrypted", async function() {
     await expect((async function() {
       const { privateKeyArmored } = await openpgp.generateKey({ userIds: [{ email: 'hello@user.com' }], passphrase: 'pass' });
-      const k = await openpgp.readArmoredKey(privateKeyArmored);
+      const k = await openpgp.readKey({ armoredKey: privateKeyArmored });
       await k.decrypt('pass');
       await k.encrypt('pass');
       await k.encrypt('pass');
@@ -3509,12 +3508,12 @@ VYGdb3eNlV8CfoEC
     });
 
     it('create and add a new rsa subkey to stored rsa key', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey(rsaOpt);
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey).to.exist;
       expect(newPrivateKey.subKeys.length).to.be.equal(total + 1);
@@ -3547,7 +3546,7 @@ VYGdb3eNlV8CfoEC
     });
 
     it('Add a new default subkey to a dsa key', async function() {
-      const key = await openpgp.readArmoredKey(dsaPrivateKey);
+      const key = await openpgp.readKey({ armoredKey: dsaPrivateKey });
       const total = key.subKeys.length;
       const newKey = await key.addSubkey();
       expect(newKey.subKeys[total].getAlgorithmInfo().algorithm).to.equal('rsaEncryptSign');
@@ -3555,21 +3554,21 @@ VYGdb3eNlV8CfoEC
     });
 
     it('should throw when trying to encrypt a subkey separately from key', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const opt = { rsaBits: rsaBits, passphrase: 'subkey passphrase' };
       await expect(privateKey.addSubkey(opt)).to.be.rejectedWith('Subkey could not be encrypted here, please encrypt whole key');
     });
 
     it('encrypt and decrypt key with added subkey', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey(rsaOpt);
-      newPrivateKey = await openpgp.readArmoredKey(newPrivateKey.armor());
+      newPrivateKey = await openpgp.readKey({ armoredKey: newPrivateKey.armor() });
       await newPrivateKey.encrypt('12345678');
       const armoredKey = newPrivateKey.armor();
-      const importedPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      const importedPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       await importedPrivateKey.decrypt('12345678');
       const subKey = importedPrivateKey.subKeys[total];
       expect(subKey).to.exist;
@@ -3587,7 +3586,7 @@ VYGdb3eNlV8CfoEC
       const subKey1 = newPrivateKey.subKeys[total];
       await newPrivateKey.encrypt('12345678');
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       await newPrivateKey.decrypt('12345678');
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey.isDecrypted()).to.be.true;
@@ -3607,7 +3606,7 @@ VYGdb3eNlV8CfoEC
       const privateKey = (await openpgp.generateKey(opt)).key;
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey({ curve: 'p256', sign: true });
-      newPrivateKey = await openpgp.readArmoredKey(newPrivateKey.armor());
+      newPrivateKey = await openpgp.readKey({ armoredKey: newPrivateKey.armor() });
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey).to.exist;
       expect(newPrivateKey.subKeys.length).to.be.equal(total + 1);
@@ -3620,13 +3619,13 @@ VYGdb3eNlV8CfoEC
     });
 
     it('create and add a new ecc subkey to a rsa key', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const total = privateKey.subKeys.length;
       const opt2 = { type: 'ecc', curve: 'curve25519' };
       let newPrivateKey = await privateKey.addSubkey(opt2);
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       expect(newPrivateKey.subKeys.length).to.be.equal(total + 1);
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey).to.exist;
@@ -3642,7 +3641,7 @@ VYGdb3eNlV8CfoEC
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey({ type: 'rsa' });
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey).to.exist;
       expect(newPrivateKey.subKeys.length).to.be.equal(total + 1);
@@ -3652,10 +3651,10 @@ VYGdb3eNlV8CfoEC
     });
 
     it('create and add a new rsa subkey to a dsa key', async function() {
-      const privateKey = await openpgp.readArmoredKey(dsaPrivateKey);
+      const privateKey = await openpgp.readKey({ armoredKey: dsaPrivateKey });
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey({ type: 'rsa', rsaBits: 2048 });
-      newPrivateKey = await openpgp.readArmoredKey(newPrivateKey.armor());
+      newPrivateKey = await openpgp.readKey({ armoredKey: newPrivateKey.armor() });
       expect(newPrivateKey.subKeys.length).to.be.equal(total + 1);
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey).to.exist;
@@ -3672,7 +3671,7 @@ VYGdb3eNlV8CfoEC
       const opt2 = { sign: true };
       let newPrivateKey = await privateKey.addSubkey(opt2);
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       const subkeyOid = subKey.keyPacket.publicParams.oid;
       const pkOid = newPrivateKey.primaryKey.publicParams.oid;
@@ -3681,7 +3680,7 @@ VYGdb3eNlV8CfoEC
       await subKey.verify(newPrivateKey.primaryKey);
       expect(await newPrivateKey.getSigningKey()).to.be.equal(subKey);
       const signed = await openpgp.sign({ message: openpgp.Message.fromText('the data to signed'), privateKeys: newPrivateKey, armor:false });
-      const message = await openpgp.readMessage(signed);
+      const message = await openpgp.readMessage({ binaryMessage: signed });
       const { signatures } = await openpgp.verify({ message, publicKeys: [newPrivateKey.toPublic()] });
       expect(signatures).to.exist;
       expect(signatures.length).to.be.equal(1);
@@ -3697,14 +3696,14 @@ VYGdb3eNlV8CfoEC
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey();
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       const publicKey = newPrivateKey.toPublic();
       await subKey.verify(newPrivateKey.primaryKey);
       expect(await newPrivateKey.getEncryptionKey()).to.be.equal(subKey);
       const encrypted = await openpgp.encrypt({ message: openpgp.Message.fromText(vData), publicKeys: publicKey, armor:false });
       expect(encrypted).to.be.exist;
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const pkSessionKeys = message.packets.filterByTag(openpgp.enums.packet.publicKeyEncryptedSessionKey);
       expect(pkSessionKeys).to.exist;
       expect(pkSessionKeys.length).to.be.equal(1);
@@ -3715,19 +3714,19 @@ VYGdb3eNlV8CfoEC
     });
 
     it('sign/verify data with the new subkey correctly using rsa', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const total = privateKey.subKeys.length;
       const opt2 = { sign: true, rsaBits: rsaBits };
       let newPrivateKey = await privateKey.addSubkey(opt2);
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       expect(subKey.getAlgorithmInfo().algorithm).to.be.equal('rsaEncryptSign');
       await subKey.verify(newPrivateKey.primaryKey);
       expect(await newPrivateKey.getSigningKey()).to.be.equal(subKey);
       const signed = await openpgp.sign({ message: openpgp.Message.fromText('the data to signed'), privateKeys: newPrivateKey, armor:false });
-      const message = await openpgp.readMessage(signed);
+      const message = await openpgp.readMessage({ binaryMessage: signed });
       const { signatures } = await openpgp.verify({ message, publicKeys: [newPrivateKey.toPublic()] });
       expect(signatures).to.exist;
       expect(signatures.length).to.be.equal(1);
@@ -3736,19 +3735,19 @@ VYGdb3eNlV8CfoEC
     });
 
     it('encrypt/decrypt data with the new subkey correctly using rsa', async function() {
-      const privateKey = await openpgp.readArmoredKey(priv_key_rsa);
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
       await privateKey.decrypt('hello world');
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey(rsaOpt);
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readArmoredKey(armoredKey);
+      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subKey = newPrivateKey.subKeys[total];
       const publicKey = newPrivateKey.toPublic();
       const vData = 'the data to encrypted!';
       expect(await newPrivateKey.getEncryptionKey()).to.be.equal(subKey);
       const encrypted = await openpgp.encrypt({ message: openpgp.Message.fromText(vData), publicKeys: publicKey, armor:false });
       expect(encrypted).to.be.exist;
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const pkSessionKeys = message.packets.filterByTag(openpgp.enums.packet.publicKeyEncryptedSessionKey);
       expect(pkSessionKeys).to.exist;
       expect(pkSessionKeys.length).to.be.equal(1);

--- a/test/general/keyring.js
+++ b/test/general/keyring.js
@@ -273,14 +273,14 @@ module.exports = () => describe("Keyring", async function() {
     const localstore2 = new openpgp.Keyring.localstore('my-custom-prefix-');
     const localstore3 = new openpgp.Keyring.localstore();
     await localstore3.storePublic([]);
-    const key = await openpgp.readArmoredKey(pubkey);
+    const key = await openpgp.readKey({ armoredKey: pubkey });
     await localstore1.storePublic([key]);
     expect((await localstore2.loadPublic())[0].getKeyId().equals(key.getKeyId())).to.be.true;
     expect(await localstore3.loadPublic()).to.have.length(0);
   });
 
   it('emptying keyring and storing removes keys', async function() {
-    const key = await openpgp.readArmoredKey(pubkey);
+    const key = await openpgp.readKey({ armoredKey: pubkey });
 
     const localstore = new openpgp.Keyring.localstore('remove-prefix-');
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -764,7 +764,7 @@ module.exports = () => describe("Packet", function() {
   });
 
   it('Reading signersUserId from armored signature', async function() {
-    const armored_sig =
+    const armoredSignature =
 `-----BEGIN PGP SIGNATURE-----
 
 iQFKBAEBCgA0FiEEdOyNPagqedqiXfEMa6Ve2Dq64bsFAlszXwQWHHRlc3Qtd2tk
@@ -777,7 +777,7 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
 =wEIR
 -----END PGP SIGNATURE-----`;
 
-    const signature = await openpgp.readArmoredSignature(armored_sig);
+    const signature = await openpgp.readSignature({ armoredSignature });
 
     expect(signature.packets[0].signersUserId).to.equal('test-wkd@metacode.biz');
   });
@@ -816,7 +816,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 =et/d
 -----END PGP PUBLIC KEY BLOCK-----`;
 
-    const key = await openpgp.readArmoredKey(pubkey);
+    const key = await openpgp.readKey({ armoredKey: pubkey });
 
     const { notations, rawNotations } = key.users[0].selfCertifications[0];
 

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -194,7 +194,7 @@ function tests() {
       passwords: ['test']
     });
     const msgAsciiArmored = await openpgp.stream.readToEnd(encrypted);
-    const message = await openpgp.readArmoredMessage(msgAsciiArmored);
+    const message = await openpgp.readMessage({ armoredMessage: msgAsciiArmored });
     const decrypted = await openpgp.decrypt({
       passwords: ['test'],
       message
@@ -212,7 +212,7 @@ function tests() {
     dataArrived();
     reader.releaseLock();
     const msgAsciiArmored = await openpgp.stream.readToEnd(encrypted);
-    const message = await openpgp.readArmoredMessage(msgAsciiArmored);
+    const message = await openpgp.readMessage({ armoredMessage: msgAsciiArmored });
     const decrypted = await openpgp.decrypt({
       passwords: ['test'],
       message,
@@ -257,7 +257,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-    const message = await openpgp.readMessage(encrypted);
+    const message = await openpgp.readMessage({ binaryMessage: encrypted });
     setTimeout(dataArrived, 3000); // Do not wait until data arrived, but wait a bit to check that it doesn't arrive early.
     const decrypted = await openpgp.decrypt({
       passwords: ['test'],
@@ -285,7 +285,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message,
@@ -316,7 +316,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         publicKeys: pubKey,
         privateKeys: privKey,
@@ -336,8 +336,8 @@ function tests() {
   it('Encrypt and decrypt larger message roundtrip using curve x25519 (allowUnauthenticatedStream=true)', async function() {
     const allowUnauthenticatedStreamValue = openpgp.config.allowUnauthenticatedStream;
     openpgp.config.allowUnauthenticatedStream = true;
-    const priv = await openpgp.readArmoredKey(xPriv);
-    const pub = await openpgp.readArmoredKey(xPub);
+    const priv = await openpgp.readKey({ armoredKey: xPriv });
+    const pub = await openpgp.readKey({ armoredKey: xPub });
     await priv.decrypt(xPass);
     try {
       const encrypted = await openpgp.encrypt({
@@ -348,7 +348,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         publicKeys: pub,
         privateKeys: priv,
@@ -368,8 +368,8 @@ function tests() {
   it('Encrypt and decrypt larger message roundtrip using curve brainpool (allowUnauthenticatedStream=true)', async function() {
     const allowUnauthenticatedStreamValue = openpgp.config.allowUnauthenticatedStream;
     openpgp.config.allowUnauthenticatedStream = true;
-    const priv = await openpgp.readArmoredKey(brainpoolPriv);
-    const pub = await openpgp.readArmoredKey(brainpoolPub);
+    const priv = await openpgp.readKey({ armoredKey: brainpoolPriv });
+    const pub = await openpgp.readKey({ armoredKey: brainpoolPub });
     await priv.decrypt(brainpoolPass);
     try {
       const encrypted = await openpgp.encrypt({
@@ -380,7 +380,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         publicKeys: pub,
         privateKeys: priv,
@@ -409,13 +409,15 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readArmoredMessage(openpgp.stream.transform(encrypted, value => {
-        value += '';
-        if (value === '=' || value.length === 6) return; // Remove checksum
-        const newlineIndex = value.indexOf('\n', 500);
-        if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
-        return value;
-      }));
+      const message = await openpgp.readMessage({
+        armoredMessage: openpgp.stream.transform(encrypted, value => {
+          value += '';
+          if (value === '=' || value.length === 6) return; // Remove checksum
+          const newlineIndex = value.indexOf('\n', 500);
+          if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
+          return value;
+        })
+      });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message,
@@ -445,12 +447,14 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readArmoredMessage(openpgp.stream.transform(encrypted, value => {
-        value += '';
-        const newlineIndex = value.indexOf('\n', 500);
-        if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
-        return value;
-      }));
+      const message = await openpgp.readMessage({
+        armoredMessage: openpgp.stream.transform(encrypted, value => {
+          value += '';
+          const newlineIndex = value.indexOf('\n', 500);
+          if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
+          return value;
+        })
+      });
       const decrypted = await openpgp.decrypt({
         publicKeys: pubKey,
         privateKeys: privKey,
@@ -480,12 +484,14 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readArmoredMessage(openpgp.stream.transform(encrypted, value => {
-        value += '';
-        const newlineIndex = value.indexOf('\n', 500);
-        if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
-        return value;
-      }));
+      const message = await openpgp.readMessage({
+        armoredMessage: openpgp.stream.transform(encrypted, value => {
+          value += '';
+          const newlineIndex = value.indexOf('\n', 500);
+          if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
+          return value;
+        })
+      });
       const decrypted = await openpgp.decrypt({
         privateKeys: privKey,
         message,
@@ -511,12 +517,14 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
-    const message = await openpgp.readArmoredMessage(openpgp.stream.transform(signed, value => {
-      value += '';
-      const newlineIndex = value.indexOf('\n', 500);
-      if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
-      return value;
-    }));
+    const message = await openpgp.readMessage({
+      armoredMessage: openpgp.stream.transform(signed, value => {
+        value += '';
+        const newlineIndex = value.indexOf('\n', 500);
+        if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
+        return value;
+      })
+    });
     const verified = await openpgp.verify({
       publicKeys: pubKey,
       message,
@@ -563,7 +571,7 @@ function tests() {
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
-    const message = await openpgp.readArmoredMessage(signed);
+    const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
       publicKeys: pubKey,
       message,
@@ -614,7 +622,7 @@ function tests() {
       privateKeys: privKey
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const message = await openpgp.readArmoredMessage(signed);
+    const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
       publicKeys: pubKey,
       message,
@@ -644,8 +652,8 @@ function tests() {
       streaming: expectedType
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const sigArmored = await openpgp.stream.readToEnd(signed);
-    const signature = await openpgp.readArmoredMessage(sigArmored);
+    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
       publicKeys: pubKey,
@@ -673,7 +681,7 @@ function tests() {
       armor: false
     });
     expect(openpgp.stream.isStream(signed)).to.be.false;
-    const signature = await openpgp.readMessage(signed);
+    const signature = await openpgp.readMessage({ binaryMessage: signed });
     const verified = await openpgp.verify({
       signature,
       publicKeys: pubKey,
@@ -693,8 +701,8 @@ function tests() {
         controller.close();
       }
     });
-    const priv = await openpgp.readArmoredKey(brainpoolPriv);
-    const pub = await openpgp.readArmoredKey(brainpoolPub);
+    const priv = await openpgp.readKey({ armoredKey: brainpoolPriv });
+    const pub = await openpgp.readKey({ armoredKey: brainpoolPub });
     await priv.decrypt(brainpoolPass);
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
@@ -703,8 +711,8 @@ function tests() {
       streaming: expectedType
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const sigArmored = await openpgp.stream.readToEnd(signed);
-    const signature = await openpgp.readArmoredMessage(sigArmored);
+    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
       publicKeys: pub,
@@ -724,8 +732,8 @@ function tests() {
         controller.close();
       }
     });
-    const priv = await openpgp.readArmoredKey(xPriv);
-    const pub = await openpgp.readArmoredKey(xPub);
+    const priv = await openpgp.readKey({ armoredKey: xPriv });
+    const pub = await openpgp.readKey({ armoredKey: xPub });
     await priv.decrypt(xPass);
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
@@ -734,8 +742,8 @@ function tests() {
       streaming: expectedType
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const sigArmored = await openpgp.stream.readToEnd(signed);
-    const signature = await openpgp.readArmoredMessage(sigArmored);
+    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
       publicKeys: pub,
@@ -798,7 +806,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message,
@@ -835,7 +843,7 @@ function tests() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
-      const message = await openpgp.readArmoredMessage(encrypted);
+      const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message
@@ -863,7 +871,7 @@ function tests() {
           passwords: ['test']
         });
         expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
-        const message = await openpgp.readArmoredMessage(encrypted);
+        const message = await openpgp.readMessage({ armoredMessage: encrypted });
         const decrypted = await openpgp.decrypt({
           passwords: ['test'],
           message,
@@ -890,7 +898,7 @@ function tests() {
         passwords: ['test']
       });
 
-      const message = await openpgp.readArmoredMessage(encrypted);
+      const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message,
@@ -911,8 +919,8 @@ module.exports = () => describe('Streaming', function() {
   let currentTest = 0;
 
   before(async function() {
-    pubKey = await openpgp.readArmoredKey(pub_key);
-    privKey = await openpgp.readArmoredKey(priv_key);
+    pubKey = await openpgp.readKey({ armoredKey: pub_key });
+    privKey = await openpgp.readKey({ armoredKey: priv_key });
     await privKey.decrypt(passphrase);
   });
 
@@ -971,7 +979,7 @@ module.exports = () => describe('Streaming', function() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal('node');
 
-      const message = await openpgp.readArmoredMessage(encrypted);
+      const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message
@@ -991,7 +999,7 @@ module.exports = () => describe('Streaming', function() {
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal('node');
 
-      const message = await openpgp.readMessage(encrypted);
+      const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message,

--- a/test/security/message_signature_bypass.js
+++ b/test/security/message_signature_bypass.js
@@ -1,7 +1,7 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const util = require('../../src/util');
 
-const { readArmoredKey, readArmoredCleartextMessage, SignaturePacket } = openpgp;
+const { readKey, readCleartextMessage, SignaturePacket } = openpgp;
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
@@ -68,7 +68,7 @@ fhGyl7nA7UCwgsqf7ZPBhRg=
 =nbjQ
 -----END PGP SIGNATURE-----`;
 async function getOtherPubKey() {
-  return readArmoredKey(OTHERPUBKEY);
+  return readKey({ armoredKey: OTHERPUBKEY });
 }
 
 /**
@@ -78,10 +78,11 @@ const STANDALONE_PKT = util.hexToUint8Array(`04020108001005025bab730a091055208b2
 async function fakeSignature() {
   // read the template and modify the text to
   // invalidate the signature.
-  let fake = await readArmoredCleartextMessage(
-    ORIGINAL.replace(
+  let fake = await readCleartextMessage({
+    cleartextMessage: ORIGINAL.replace(
       'You owe me',
-      'I owe you'));
+      'I owe you')
+  });
   // read the standalone signature packet
   const tmp = new SignaturePacket();
   await tmp.read(STANDALONE_PKT);
@@ -92,7 +93,7 @@ async function fakeSignature() {
   const faked_armored = await fake.armor();
   // re-read the message to eliminate any
   // behaviour due to cached values.
-  fake = await readArmoredCleartextMessage(faked_armored);
+  fake = await readCleartextMessage({ cleartextMessage: faked_armored });
   // faked message now verifies correctly
   const res = await openpgp.verify({
     message: fake,

--- a/test/security/preferred_algo_mismatch.js
+++ b/test/security/preferred_algo_mismatch.js
@@ -5,7 +5,7 @@ chai.use(require('chai-as-promised'));
 
 const expect = chai.expect;
 
-const messageArmor = `-----BEGIN PGP MESSAGE-----
+const armoredMessage = `-----BEGIN PGP MESSAGE-----
 Version: OpenPGP.js VERSION
 Comment: https://openpgpjs.org
 
@@ -41,7 +41,7 @@ EnxUPL95HuMKoVkf4w==
 -----END PGP PRIVATE KEY BLOCK-----`;
 
 module.exports = () => it('Does not accept message encrypted with algo not mentioned in preferred algorithms', async function() {
-  const message = await openpgp.readArmoredMessage(messageArmor);
-  const privKey = await openpgp.readArmoredKey(privateKeyArmor);
+  const message = await openpgp.readMessage({ armoredMessage });
+  const privKey = await openpgp.readKey({ armoredKey: privateKeyArmor });
   await expect(openpgp.decrypt({ message, privateKeys: [privKey] })).to.be.rejectedWith('A non-preferred symmetric algorithm was used.');
 });

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -1,6 +1,6 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 
-const { readArmoredKey, Key, readArmoredCleartextMessage, CleartextMessage, enums, PacketList, SignaturePacket } = openpgp;
+const { readKey, Key, readCleartextMessage, CleartextMessage, enums, PacketList, SignaturePacket } = openpgp;
 const key = require('../../src/key');
 
 const chai = require('chai');
@@ -66,9 +66,9 @@ async function testSubkeyTrust() {
     fakeBindingSignature // faked key binding
   ]);
   let fakeKey = new Key(newList);
-  fakeKey = await readArmoredKey(await fakeKey.toPublic().armor());
+  fakeKey = await readKey({ armoredKey: await fakeKey.toPublic().armor() });
   const verifyAttackerIsBatman = await openpgp.verify({
-    message: (await readArmoredCleartextMessage(signed)),
+    message: await readCleartextMessage({ cleartextMessage: signed }),
     publicKeys: fakeKey,
     streaming: false
   });

--- a/test/security/unsigned_subpackets.js
+++ b/test/security/unsigned_subpackets.js
@@ -1,6 +1,6 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 
-const { readArmoredKey, Key, message, enums, PacketList, SignaturePacket } = openpgp;
+const { readKey, Key, message, enums, PacketList, SignaturePacket } = openpgp;
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
@@ -49,7 +49,7 @@ Dc2vwS83Aja9iWrIEg==
 -----END PGP PRIVATE KEY BLOCK-----`;
 
 async function getInvalidKey() {
-  return readArmoredKey(INVALID_KEY);
+  return readKey({ armoredKey: INVALID_KEY });
 }
 async function makeKeyValid() {
   /**
@@ -85,7 +85,7 @@ async function makeKeyValid() {
   let modifiedkey = new Key(newlist);
   // re-read the message to eliminate any
   // behaviour due to cached values.
-  modifiedkey = await readArmoredKey(await modifiedkey.armor());
+  modifiedkey = await readKey({ armoredKey: await modifiedkey.armor() });
 
   expect(await encryptFails(invalidkey)).to.be.true;
   expect(await encryptFails(modifiedkey)).to.be.true;

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -6,7 +6,7 @@
  *  - if it fails to run, edit this file to match the actual library API, then edit the definitions file (openpgp.d.ts) accordingly.
  */
 
-import { generateKey, readArmoredKey, readArmoredKeys, Key, readMessage, readArmoredMessage, Message, CleartextMessage, encrypt, decrypt, sign, verify } from '../..';
+import { generateKey, readKey, readKeys, Key, readMessage, Message, CleartextMessage, encrypt, decrypt, sign, verify } from '../..';
 import { expect } from 'chai';
 
 (async () => {
@@ -18,8 +18,8 @@ import { expect } from 'chai';
   const publicKeys = [key.toPublic()];
 
   // Parse keys
-  expect(await readArmoredKey(publicKeyArmored)).to.be.instanceOf(Key);
-  expect(await readArmoredKeys(publicKeyArmored)).to.have.lengthOf(1);
+  expect(await readKey({ armoredKey: publicKeyArmored })).to.be.instanceOf(Key);
+  expect(await readKeys({ armoredKeys: publicKeyArmored })).to.have.lengthOf(1);
 
   // Encrypt text message (armored)
   const text = 'hello';
@@ -36,19 +36,19 @@ import { expect } from 'chai';
   expect(encryptedBinary).to.be.instanceOf(Uint8Array);
 
   // Decrypt text message (armored)
-  const encryptedTextMessage = await readArmoredMessage(encryptedArmor);
+  const encryptedTextMessage = await readMessage({ armoredMessage: encryptedArmor });
   const decryptedText = await decrypt({ privateKeys, message: encryptedTextMessage });
   const decryptedTextData: string = decryptedText.data;
   expect(decryptedTextData).to.equal(text);
 
   // Decrypt binary message (unarmored)
-  const encryptedBinaryMessage = await readMessage(encryptedBinary);
+  const encryptedBinaryMessage = await readMessage({ binaryMessage: encryptedBinary });
   const decryptedBinary = await decrypt({ privateKeys, message: encryptedBinaryMessage, format: 'binary' });
   const decryptedBinaryData: Uint8Array = decryptedBinary.data;
   expect(decryptedBinaryData).to.deep.equal(binary);
 
   // Encrypt message (inspect packets)
-  const encryptedMessage = await readMessage(encryptedBinary);
+  const encryptedMessage = await readMessage({ binaryMessage: encryptedBinary });
   expect(encryptedMessage).to.be.instanceOf(Message);
 
   // Sign cleartext message (armored)
@@ -65,13 +65,13 @@ import { expect } from 'chai';
   expect(textSignedBinary).to.be.instanceOf(Uint8Array);
 
   // Verify signed text message (armored)
-  const signedMessage = await readArmoredMessage(textSignedArmor);
+  const signedMessage = await readMessage({ armoredMessage: textSignedArmor });
   const verifiedText = await verify({ publicKeys, message: signedMessage });
   const verifiedTextData: string = verifiedText.data;
   expect(verifiedTextData).to.equal(text);
 
   // Verify signed binary message (unarmored)
-  const message = await readMessage(textSignedBinary);
+  const message = await readMessage({ binaryMessage: textSignedBinary });
   const verifiedBinary = await verify({ publicKeys, message, format: 'binary' });
   const verifiedBinaryData: Uint8Array = verifiedBinary.data;
   expect(verifiedBinaryData).to.deep.equal(binary);

--- a/test/worker/worker_example.js
+++ b/test/worker/worker_example.js
@@ -44,8 +44,8 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
     let result;
     switch (action) {
       case 'encrypt': {
-        const publicKey = await openpgp.readArmoredKey(publicKeyArmored);
-        const privateKey = await openpgp.readArmoredKey(privateKeyArmored);
+        const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
+        const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
         await privateKey.decrypt('test');
         const data = await openpgp.encrypt({
           message: openpgp.Message.fromText(message),
@@ -56,11 +56,11 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
         break;
       }
       case 'decrypt': {
-        const publicKey = await openpgp.readArmoredKey(publicKeyArmored);
-        const privateKey = await openpgp.readArmoredKey(privateKeyArmored);
+        const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
+        const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
         await privateKey.decrypt('test');
         const { data, signatures } = await openpgp.decrypt({
-          message: await openpgp.readArmoredMessage(message),
+          message: await openpgp.readMessage({ armoredMessage: message }),
           publicKeys: publicKey,
           privateKeys: privateKey
         });


### PR DESCRIPTION
Make all `read*` functions accept an options object, so that we can add config options to them later (for #1166). This is necessary so that we can remove the global `openpgp.config`, which doesn't work that well when importing individual functions.

Furthermore, merge `readMessage` and `readArmoredMessage` into one function, et cetera.