### PR TITLE
Pass configuration to top-level functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -207,7 +207,7 @@ module.exports = {
     "no-param-reassign": "off",
     "no-path-concat": "error",
     "no-plusplus": "off",
-    "no-process-env": "off",
+    "no-process-env": "error",
     "no-process-exit": "error",
     "no-proto": "error",
     "no-prototype-builtins": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -207,7 +207,7 @@ module.exports = {
     "no-param-reassign": "off",
     "no-path-concat": "error",
     "no-plusplus": "off",
-    "no-process-env": "error",
+    "no-process-env": "off",
     "no-process-exit": "error",
     "no-proto": "error",
     "no-prototype-builtins": "off",

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ library to convert back and forth between them.
 
 * Version 2.x of the library has been built from the ground up with Uint8Arrays. This allows for much better performance and memory usage than strings.
 
-* If the user's browser supports [native WebCrypto](https://caniuse.com/#feat=cryptography) via the `window.crypto.subtle` API, this will be used. Under Node.js the native [crypto module](https://nodejs.org/api/crypto.html#crypto_crypto) is used. This can be deactivated by setting `openpgp.config.useNative = false`.
+* If the user's browser supports [native WebCrypto](https://caniuse.com/#feat=cryptography) via the `window.crypto.subtle` API, this will be used. Under Node.js the native [crypto module](https://nodejs.org/api/crypto.html#crypto_crypto) is used.
 
 * The library implements the [IETF proposal](https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-07) for authenticated encryption using native AES-EAX, OCB, or GCM. This makes symmetric encryption up to 30x faster on supported platforms. Since the specification has not been finalized and other OpenPGP implementations haven't adopted it yet, the feature is currently behind a flag. **Note: activating this setting can break compatibility with other OpenPGP implementations, and also with future versions of OpenPGP.js. Don't use it with messages you want to store on disk or in a database.** You can enable it by setting `openpgp.config.aeadProtect = true`.
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -35,7 +35,7 @@ export class Key {
   public getUserIds(): string[];
   public isPrivate(): boolean;
   public isPublic(): boolean;
-  public toPublic(config?: Config): Key;
+  public toPublic(): Key;
   public update(key: Key, config?: Config): void;
   public verifyPrimaryKey(date?: Date, userId?: UserID, config?: Config): Promise<void>; // throws on error
   public isRevoked(signature: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
@@ -125,12 +125,12 @@ export class CleartextMessage {
    *
    *  @param privateKeys private keys with decrypted secret key data for signing
    */
-  sign(privateKeys: Key[], signature?: Signature, signingKeyIds?: Keyid[], date?: Date, userIds?: UserID[], streaming?: boolean, config?: Config): void;
+  sign(privateKeys: Key[], signature?: Signature, signingKeyIds?: Keyid[], date?: Date, userIds?: UserID[], config?: Config): void;
 
   /** Verify signatures of cleartext signed message
    *  @param keys array of keys to verify signatures
    */
-  verify(keys: Key[], date?: Date, streaming?: boolean, config?: Config): Promise<VerificationResult[]>;
+  verify(keys: Key[], date?: Date, config?: Config): Promise<VerificationResult[]>;
 
   static fromText(text: string): CleartextMessage;
 }

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -314,7 +314,6 @@ export namespace config {
   let minRsaBits: number;
   let passwordCollisionCheck: boolean;
   let revocationsExpire: boolean;
-  let useNative: boolean;
   let zeroCopy: boolean;
   let tolerant: boolean;
   let versionString: string;

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -74,8 +74,8 @@ export class CleartextMessage {
    * @returns {Promise<module:cleartext.CleartextMessage>} new cleartext message with signed content
    * @async
    */
-  async sign(privateKeys, signature = null, signingKeyIds = [], date = new Date(), userIds = [], streaming, config = defaultConfig) {
-    return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, signingKeyIds, date, userIds, undefined, config));
+  async sign(privateKeys, signature = null, signingKeyIds = [], date = new Date(), userIds = [], config = defaultConfig) {
+    return new CleartextMessage(this.text, await this.signDetached(privateKeys, signature, signingKeyIds, date, userIds, config));
   }
 
   /**
@@ -89,7 +89,7 @@ export class CleartextMessage {
    * @returns {Promise<module:signature.Signature>}      new detached signature of message content
    * @async
    */
-  async signDetached(privateKeys, signature = null, signingKeyIds = [], date = new Date(), userIds = [], streaming, config = defaultConfig) {
+  async signDetached(privateKeys, signature = null, signingKeyIds = [], date = new Date(), userIds = [], config = defaultConfig) {
     const literalDataPacket = new LiteralDataPacket();
     literalDataPacket.setText(this.text);
 
@@ -104,8 +104,8 @@ export class CleartextMessage {
    * @returns {Promise<Array<{keyid: module:type/keyid, valid: Boolean}>>} list of signer's keyid and validity of signature
    * @async
    */
-  verify(keys, date = new Date(), streaming, config = defaultConfig) {
-    return this.verifyDetached(this.signature, keys, date, null, config);
+  verify(keys, date = new Date(), config = defaultConfig) {
+    return this.verifyDetached(this.signature, keys, date, config);
   }
 
   /**
@@ -116,7 +116,7 @@ export class CleartextMessage {
    * @returns {Promise<Array<{keyid: module:type/keyid, valid: Boolean}>>} list of signer's keyid and validity of signature
    * @async
    */
-  verifyDetached(signature, keys, date = new Date(), streaming, config = defaultConfig) {
+  verifyDetached(signature, keys, date = new Date(), config = defaultConfig) {
     const signatureList = signature.packets;
     const literalDataPacket = new LiteralDataPacket();
     // we assume that cleartext signature is generated based on UTF8 cleartext

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -70,6 +70,7 @@ export class CleartextMessage {
    * @param  {Array<module:type/keyid>} signingKeyIds (optional) array of key IDs to use for signing. Each signingKeyIds[i] corresponds to privateKeys[i]
    * @param  {Date} date                       (optional) The creation time of the signature that should be created
    * @param  {Array} userIds                   (optional) user IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param  {Object} config                   (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:cleartext.CleartextMessage>} new cleartext message with signed content
    * @async
    */
@@ -84,6 +85,7 @@ export class CleartextMessage {
    * @param  {Array<module:type/keyid>} signingKeyIds (optional) array of key IDs to use for signing. Each signingKeyIds[i] corresponds to privateKeys[i]
    * @param  {Date} date                       (optional) The creation time of the signature that should be created
    * @param  {Array} userIds                   (optional) user IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param  {Object} config                   (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:signature.Signature>}      new detached signature of message content
    * @async
    */
@@ -98,10 +100,11 @@ export class CleartextMessage {
    * Verify signatures of cleartext signed message
    * @param {Array<module:key.Key>} keys array of keys to verify signatures
    * @param {Date} date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
+   * @param {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{keyid: module:type/keyid, valid: Boolean}>>} list of signer's keyid and validity of signature
    * @async
    */
-  verify(keys, date = new Date(), streaming, config) {
+  verify(keys, date = new Date(), streaming, config = defaultConfig) {
     return this.verifyDetached(this.signature, keys, date, null, config);
   }
 
@@ -109,6 +112,7 @@ export class CleartextMessage {
    * Verify signatures of cleartext signed message
    * @param {Array<module:key.Key>} keys array of keys to verify signatures
    * @param {Date} date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
+   * @param {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{keyid: module:type/keyid, valid: Boolean}>>} list of signer's keyid and validity of signature
    * @async
    */
@@ -131,6 +135,7 @@ export class CleartextMessage {
 
   /**
    * Returns ASCII armored text of cleartext signed message
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {String | ReadableStream<String>} ASCII armor
    */
   armor(config = defaultConfig) {
@@ -160,6 +165,7 @@ export class CleartextMessage {
 /**
  * Reads an OpenPGP cleartext signed message and returns a CleartextMessage object
  * @param {String | ReadableStream<String>} cleartextMessage text to be parsed
+ * @param {Object} config (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {module:cleartext.CleartextMessage} new cleartext message object
  * @async
  * @static

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -143,7 +143,7 @@ export class CleartextMessage {
       text: this.text,
       data: this.signature.packets.write()
     };
-    return armor(enums.armor.signed, body, null, null, null, config);
+    return armor(enums.armor.signed, body, undefined, undefined, undefined, config);
   }
 
   /**
@@ -164,7 +164,8 @@ export class CleartextMessage {
  * @async
  * @static
  */
-export async function readCleartextMessage({ cleartextMessage, config = defaultConfig }) {
+export async function readCleartextMessage({ cleartextMessage, config }) {
+  config = { ...defaultConfig, ...config };
   if (!cleartextMessage) {
     throw new Error('readCleartextMessage: must pass options object containing `cleartextMessage`');
   }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -131,11 +131,6 @@ export default {
 
   /**
    * @memberof module:config
-   * @property {Boolean} useNative Use native Node.js crypto/zlib and WebCrypto APIs when available
-   */
-  useNative: true, // TODO remove
-  /**
-   * @memberof module:config
    * @property {Integer} minBytesForWebCrypto The minimum amount of bytes for which to use native WebCrypto APIs when available
    */
   minBytesForWebCrypto: 1000,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -105,11 +105,6 @@ export default {
   checksumRequired: false,
   /**
    * @memberof module:config
-   * @property {Boolean} rsaBlinding
-   */
-  rsaBlinding: true,
-  /**
-   * @memberof module:config
    * @property {Number} minRsaBits Minimum RSA key size allowed for key generation
    */
   minRsaBits: 2048,
@@ -138,17 +133,12 @@ export default {
    * @memberof module:config
    * @property {Boolean} useNative Use native Node.js crypto/zlib and WebCrypto APIs when available
    */
-  useNative: true,
+  useNative: true, // TODO remove
   /**
    * @memberof module:config
    * @property {Integer} minBytesForWebCrypto The minimum amount of bytes for which to use native WebCrypto APIs when available
    */
   minBytesForWebCrypto: 1000,
-  /**
-   * @memberof module:config
-   * @property {Boolean} debug If enabled, debug messages will be printed
-   */
-  debug: false,
   /**
    * @memberof module:config
    * @property {Boolean} tolerant Ignore unsupported/unrecognizable packets instead of throwing an error

--- a/src/crypto/cfb.js
+++ b/src/crypto/cfb.js
@@ -28,7 +28,6 @@ import { AES_CFB } from 'asmcrypto.js/dist_es8/aes/cfb';
 
 import stream from 'web-stream-tools';
 import * as cipher from './cipher';
-import config from '../config';
 import util from '../util';
 
 const webCrypto = util.getWebCrypto();
@@ -47,12 +46,12 @@ const nodeAlgos = {
   /* twofish is not implemented in OpenSSL */
 };
 
-export async function encrypt(algo, key, plaintext, iv) {
+export async function encrypt(algo, key, plaintext, iv, config) {
   if (util.getNodeCrypto() && nodeAlgos[algo]) { // Node crypto library.
     return nodeEncrypt(algo, key, plaintext, iv);
   }
   if (algo.substr(0, 3) === 'aes') {
-    return aesEncrypt(algo, key, plaintext, iv);
+    return aesEncrypt(algo, key, plaintext, iv, config);
   }
 
   const cipherfn = new cipher[algo](key);
@@ -113,7 +112,7 @@ export async function decrypt(algo, key, ciphertext, iv) {
   return stream.transform(ciphertext, process, process);
 }
 
-function aesEncrypt(algo, key, pt, iv) {
+function aesEncrypt(algo, key, pt, iv, config) {
   if (
     util.getWebCrypto() &&
     key.length !== 24 && // Chrome doesn't support 192 bit keys, see https://www.chromium.org/blink/webcrypto#TOC-AES-support

--- a/src/crypto/hash/index.js
+++ b/src/crypto/hash/index.js
@@ -6,7 +6,6 @@
  * @requires hash.js
  * @requires web-stream-tools
  * @requires crypto/hash/md5
- * @requires config
  * @requires util
  * @module crypto/hash
  */
@@ -19,8 +18,8 @@ import sha512 from 'hash.js/lib/hash/sha/512';
 import { ripemd160 } from 'hash.js/lib/hash/ripemd';
 import stream from 'web-stream-tools';
 import md5 from './md5';
-import config from '../../config';
 import util from '../../util';
+import defaultConfig from '../../config';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -36,7 +35,7 @@ function node_hash(type) {
 }
 
 function hashjs_hash(hash, webCryptoHash) {
-  return async function(data) {
+  return async function(data, config = defaultConfig) {
     if (!util.isStream(data) && webCrypto && webCryptoHash && data.length >= config.minBytesForWebCrypto) {
       return new Uint8Array(await webCrypto.digest(webCryptoHash, data));
     }
@@ -48,7 +47,7 @@ function hashjs_hash(hash, webCryptoHash) {
 }
 
 function asmcrypto_hash(hash, webCryptoHash) {
-  return async function(data) {
+  return async function(data, config = defaultConfig) {
     if (util.isStream(data)) {
       const hashInstance = new hash();
       return stream.transform(data, value => {

--- a/src/crypto/random.js
+++ b/src/crypto/random.js
@@ -24,8 +24,7 @@
  */
 import util from '../util';
 
-// Do not use util.getNodeCrypto because we need this regardless of useNative setting
-const nodeCrypto = util.detectNode() && require('crypto');
+const nodeCrypto = util.getNodeCrypto();
 
 /**
  * Buffer for secure random numbers

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -27,8 +27,8 @@
 import stream from 'web-stream-tools';
 import * as base64 from './base64.js';
 import enums from '../enums.js';
-import config from '../config';
 import util from '../util';
+import defaultConfig from '../config';
 
 /**
  * Finds out which Ascii Armoring type is used. Throws error if unknown type.
@@ -100,7 +100,7 @@ function getType(text) {
  * @param {String} customComment (optional) additional comment to add to the armored string
  * @returns {String} The header information
  */
-function addheader(customComment) {
+function addheader(customComment, config) {
   let result = "";
   if (config.showVersion) {
     result += "Version: " + config.versionString + '\n';
@@ -233,7 +233,7 @@ function splitChecksum(text) {
  * @async
  * @static
  */
-export function unarmor(input) {
+export function unarmor(input, config = defaultConfig) {
   return new Promise(async (resolve, reject) => {
     try {
       const reSplit = /^-----[^-]+-----$/m;
@@ -359,7 +359,7 @@ export function unarmor(input) {
  * @returns {String | ReadableStream<String>} Armored text
  * @static
  */
-export function armor(messagetype, body, partindex, parttotal, customComment) {
+export function armor(messagetype, body, partindex, parttotal, customComment, config = defaultConfig) {
   let text;
   let hash;
   if (messagetype === enums.armor.signed) {
@@ -372,14 +372,14 @@ export function armor(messagetype, body, partindex, parttotal, customComment) {
   switch (messagetype) {
     case enums.armor.multipartSection:
       result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP MESSAGE, PART " + partindex + "/" + parttotal + "-----\n");
       break;
     case enums.armor.multipartLast:
       result.push("-----BEGIN PGP MESSAGE, PART " + partindex + "-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP MESSAGE, PART " + partindex + "-----\n");
@@ -389,35 +389,35 @@ export function armor(messagetype, body, partindex, parttotal, customComment) {
       result.push("Hash: " + hash + "\n\n");
       result.push(text.replace(/^-/mg, "- -"));
       result.push("\n-----BEGIN PGP SIGNATURE-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP SIGNATURE-----\n");
       break;
     case enums.armor.message:
       result.push("-----BEGIN PGP MESSAGE-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP MESSAGE-----\n");
       break;
     case enums.armor.publicKey:
       result.push("-----BEGIN PGP PUBLIC KEY BLOCK-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP PUBLIC KEY BLOCK-----\n");
       break;
     case enums.armor.privateKey:
       result.push("-----BEGIN PGP PRIVATE KEY BLOCK-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP PRIVATE KEY BLOCK-----\n");
       break;
     case enums.armor.signature:
       result.push("-----BEGIN PGP SIGNATURE-----\n");
-      result.push(addheader(customComment));
+      result.push(addheader(customComment, config));
       result.push(base64.encode(body));
       result.push("=", getCheckSum(bodyClone));
       result.push("-----END PGP SIGNATURE-----\n");

--- a/src/hkp.js
+++ b/src/hkp.js
@@ -21,7 +21,7 @@
  * @module hkp
  */
 
-import config from './config';
+import defaultConfig from './config';
 
 class HKP {
   /**
@@ -30,7 +30,7 @@ class HKP {
    *   the protocol to use, e.g. 'https://pgp.mit.edu'; defaults to
    *   openpgp.config.keyserver (https://keyserver.ubuntu.com)
    */
-  constructor(keyServerBaseUrl) {
+  constructor(keyServerBaseUrl, config = defaultConfig) {
     this._baseUrl = keyServerBaseUrl || config.keyserver;
     this._fetch = typeof globalThis.fetch === 'function' ? globalThis.fetch : require('node-fetch');
   }

--- a/src/hkp.js
+++ b/src/hkp.js
@@ -29,6 +29,7 @@ class HKP {
    * @param {String}    keyServerBaseUrl  (optional) The HKP key server base url including
    *   the protocol to use, e.g. 'https://pgp.mit.edu'; defaults to
    *   openpgp.config.keyserver (https://keyserver.ubuntu.com)
+   * @param {Object}    config (optional) full configuration, defaults to openpgp.config
    */
   constructor(keyServerBaseUrl, config = defaultConfig) {
     this._baseUrl = keyServerBaseUrl || config.keyserver;

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -45,6 +45,7 @@ import { unarmor } from '../encoding/armor';
  * @param {String}  options.passphrase            Passphrase used to encrypt the resulting private key
  * @param {Number}  options.keyExpirationTime     (optional) Number of seconds from the key creation time after which the key expires
  * @param {Date}    options.date                  Creation date of the key and the key signatures
+ * @param {Object}  config                        Full configuration
  * @param {Array<Object>} options.subkeys         (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
  *                                                  sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
  * @returns {Promise<module:key.Key>}
@@ -68,6 +69,7 @@ export async function generate(options, config) {
  * @param {Number} options.keyExpirationTime      Number of seconds from the key creation time after which the key expires
  * @param {Date}   options.date                   Override the creation date of the key and the key signatures
  * @param {Array<Object>} options.subkeys         (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
+ * @param {Object} config                         Full configuration
  *
  * @returns {Promise<module:key.Key>}
  * @async

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -254,11 +254,13 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
  * Reads an (optionally armored) OpenPGP key and returns a key object
  * @param {String} armoredKey armored key to be parsed
  * @param {Uint8Array} binaryKey binary key to be parsed
+ * @param {Object} config (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Key>} key object
  * @async
  * @static
  */
-export async function readKey({ armoredKey, binaryKey, config = defaultConfig }) {
+export async function readKey({ armoredKey, binaryKey, config }) {
+  config = { ...defaultConfig, ...config };
   if (!armoredKey && !binaryKey) {
     throw new Error('readKey: must pass options object containing `armoredKey` or `binaryKey`');
   }
@@ -281,11 +283,13 @@ export async function readKey({ armoredKey, binaryKey, config = defaultConfig })
  * Reads an (optionally armored) OpenPGP key block and returns a list of key objects
  * @param {String | ReadableStream<String>} armoredKeys armored keys to be parsed
  * @param {Uint8Array | ReadableStream<Uint8Array>} binaryKeys binary keys to be parsed
+ * @param {Object} config (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Array<Key>>} key objects
  * @async
  * @static
  */
-export async function readKeys({ armoredKeys, binaryKeys, config = defaultConfig }) {
+export async function readKeys({ armoredKeys, binaryKeys, config }) {
+  config = { ...defaultConfig, ...config };
   let input = armoredKeys || binaryKeys;
   if (!input) {
     throw new Error('readKeys: must pass options object containing `armoredKeys` or `binaryKeys`');

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -51,6 +51,7 @@ export async function generateSecretKey(options, config) {
  * Returns the valid and non-expired signature that has the latest creation date, while ignoring signatures created in the future.
  * @param  {Array<SignaturePacket>}         signatures  List of signatures
  * @param  {Date}                           date        Use the given date instead of the current time
+ * @param  {Object} config full configuration
  * @returns {Promise<SignaturePacket>} The latest valid signature
  * @async
  */
@@ -97,6 +98,7 @@ export function isDataExpired(keyPacket, signature, date = new Date()) {
  * @param {SecretSubkeyPacket} subkey Subkey key packet
  * @param {SecretKeyPacket} primaryKey Primary key packet
  * @param {Object} options
+ * @param {Object} config full configuration
  */
 export async function createBindingSignature(subkey, primaryKey, options, config) {
   const dataToSign = {};
@@ -128,6 +130,7 @@ export async function createBindingSignature(subkey, primaryKey, options, config
  * @param  {SecretKeyPacket|SecretSubkeyPacket} keyPacket key packet used for signing
  * @param  {Date} date (optional) use the given date for verification instead of the current time
  * @param  {Object} userId (optional) user ID
+ * @param  {Object} config full configuration
  * @returns {Promise<String>}
  * @async
  */
@@ -164,6 +167,7 @@ export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), us
  * @param  {Array<module:key.Key>} keys Set of keys
  * @param  {Date} date (optional) use the given date for verification instead of the current time
  * @param  {Array} userIds (optional) user IDs
+ * @param  {Object} config (optional) full configuration, defaults to openpgp.config
  * @returns {Promise<module:enums.symmetric>}   Preferred symmetric algorithm
  * @async
  */
@@ -207,6 +211,7 @@ export async function getPreferredAlgo(type, keys, date = new Date(), userIds = 
  * @param  {Object} userId                   (optional) user ID
  * @param  {Object} detached                 (optional) whether to create a detached signature packet
  * @param  {Boolean} streaming               (optional) whether to process data as a stream
+ * @param  {Object} config                   full configuration
  * @returns {module:packet/signature}         signature packet
  */
 export async function createSignaturePacket(dataToSign, privateKey, signingKeyPacket, signatureProperties, date, userId, detached = false, streaming = false, config) {
@@ -262,6 +267,7 @@ export async function mergeSignatures(source, dest, attr, checkFn) {
  *          PublicKeyPacket|
  *          SecretKeyPacket} key, optional The key packet to check the signature
  * @param  {Date}                     date          Use the given date instead of the current time
+ * @param {Object} config full configuration
  * @returns {Promise<Boolean>}                      True if the signature revokes the data
  * @async
  */
@@ -313,6 +319,7 @@ export function getExpirationTime(keyPacket, signature) {
  * @param  {Array<module:key.Key>} keys Set of keys
  * @param  {Date} date (optional) use the given date for verification instead of the current time
  * @param  {Array} userIds (optional) user IDs
+ * @param  {Object} config full configuration
  * @returns {Promise<Boolean>}
  * @async
  */

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -17,9 +17,9 @@ import {
   SignaturePacket
 } from '../packet';
 import enums from '../enums';
-import config from '../config';
 import crypto from '../crypto';
 import util from '../util';
+import defaultConfig from '../config';
 
 export const allowedKeyPackets = {
   PublicKeyPacket,
@@ -31,19 +31,19 @@ export const allowedKeyPackets = {
   SignaturePacket
 };
 
-export async function generateSecretSubkey(options) {
-  const secretSubkeyPacket = new SecretSubkeyPacket(options.date);
+export async function generateSecretSubkey(options, config) {
+  const secretSubkeyPacket = new SecretSubkeyPacket(options.date, config);
   secretSubkeyPacket.packets = null;
   secretSubkeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
   await secretSubkeyPacket.generate(options.rsaBits, options.curve);
   return secretSubkeyPacket;
 }
 
-export async function generateSecretKey(options) {
-  const secretKeyPacket = new SecretKeyPacket(options.date);
+export async function generateSecretKey(options, config) {
+  const secretKeyPacket = new SecretKeyPacket(options.date, config);
   secretKeyPacket.packets = null;
   secretKeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
-  await secretKeyPacket.generate(options.rsaBits, options.curve);
+  await secretKeyPacket.generate(options.rsaBits, options.curve, options.config);
   return secretKeyPacket;
 }
 
@@ -54,7 +54,7 @@ export async function generateSecretKey(options) {
  * @returns {Promise<SignaturePacket>} The latest valid signature
  * @async
  */
-export async function getLatestValidSignature(signatures, primaryKey, signatureType, dataToVerify, date = new Date()) {
+export async function getLatestValidSignature(signatures, primaryKey, signatureType, dataToVerify, date = new Date(), config) {
   let signature;
   let exception;
   for (let i = signatures.length - 1; i >= 0; i--) {
@@ -65,7 +65,7 @@ export async function getLatestValidSignature(signatures, primaryKey, signatureT
         !signatures[i].isExpired(date)
       ) {
         // check binding signature is verified
-        signatures[i].verified || await signatures[i].verify(primaryKey, signatureType, dataToVerify);
+        signatures[i].verified || await signatures[i].verify(primaryKey, signatureType, dataToVerify, undefined, undefined, config);
         signature = signatures[i];
       }
     } catch (e) {
@@ -98,19 +98,19 @@ export function isDataExpired(keyPacket, signature, date = new Date()) {
  * @param {SecretKeyPacket} primaryKey Primary key packet
  * @param {Object} options
  */
-export async function createBindingSignature(subkey, primaryKey, options) {
+export async function createBindingSignature(subkey, primaryKey, options, config) {
   const dataToSign = {};
   dataToSign.key = primaryKey;
   dataToSign.bind = subkey;
   const subkeySignaturePacket = new SignaturePacket(options.date);
   subkeySignaturePacket.signatureType = enums.signature.subkeyBinding;
   subkeySignaturePacket.publicKeyAlgorithm = primaryKey.algorithm;
-  subkeySignaturePacket.hashAlgorithm = await getPreferredHashAlgo(null, subkey);
+  subkeySignaturePacket.hashAlgorithm = await getPreferredHashAlgo(null, subkey, undefined, undefined, config);
   if (options.sign) {
     subkeySignaturePacket.keyFlags = [enums.keyFlags.signData];
     subkeySignaturePacket.embeddedSignature = await createSignaturePacket(dataToSign, null, subkey, {
       signatureType: enums.signature.keyBinding
-    }, options.date);
+    }, options.date, undefined, undefined, undefined, config);
   } else {
     subkeySignaturePacket.keyFlags = [enums.keyFlags.encryptCommunication | enums.keyFlags.encryptStorage];
   }
@@ -131,11 +131,11 @@ export async function createBindingSignature(subkey, primaryKey, options) {
  * @returns {Promise<String>}
  * @async
  */
-export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), userId = {}) {
+export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), userId = {}, config) {
   let hash_algo = config.preferHashAlgorithm;
   let pref_algo = hash_algo;
   if (key) {
-    const primaryUser = await key.getPrimaryUser(date, userId);
+    const primaryUser = await key.getPrimaryUser(date, userId, config);
     if (primaryUser.selfCertification.preferredHashAlgorithms) {
       [pref_algo] = primaryUser.selfCertification.preferredHashAlgorithms;
       hash_algo = crypto.hash.getHashByteLength(hash_algo) <= crypto.hash.getHashByteLength(pref_algo) ?
@@ -167,12 +167,12 @@ export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), us
  * @returns {Promise<module:enums.symmetric>}   Preferred symmetric algorithm
  * @async
  */
-export async function getPreferredAlgo(type, keys, date = new Date(), userIds = []) {
+export async function getPreferredAlgo(type, keys, date = new Date(), userIds = [], config = defaultConfig) {
   const prefProperty = type === 'symmetric' ? 'preferredSymmetricAlgorithms' : 'preferredAeadAlgorithms';
   const defaultAlgo = type === 'symmetric' ? enums.symmetric.aes128 : enums.aead.eax;
   const prioMap = {};
   await Promise.all(keys.map(async function(key, i) {
-    const primaryUser = await key.getPrimaryUser(date, userIds[i]);
+    const primaryUser = await key.getPrimaryUser(date, userIds[i], config);
     if (!primaryUser.selfCertification[prefProperty]) {
       return defaultAlgo;
     }
@@ -209,7 +209,7 @@ export async function getPreferredAlgo(type, keys, date = new Date(), userIds = 
  * @param  {Boolean} streaming               (optional) whether to process data as a stream
  * @returns {module:packet/signature}         signature packet
  */
-export async function createSignaturePacket(dataToSign, privateKey, signingKeyPacket, signatureProperties, date, userId, detached = false, streaming = false) {
+export async function createSignaturePacket(dataToSign, privateKey, signingKeyPacket, signatureProperties, date, userId, detached = false, streaming = false, config) {
   if (signingKeyPacket.isDummy()) {
     throw new Error('Cannot sign with a gnu-dummy key.');
   }
@@ -219,7 +219,7 @@ export async function createSignaturePacket(dataToSign, privateKey, signingKeyPa
   const signaturePacket = new SignaturePacket(date);
   Object.assign(signaturePacket, signatureProperties);
   signaturePacket.publicKeyAlgorithm = signingKeyPacket.algorithm;
-  signaturePacket.hashAlgorithm = await getPreferredHashAlgo(privateKey, signingKeyPacket, date, userId);
+  signaturePacket.hashAlgorithm = await getPreferredHashAlgo(privateKey, signingKeyPacket, date, userId, config);
   await signaturePacket.sign(signingKeyPacket, dataToSign, detached, streaming);
   return signaturePacket;
 }
@@ -265,7 +265,7 @@ export async function mergeSignatures(source, dest, attr, checkFn) {
  * @returns {Promise<Boolean>}                      True if the signature revokes the data
  * @async
  */
-export async function isDataRevoked(primaryKey, signatureType, dataToVerify, revocations, signature, key, date = new Date()) {
+export async function isDataRevoked(primaryKey, signatureType, dataToVerify, revocations, signature, key, date = new Date(), config) {
   key = key || primaryKey;
   const normDate = util.normalizeDate(date);
   const revocationKeyIds = [];
@@ -283,7 +283,7 @@ export async function isDataRevoked(primaryKey, signatureType, dataToVerify, rev
         (!signature || revocationSignature.issuerKeyId.equals(signature.issuerKeyId)) &&
         !(config.revocationsExpire && revocationSignature.isExpired(normDate))
       ) {
-        revocationSignature.verified || await revocationSignature.verify(key, signatureType, dataToVerify);
+        revocationSignature.verified || await revocationSignature.verify(key, signatureType, dataToVerify, undefined, undefined, config);
 
         // TODO get an identifier of the revoked object instead
         revocationKeyIds.push(revocationSignature.issuerKeyId);
@@ -316,11 +316,11 @@ export function getExpirationTime(keyPacket, signature) {
  * @returns {Promise<Boolean>}
  * @async
  */
-export async function isAeadSupported(keys, date = new Date(), userIds = []) {
+export async function isAeadSupported(keys, date = new Date(), userIds = [], config = defaultConfig) {
   let supported = true;
   // TODO replace when Promise.some or Promise.any are implemented
   await Promise.all(keys.map(async function(key, i) {
-    const primaryUser = await key.getPrimaryUser(date, userIds[i]);
+    const primaryUser = await key.getPrimaryUser(date, userIds[i], config);
     if (!primaryUser.selfCertification.features ||
         !(primaryUser.selfCertification.features[0] & enums.features.aead)) {
       supported = false;
@@ -388,7 +388,7 @@ export function isValidEncryptionKeyPacket(keyPacket, signature) {
       (signature.keyFlags[0] & enums.keyFlags.encryptStorage) !== 0);
 }
 
-export function isValidDecryptionKeyPacket(signature) {
+export function isValidDecryptionKeyPacket(signature, config) {
   if (!signature.verified) { // Sanity check
     throw new Error('Signature not verified');
   }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -239,6 +239,7 @@ class Key {
 
   /**
    * Returns key as public key (shallow copy)
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {module:key.Key} new public Key
    */
   toPublic(config = defaultConfig) {
@@ -270,6 +271,7 @@ class Key {
 
   /**
    * Returns ASCII armored text of key
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {ReadableStream<String>} ASCII armor
    */
   armor(config = defaultConfig) {
@@ -282,6 +284,7 @@ class Key {
    * @param  {module:type/keyid} keyId, optional
    * @param  {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId, optional user ID
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key|module:key~SubKey|null>} key or null if no signing key has been found
    * @async
    */
@@ -322,6 +325,7 @@ class Key {
    * @param  {module:type/keyid} keyId, optional
    * @param  {Date}              date, optional
    * @param  {String}            userId, optional
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key|module:key~SubKey|null>} key or null if no encryption key has been found
    * @async
    */
@@ -360,10 +364,11 @@ class Key {
    * @param  {module:type/keyid} keyId, optional
    * @param  {Date}              date, optional
    * @param  {String}            userId, optional
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Array<module:key.Key|module:key~SubKey>>} array of decryption keys
    * @async
    */
-  async getDecryptionKeys(keyId, date = new Date(), userId = {}, config) {
+  async getDecryptionKeys(keyId, date = new Date(), userId = {}, config = defaultConfig) {
     const primaryKey = this.keyPacket;
     const keys = [];
     for (let i = 0; i < this.subKeys.length; i++) {
@@ -392,6 +397,7 @@ class Key {
    * Encrypts all secret key and subkey packets matching keyId
    * @param  {String|Array<String>} passphrases - if multiple passphrases, then should be in same order as packets each should encrypt
    * @param  {module:type/keyid} keyId
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if encryption failed for any key or subkey
    * @async
    */
@@ -417,6 +423,7 @@ class Key {
    * Decrypts all secret key and subkey packets matching keyId
    * @param  {String|Array<String>} passphrases
    * @param  {module:type/keyid} keyId
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if any matching key or subkey packets did not decrypt successfully
    * @async
    */
@@ -464,10 +471,11 @@ class Key {
    * In case of gnu-dummy primary key, it is enough to validate any signing subkeys
    *   otherwise all encryption subkeys are validated
    * If only gnu-dummy keys are found, we cannot properly validate so we throw an error
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if validation was not successful and the key cannot be trusted
    * @async
    */
-  async validate(config) {
+  async validate(config = defaultConfig) {
     if (!this.isPrivate()) {
       throw new Error("Cannot validate a public key");
     }
@@ -522,10 +530,11 @@ class Key {
    *          PublicKeyPacket|
    *          SecretKeyPacket} key, optional The key to verify the signature
    * @param  {Date}                     date          Use the given date instead of the current time
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}                      True if the certificate is revoked
    * @async
    */
-  async isRevoked(signature, key, date = new Date(), config) {
+  async isRevoked(signature, key, date = new Date(), config = defaultConfig) {
     return helper.isDataRevoked(
       this.keyPacket, enums.signature.keyRevocation, { key: this.keyPacket }, this.revocationSignatures, signature, key, date, config
     );
@@ -534,8 +543,9 @@ class Key {
   /**
    * Verify primary key. Checks for revocation signatures, expiration time
    * and valid self signature. Throws if the primary key is invalid.
-   * @param {Date} date (optional) use the given date for verification instead of the current time
+   * @param  {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId (optional) user ID
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} If key verification failed
    * @async
    */
@@ -561,6 +571,7 @@ class Key {
    * @param  {encrypt|sign|encrypt_sign} capabilities, optional
    * @param  {module:type/keyid} keyId, optional
    * @param  {Object} userId, optional user ID
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Date | Infinity | null>}
    * @async
    */
@@ -595,6 +606,7 @@ class Key {
    * - otherwise, returns the user with the latest self signature
    * @param  {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId (optional) user ID to get instead of the primary user, if it exists
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<{user: module:key.User,
    *                    selfCertification: SignaturePacket}>} The primary user and the self signature
    * @async
@@ -650,6 +662,7 @@ class Key {
    * If the specified key is a private key and the destination key is public,
    * the destination key is transformed to a private key.
    * @param  {module:key.Key} key Source key to merge
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<undefined>}
    * @async
    */
@@ -714,6 +727,7 @@ class Key {
    * @param  {module:enums.reasonForRevocation} reasonForRevocation.flag optional, flag indicating the reason for revocation
    * @param  {String} reasonForRevocation.string optional, string explaining the reason for revocation
    * @param  {Date} date optional, override the creationtime of the revocation signature
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key>} new key with revocation signature
    * @async
    */
@@ -742,6 +756,7 @@ class Key {
    * Get revocation certificate from a revoked key.
    *   (To get a revocation certificate for an unrevoked key, call revoke() first.)
    * @param  {Date} date Use the given date instead of the current time
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<String>} armored revocation certificate
    * @async
    */
@@ -758,6 +773,7 @@ class Key {
    * This adds the first signature packet in the armored text to the key,
    * if it is a valid revocation signature.
    * @param  {String} revocationCertificate armored revocation certificate
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key>} new revoked key
    * @async
    */
@@ -790,6 +806,7 @@ class Key {
    * @param  {Array<module:key.Key>} privateKeys decrypted private keys for signing
    * @param  {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId (optional) user ID to get instead of the primary user, if it exists
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key>} new public key with new certificate signature
    * @async
    */
@@ -804,6 +821,7 @@ class Key {
   /**
    * Signs all users of key
    * @param  {Array<module:key.Key>} privateKeys decrypted private keys for signing
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key.Key>} new public key with new certificate signature
    * @async
    */
@@ -823,6 +841,7 @@ class Key {
    * @param  {Array<module:key.Key>} keys array of keys to verify certificate signatures
    * @param  {Date} date (optional) use the given date for verification instead of the current time
    * @param  {Object} userId (optional) user ID to get instead of the primary user, if it exists
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{keyid: module:type/keyid,
    *                          valid: Boolean}>>}    List of signer's keyid and validity of signature
    * @async
@@ -840,6 +859,7 @@ class Key {
    * - if no arguments are given, verifies the self certificates;
    * - otherwise, verifies all certificates signed with given keys.
    * @param  {Array<module:key.Key>} keys array of keys to verify certificate signatures
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{userid: String,
    *                          keyid: module:type/keyid,
    *                          valid: Boolean}>>} list of userid, signer's keyid and validity of signature
@@ -871,11 +891,12 @@ class Key {
    * @param {Number}  options.keyExpirationTime (optional) Number of seconds from the key creation time after which the key expires
    * @param {Date}    options.date       (optional) Override the creation date of the key and the key signatures
    * @param {Boolean} options.sign       (optional) Indicates whether the subkey should sign rather than encrypt. Defaults to false
+   * @param {Object}  options.config     (optional) custom configuration settings to overwrite those in openpgp.config
    * @returns {Promise<module:key.Key>}
    * @async
    */
   async addSubkey(options = {}) {
-    const config = options.config || defaultConfig;
+    const config = { ...defaultConfig, ...options.config };
     if (!this.isPrivate()) {
       throw new Error("Cannot add a subkey to a public key");
     }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -242,7 +242,7 @@ class Key {
    * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {module:key.Key} new public Key
    */
-  toPublic(config = defaultConfig) {
+  toPublic() {
     const packetlist = new PacketList();
     const keyPackets = this.toPacketlist();
     let bytes;
@@ -252,13 +252,13 @@ class Key {
       switch (keyPackets[i].tag) {
         case enums.packet.secretKey:
           bytes = keyPackets[i].writePublicKey();
-          pubKeyPacket = new PublicKeyPacket(undefined, config);
+          pubKeyPacket = new PublicKeyPacket();
           pubKeyPacket.read(bytes);
           packetlist.push(pubKeyPacket);
           break;
         case enums.packet.secretSubkey:
           bytes = keyPackets[i].writePublicKey();
-          pubSubkeyPacket = new PublicSubkeyPacket(undefined, config);
+          pubSubkeyPacket = new PublicSubkeyPacket();
           pubSubkeyPacket.read(bytes);
           packetlist.push(pubSubkeyPacket);
           break;

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -51,10 +51,11 @@ class SubKey {
    *          PublicKeyPacket|
    *          SecretKeyPacket} key, optional The key to verify the signature
    * @param  {Date}                     date          Use the given date instead of the current time
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}                      True if the binding signature is revoked
    * @async
    */
-  async isRevoked(primaryKey, signature, key, date = new Date(), config) {
+  async isRevoked(primaryKey, signature, key, date = new Date(), config = defaultConfig) {
     return helper.isDataRevoked(
       primaryKey, enums.signature.subkeyRevocation, {
         key: primaryKey,
@@ -69,6 +70,7 @@ class SubKey {
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket} primaryKey The primary key packet
    * @param  {Date}            date       Use the given date instead of the current time
+   * @param  {Object}          config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<SignaturePacket>}
    * @throws {Error}           if the subkey is invalid.
    * @async
@@ -94,6 +96,7 @@ class SubKey {
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket} primaryKey  The primary key packet
    * @param  {Date}            date        Use the given date instead of the current time
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Date | Infinity | null>}
    * @async
    */
@@ -115,10 +118,11 @@ class SubKey {
    * @param  {module:key~SubKey}  subKey     Source subkey to merge
    * @param  {SecretKeyPacket|
               SecretSubkeyPacket} primaryKey primary key used for validation
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if update failed
    * @async
    */
-  async update(subKey, primaryKey, config) {
+  async update(subKey, primaryKey, config = defaultConfig) {
     if (!this.hasSameFingerprintAs(subKey)) {
       throw new Error('SubKey update method: fingerprints of subkeys not equal');
     }
@@ -159,6 +163,7 @@ class SubKey {
    * @param  {module:enums.reasonForRevocation} reasonForRevocation.flag optional, flag indicating the reason for revocation
    * @param  {String} reasonForRevocation.string optional, string explaining the reason for revocation
    * @param  {Date} date optional, override the creationtime of the revocation signature
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<module:key~SubKey>} new subkey with revocation signature
    * @async
    */

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -45,6 +45,7 @@ class User {
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket}          primaryKey  The primary key packet
    * @param  {Array<module:key.Key>}    privateKeys Decrypted private keys for signing
+   * @param  {Object}                   config      Full configuration
    * @returns {Promise<module:key.Key>}             New user with new certificate signatures
    * @async
    */
@@ -83,6 +84,7 @@ class User {
    *          PublicKeyPacket|
    *          SecretKeyPacket} key, optional The key to verify the signature
    * @param  {Date}                     date          Use the given date instead of the current time
+   * @param  {Object}          config Full configuration
    * @returns {Promise<Boolean>}                      True if the certificate is revoked
    * @async
    */
@@ -103,10 +105,11 @@ class User {
    * @param  {SignaturePacket}  certificate A certificate of this user
    * @param  {Array<module:key.Key>}    keys        Array of keys to verify certificate signatures
    * @param  {Date}                     date        Use the given date instead of the current time
+   * @param  {Object}                   config      Full configuration
    * @returns {Promise<true|null>}   status of the certificate
    * @async
    */
-  async verifyCertificate(primaryKey, certificate, keys, date = new Date(), config = defaultConfig) {
+  async verifyCertificate(primaryKey, certificate, keys, date = new Date(), config) {
     const that = this;
     const keyid = certificate.issuerKeyId;
     const dataToVerify = {
@@ -140,7 +143,8 @@ class User {
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket} primaryKey The primary key packet
    * @param  {Array<module:key.Key>}    keys       Array of keys to verify certificate signatures
-   * @param  {Date}                     date        Use the given date instead of the current time
+   * @param  {Date}                     date       Use the given date instead of the current time
+   * @param  {Object}                   config     Full configuration
    * @returns {Promise<Array<{keyid: module:type/keyid,
    *                          valid: Boolean}>>}   List of signer's keyid and validity of signature
    * @async
@@ -162,11 +166,12 @@ class User {
    * @param  {SecretKeyPacket|
    *          PublicKeyPacket} primaryKey The primary key packet
    * @param  {Date}            date       Use the given date instead of the current time
+   * @param  {Object}          config     Full configuration
    * @returns {Promise<true>}             Status of user
    * @throws {Error} if there are no valid self signatures.
    * @async
    */
-  async verify(primaryKey, date = new Date(), config = defaultConfig) {
+  async verify(primaryKey, date = new Date(), config) {
     if (!this.selfCertifications.length) {
       throw new Error('No self-certifications');
     }
@@ -205,6 +210,7 @@ class User {
    * @param  {module:key.User}    user       Source user to merge
    * @param  {SecretKeyPacket|
    *          SecretSubkeyPacket} primaryKey primary key used for validation
+   * @param  {Object}             config Full configuration
    * @returns {Promise<undefined>}
    * @async
    */

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -10,7 +10,6 @@ import enums from '../enums';
 import util from '../util';
 import { PacketList } from '../packet';
 import { mergeSignatures, isDataRevoked, createSignaturePacket } from './helper';
-import defaultConfig from '../config';
 
 /**
  * Class that represents an user ID or attribute packet and the relevant signatures.

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -10,6 +10,7 @@ import enums from '../enums';
 import util from '../util';
 import { PacketList } from '../packet';
 import { mergeSignatures, isDataRevoked, createSignaturePacket } from './helper';
+import defaultConfig from '../config';
 
 /**
  * Class that represents an user ID or attribute packet and the relevant signatures.
@@ -47,7 +48,7 @@ class User {
    * @returns {Promise<module:key.Key>}             New user with new certificate signatures
    * @async
    */
-  async sign(primaryKey, privateKeys) {
+  async sign(primaryKey, privateKeys, config) {
     const dataToSign = {
       userId: this.userId,
       userAttribute: this.userAttribute,
@@ -61,12 +62,12 @@ class User {
       if (privateKey.hasSameFingerprintAs(primaryKey)) {
         throw new Error('Not implemented for self signing');
       }
-      const signingKey = await privateKey.getSigningKey();
+      const signingKey = await privateKey.getSigningKey(undefined, undefined, undefined, config);
       return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,
         keyFlags: [enums.keyFlags.certifyKeys | enums.keyFlags.signData]
-      });
+      }, undefined, undefined, undefined, undefined, config);
     }));
     await user.update(this, primaryKey);
     return user;
@@ -85,13 +86,13 @@ class User {
    * @returns {Promise<Boolean>}                      True if the certificate is revoked
    * @async
    */
-  async isRevoked(primaryKey, certificate, key, date = new Date()) {
+  async isRevoked(primaryKey, certificate, key, date = new Date(), config) {
     return isDataRevoked(
       primaryKey, enums.signature.certRevocation, {
         key: primaryKey,
         userId: this.userId,
         userAttribute: this.userAttribute
-      }, this.revocationSignatures, certificate, key, date
+      }, this.revocationSignatures, certificate, key, date, config
     );
   }
 
@@ -105,7 +106,7 @@ class User {
    * @returns {Promise<true|null>}   status of the certificate
    * @async
    */
-  async verifyCertificate(primaryKey, certificate, keys, date = new Date()) {
+  async verifyCertificate(primaryKey, certificate, keys, date = new Date(), config = defaultConfig) {
     const that = this;
     const keyid = certificate.issuerKeyId;
     const dataToVerify = {
@@ -117,12 +118,12 @@ class User {
       if (!key.getKeyIds().some(id => id.equals(keyid))) {
         return null;
       }
-      const signingKey = await key.getSigningKey(keyid, date);
-      if (certificate.revoked || await that.isRevoked(primaryKey, certificate, signingKey.keyPacket, date)) {
+      const signingKey = await key.getSigningKey(keyid, date, undefined, config);
+      if (certificate.revoked || await that.isRevoked(primaryKey, certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }
       try {
-        certificate.verified || await certificate.verify(signingKey.keyPacket, enums.signature.certGeneric, dataToVerify);
+        certificate.verified || await certificate.verify(signingKey.keyPacket, enums.signature.certGeneric, dataToVerify, undefined, undefined, config);
       } catch (e) {
         throw util.wrapError('User certificate is invalid', e);
       }
@@ -144,13 +145,13 @@ class User {
    *                          valid: Boolean}>>}   List of signer's keyid and validity of signature
    * @async
    */
-  async verifyAllCertifications(primaryKey, keys, date = new Date()) {
+  async verifyAllCertifications(primaryKey, keys, date = new Date(), config) {
     const that = this;
     const certifications = this.selfCertifications.concat(this.otherCertifications);
     return Promise.all(certifications.map(async function(certification) {
       return {
         keyid: certification.issuerKeyId,
-        valid: await that.verifyCertificate(primaryKey, certification, keys, date).catch(() => false)
+        valid: await that.verifyCertificate(primaryKey, certification, keys, date, config).catch(() => false)
       };
     }));
   }
@@ -165,7 +166,7 @@ class User {
    * @throws {Error} if there are no valid self signatures.
    * @async
    */
-  async verify(primaryKey, date = new Date()) {
+  async verify(primaryKey, date = new Date(), config = defaultConfig) {
     if (!this.selfCertifications.length) {
       throw new Error('No self-certifications');
     }
@@ -180,11 +181,11 @@ class User {
     for (let i = this.selfCertifications.length - 1; i >= 0; i--) {
       try {
         const selfCertification = this.selfCertifications[i];
-        if (selfCertification.revoked || await that.isRevoked(primaryKey, selfCertification, undefined, date)) {
+        if (selfCertification.revoked || await that.isRevoked(primaryKey, selfCertification, undefined, date, config)) {
           throw new Error('Self-certification is revoked');
         }
         try {
-          selfCertification.verified || await selfCertification.verify(primaryKey, enums.signature.certGeneric, dataToVerify);
+          selfCertification.verified || await selfCertification.verify(primaryKey, enums.signature.certGeneric, dataToVerify, undefined, undefined, config);
         } catch (e) {
           throw util.wrapError('Self-certification is invalid', e);
         }
@@ -207,7 +208,7 @@ class User {
    * @returns {Promise<undefined>}
    * @async
    */
-  async update(user, primaryKey) {
+  async update(user, primaryKey, config) {
     const dataToVerify = {
       userId: this.userId,
       userAttribute: this.userAttribute,
@@ -216,7 +217,7 @@ class User {
     // self signatures
     await mergeSignatures(user, this, 'selfCertifications', async function(srcSelfSig) {
       try {
-        srcSelfSig.verified || await srcSelfSig.verify(primaryKey, enums.signature.certGeneric, dataToVerify);
+        srcSelfSig.verified || await srcSelfSig.verify(primaryKey, enums.signature.certGeneric, dataToVerify, undefined, undefined, config);
         return true;
       } catch (e) {
         return false;
@@ -226,7 +227,7 @@ class User {
     await mergeSignatures(user, this, 'otherCertifications');
     // revocation signatures
     await mergeSignatures(user, this, 'revocationSignatures', function(srcRevSig) {
-      return isDataRevoked(primaryKey, enums.signature.certRevocation, dataToVerify, [srcRevSig]);
+      return isDataRevoked(primaryKey, enums.signature.certRevocation, dataToVerify, [srcRevSig], undefined, undefined, undefined, config);
     });
   }
 }

--- a/src/keyring/keyring.js
+++ b/src/keyring/keyring.js
@@ -78,6 +78,7 @@ class KeyArray {
   /**
    * Imports a key from an ascii armored message
    * @param {String} armored message to read the keys/key from
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @async
    */
   async importKey(armored, config = defaultConfig) {
@@ -124,6 +125,7 @@ class Keyring {
   /**
    * Initialization routine for the keyring.
    * @param {keyring/localstore} [storeHandler] class implementing loadPublic(), loadPrivate(), storePublic(), and storePrivate() methods
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    */
   constructor(storeHandler, config = defaultConfig) {
     this.storeHandler = storeHandler || new LocalStore(undefined, config);

--- a/src/keyring/keyring.js
+++ b/src/keyring/keyring.js
@@ -23,6 +23,7 @@
  */
 
 import { readKeys } from '../key';
+import defaultConfig from '../config';
 import LocalStore from './localstore';
 
 /**
@@ -79,8 +80,8 @@ class KeyArray {
    * @param {String} armored message to read the keys/key from
    * @async
    */
-  async importKey(armored) {
-    const imported = await readKeys({ armoredKeys: armored });
+  async importKey(armored, config = defaultConfig) {
+    const imported = await readKeys({ armoredKeys: armored, config });
     for (let i = 0; i < imported.length; i++) {
       const key = imported[i];
       // check if key already in key array
@@ -124,8 +125,8 @@ class Keyring {
    * Initialization routine for the keyring.
    * @param {keyring/localstore} [storeHandler] class implementing loadPublic(), loadPrivate(), storePublic(), and storePrivate() methods
    */
-  constructor(storeHandler) {
-    this.storeHandler = storeHandler || new LocalStore();
+  constructor(storeHandler, config = defaultConfig) {
+    this.storeHandler = storeHandler || new LocalStore(undefined, config);
   }
 
   /**

--- a/src/keyring/localstore.js
+++ b/src/keyring/localstore.js
@@ -34,6 +34,7 @@ import defaultConfig from '../config';
 class LocalStore {
   /**
    * @param {String} prefix prefix for itemnames in localstore
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    */
   constructor(prefix, config = defaultConfig) {
     prefix = prefix || 'openpgp-';
@@ -57,6 +58,7 @@ class LocalStore {
 
   /**
    * Load the private keys from HTML5 local storage.
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @returns {Array<module:key.Key>} array of keys retrieved from localstore
    * @async
    */
@@ -68,6 +70,7 @@ class LocalStore {
    * Saves the current state of the public keys to HTML5 local storage.
    * The key array gets stringified using JSON
    * @param {Array<module:key.Key>} keys array of keys to save in localstore
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @async
    */
   async storePublic(keys, config = defaultConfig) {
@@ -78,6 +81,7 @@ class LocalStore {
    * Saves the current state of the private keys to HTML5 local storage.
    * The key array gets stringified using JSON
    * @param {Array<module:key.Key>} keys array of keys to save in localstore
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @async
    */
   async storePrivate(keys, config = defaultConfig) {

--- a/src/message.js
+++ b/src/message.js
@@ -810,11 +810,13 @@ export async function createVerificationObjects(signatureList, literalDataList, 
  * Reads an (optionally armored) OpenPGP message and returns a Message object
  * @param {String | ReadableStream<String>} armoredMessage armored message to be parsed
  * @param {Uint8Array | ReadableStream<Uint8Array>} binaryMessage binary to be parsed
+ * @param  {Object} config (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Message>} new message object
  * @async
  * @static
  */
-export async function readMessage({ armoredMessage, binaryMessage, config = defaultConfig }) {
+export async function readMessage({ armoredMessage, binaryMessage, config }) {
+  config = { ...defaultConfig, ...config };
   let input = armoredMessage || binaryMessage;
   if (!input) {
     throw new Error('readMessage: must pass options object containing `armoredMessage` or `binaryMessage`');

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -74,12 +74,14 @@ if (globalThis.ReadableStream) {
  * @param  {Number} keyExpirationTime      (optional) Number of seconds from the key creation time after which the key expires
  * @param  {Array<Object>} subkeys         (optional) Options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
  *                                             sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
+ * @param  {Object} config                 (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Object>}         The generated key object in the form:
  *                                     { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  * @async
  * @static
  */
-export function generateKey({ userIds = [], passphrase = "", type = "ecc", rsaBits = 4096, curve = "curve25519", keyExpirationTime = 0, date = new Date(), subkeys = [{}], config = defaultConfig }) {
+export function generateKey({ userIds = [], passphrase = "", type = "ecc", rsaBits = 4096, curve = "curve25519", keyExpirationTime = 0, date = new Date(), subkeys = [{}], config }) {
+  config = { ...defaultConfig, ...config };
   userIds = toArray(userIds);
   const options = { userIds, passphrase, type, rsaBits, curve, keyExpirationTime, date, subkeys };
   if (type === "rsa" && rsaBits < config.minRsaBits) {
@@ -107,12 +109,14 @@ export function generateKey({ userIds = [], passphrase = "", type = "ecc", rsaBi
  * @param  {Object|Array<Object>} userIds  User IDs as objects: { name:'Jo Doe', email:'info@jo.com' }
  * @param  {String} passphrase             (optional) The passphrase used to encrypt the resulting private key
  * @param  {Number} keyExpirationTime      (optional) Number of seconds from the key creation time after which the key expires
+ * @param  {Object} config                 (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Object>}         The generated key object in the form:
  *                                     { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  * @async
  * @static
  */
-export function reformatKey({ privateKey, userIds = [], passphrase = "", keyExpirationTime = 0, date, config = defaultConfig }) {
+export function reformatKey({ privateKey, userIds = [], passphrase = "", keyExpirationTime = 0, date, config }) {
+  config = { ...defaultConfig, ...config };
   userIds = toArray(userIds);
   const options = { privateKey, userIds, passphrase, keyExpirationTime, date };
 
@@ -139,12 +143,15 @@ export function reformatKey({ privateKey, userIds = [], passphrase = "", keyExpi
  * @param  {Object} reasonForRevocation (optional) object indicating the reason for revocation
  * @param  {module:enums.reasonForRevocation} reasonForRevocation.flag (optional) flag indicating the reason for revocation
  * @param  {String} reasonForRevocation.string (optional) string explaining the reason for revocation
+ * @param  {Object} config                  (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Object>}         The revoked key object in the form:
  *                                     { privateKey:Key, privateKeyArmored:String, publicKey:Key, publicKeyArmored:String }
  *                                     (if private key is passed) or { publicKey:Key, publicKeyArmored:String } (otherwise)
+ * @async
  * @static
  */
-export function revokeKey({ key, revocationCertificate, reasonForRevocation, config = defaultConfig }) {
+export function revokeKey({ key, revocationCertificate, reasonForRevocation, config }) {
+  config = { ...defaultConfig, ...config };
   return Promise.resolve().then(() => {
     if (revocationCertificate) {
       return key.applyRevocationCertificate(revocationCertificate, config);
@@ -173,10 +180,12 @@ export function revokeKey({ key, revocationCertificate, reasonForRevocation, con
  * This method does not change the original key.
  * @param  {Key} privateKey                   the private key to decrypt
  * @param  {String|Array<String>} passphrase  the user's passphrase(s)
+ * @param  {Object} config                    (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Key>}                    the unlocked key object
  * @async
  */
-export async function decryptKey({ privateKey, passphrase, config = defaultConfig }) {
+export async function decryptKey({ privateKey, passphrase, config }) {
+  config = { ...defaultConfig, ...config };
   const key = await privateKey.clone();
   // shallow clone is enough since the encrypted material is not changed in place by decryption
   key.getKeys().forEach(k => {
@@ -199,10 +208,12 @@ export async function decryptKey({ privateKey, passphrase, config = defaultConfi
  * This method does not change the original key.
  * @param  {Key} privateKey                   the private key to encrypt
  * @param  {String|Array<String>} passphrase  if multiple passphrases, they should be in the same order as the packets each should encrypt
+ * @param  {Object} config                    (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Key>}                    the locked key object
  * @async
  */
-export async function encryptKey({ privateKey, passphrase, config = defaultConfig }) {
+export async function encryptKey({ privateKey, passphrase, config }) {
+  config = { ...defaultConfig, ...config };
   const key = await privateKey.clone();
   key.getKeys().forEach(k => {
     // shallow clone the key packets
@@ -252,11 +263,13 @@ export async function encryptKey({ privateKey, passphrase, config = defaultConfi
  * @param  {Date} date                                  (optional) override the creation date of the message signature
  * @param  {Array<Object>} fromUserIds                  (optional) array of user IDs to sign with, one per key in `privateKeys`, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
  * @param  {Array<Object>} toUserIds                    (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [{ name:'Robert Receiver', email:'robert@openpgp.org' }]
+ * @param  {Object} config                              (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<String|ReadableStream<String>|NodeStream<String>|Uint8Array|ReadableStream<Uint8Array>|NodeStream<Uint8Array>>} (String if `armor` was true, the default; Uint8Array if `armor` was false)
  * @async
  * @static
  */
-export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKey, armor = true, streaming = message && message.fromStream, detached = false, signature = null, wildcard = false, signingKeyIds = [], encryptionKeyIds = [], date = new Date(), fromUserIds = [], toUserIds = [], config = defaultConfig }) {
+export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKey, armor = true, streaming = message && message.fromStream, detached = false, signature = null, wildcard = false, signingKeyIds = [], encryptionKeyIds = [], date = new Date(), fromUserIds = [], toUserIds = [], config }) {
+  config = { ...defaultConfig, ...config };
   checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); fromUserIds = toArray(fromUserIds); toUserIds = toArray(toUserIds);
   if (detached) {
     throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
@@ -288,6 +301,7 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @param  {'web'|'ponyfill'|'node'|false} streaming  (optional) whether to return data as a stream. Defaults to the type of stream `message` was created from, if any.
  * @param  {Signature} signature                      (optional) detached signature for verification
  * @param  {Date} date                                (optional) use the given date for verification instead of the current time
+ * @param  {Object} config                            (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Object>}                         Object containing decrypted and verified message in the form:
  *
  *     {
@@ -305,7 +319,8 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @async
  * @static
  */
-export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, format = 'utf8', streaming = message && message.fromStream, signature = null, date = new Date(), config = defaultConfig }) {
+export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, format = 'utf8', streaming = message && message.fromStream, signature = null, date = new Date(), config }) {
+  config = { ...defaultConfig, ...config };
   checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
 
   return message.decrypt(privateKeys, passwords, sessionKeys, streaming, config).then(async function(decrypted) {
@@ -342,11 +357,13 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
  * @param  {Array<module:type/keyid>} signingKeyIds   (optional) array of key IDs to use for signing. Each signingKeyIds[i] corresponds to privateKeys[i]
  * @param  {Date} date                                (optional) override the creation date of the signature
  * @param  {Array<Object>} fromUserIds                (optional) array of user IDs to sign with, one per key in `privateKeys`, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+ * @param  {Object} config                            (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<String|ReadableStream<String>|NodeStream<String>|Uint8Array|ReadableStream<Uint8Array>|NodeStream<Uint8Array>>} (String if `armor` was true, the default; Uint8Array if `armor` was false)
  * @async
  * @static
  */
-export function sign({ message, privateKeys, armor = true, streaming = message && message.fromStream, detached = false, signingKeyIds = [], date = new Date(), fromUserIds = [], config = defaultConfig }) {
+export function sign({ message, privateKeys, armor = true, streaming = message && message.fromStream, detached = false, signingKeyIds = [], date = new Date(), fromUserIds = [], config }) {
+  config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && !armor) throw new Error("Can't sign non-armored cleartext message");
   if (message instanceof CleartextMessage && detached) throw new Error("Can't sign detached cleartext message");
@@ -380,6 +397,7 @@ export function sign({ message, privateKeys, armor = true, streaming = message &
  * @param  {'web'|'ponyfill'|'node'|false} streaming  (optional) whether to return data as a stream. Defaults to the type of stream `message` was created from, if any.
  * @param  {Signature} signature                      (optional) detached signature for verification
  * @param  {Date} date                                (optional) use the given date for verification instead of the current time
+ * @param  {Object} config                            (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<Object>}                         Object containing verified message in the form:
  *
  *     {
@@ -396,7 +414,8 @@ export function sign({ message, privateKeys, armor = true, streaming = message &
  * @async
  * @static
  */
-export function verify({ message, publicKeys, format = 'utf8', streaming = message && message.fromStream, signature = null, date = new Date(), config = defaultConfig }) {
+export function verify({ message, publicKeys, format = 'utf8', streaming = message && message.fromStream, signature = null, date = new Date(), config }) {
+  config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && format === 'binary') throw new Error("Can't return cleartext message data as binary");
   publicKeys = toArray(publicKeys);
@@ -424,11 +443,13 @@ export function verify({ message, publicKeys, format = 'utf8', streaming = messa
  * @param  {Key|Array<Key>} publicKeys  array of public keys or single key used to select algorithm preferences for
  * @param  {Date} date                  (optional) date to select algorithm preferences at
  * @param  {Array} toUserIds            (optional) user IDs to select algorithm preferences for
+ * @param  {Object} config              (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<{ data: Uint8Array, algorithm: String }>} object with session key data and algorithm
  * @async
  * @static
  */
-export function generateSessionKey({ publicKeys, date = new Date(), toUserIds = [], config = defaultConfig }) {
+export function generateSessionKey({ publicKeys, date = new Date(), toUserIds = [], config }) {
+  config = { ...defaultConfig, ...config };
   publicKeys = toArray(publicKeys); toUserIds = toArray(toUserIds);
 
   return Promise.resolve().then(async function() {
@@ -451,11 +472,13 @@ export function generateSessionKey({ publicKeys, date = new Date(), toUserIds = 
  * @param  {Array<module:type/keyid>} encryptionKeyIds  (optional) array of key IDs to use for encryption. Each encryptionKeyIds[i] corresponds to publicKeys[i]
  * @param  {Date} date                                  (optional) override the date
  * @param  {Array} toUserIds                            (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [{ name:'Phil Zimmermann', email:'phil@openpgp.org' }]
+ * @param  {Object} config                              (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Promise<String|Uint8Array>} (String if `armor` was true, the default; Uint8Array if `armor` was false)
  * @async
  * @static
  */
-export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, armor = true, wildcard = false, encryptionKeyIds = [], date = new Date(), toUserIds = [], config = defaultConfig }) {
+export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, armor = true, wildcard = false, encryptionKeyIds = [], date = new Date(), toUserIds = [], config }) {
+  config = { ...defaultConfig, ...config };
   checkBinary(data); checkString(algorithm, 'algorithm'); publicKeys = toArray(publicKeys); passwords = toArray(passwords); toUserIds = toArray(toUserIds);
 
   return Promise.resolve().then(async function() {
@@ -469,16 +492,18 @@ export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, 
 /**
  * Decrypt symmetric session keys with a private key or password. Either a private key or
  *   a password must be specified.
- * @param  {Message} message                 a message object containing the encrypted session key packets
+ * @param  {Message} message                a message object containing the encrypted session key packets
  * @param  {Key|Array<Key>} privateKeys     (optional) private keys with decrypted secret key data
  * @param  {String|Array<String>} passwords (optional) passwords to decrypt the session key
- * @returns {Promise<Object|undefined>}    Array of decrypted session key, algorithm pairs in form:
- *                                          { data:Uint8Array, algorithm:String }
- *                                          or 'undefined' if no key packets found
+ * @param  {Object} config                  (optional) custom configuration settings to overwrite those in openpgp.config
+ * @returns {Promise<Object|undefined>}     Array of decrypted session key, algorithm pairs in form:
+ *                                            { data:Uint8Array, algorithm:String }
+ *                                            or 'undefined' if no key packets found
  * @async
  * @static
  */
-export function decryptSessionKeys({ message, privateKeys, passwords, config = defaultConfig }) {
+export function decryptSessionKeys({ message, privateKeys, passwords, config }) {
+  config = { ...defaultConfig, ...config };
   checkMessage(message); privateKeys = toArray(privateKeys); passwords = toArray(passwords);
 
   return Promise.resolve().then(async function() {

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -25,7 +25,6 @@
  */
 
 import stream from 'web-stream-tools';
-import config from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
@@ -110,7 +109,7 @@ class AEADEncryptedDataPacket {
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(sessionKeyAlgorithm, key, streaming) {
+  async encrypt(sessionKeyAlgorithm, key, streaming, config) {
     this.cipherAlgo = enums.write(enums.symmetric, sessionKeyAlgorithm);
     this.aeadAlgo = enums.write(enums.aead, this.aeadAlgorithm);
     const mode = crypto[enums.read(enums.aead, this.aeadAlgo)];

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -34,6 +34,7 @@ import {
   OnePassSignaturePacket,
   SignaturePacket
 } from '../packet';
+import defaultConfig from '../config';
 
 const VERSION = 1; // A one-octet version number of the data packet.
 
@@ -106,10 +107,11 @@ class AEADEncryptedDataPacket {
    * @param  {String} sessionKeyAlgorithm   The session key's cipher algorithm e.g. 'aes128'
    * @param  {Uint8Array} key               The session key used to encrypt the payload
    * @param  {Boolean} streaming            Whether the top-level function will return a stream
+   * @param  {Object} config                (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(sessionKeyAlgorithm, key, streaming, config) {
+  async encrypt(sessionKeyAlgorithm, key, streaming, config = defaultConfig) {
     this.cipherAlgo = enums.write(enums.symmetric, sessionKeyAlgorithm);
     this.aeadAlgo = enums.write(enums.aead, this.aeadAlgorithm);
     const mode = crypto[enums.read(enums.aead, this.aeadAlgo)];

--- a/src/packet/compressed_data.js
+++ b/src/packet/compressed_data.js
@@ -49,6 +49,9 @@ import {
  * @memberof module:packet
  */
 class CompressedDataPacket {
+  /**
+   * @param {Object} config (optional) full configuration, defaults to openpgp.config
+   */
   constructor(config = defaultConfig) {
     /**
      * Packet type

--- a/src/packet/compressed_data.js
+++ b/src/packet/compressed_data.js
@@ -82,7 +82,7 @@ class CompressedDataPacket {
    * Parsing function for the packet.
    * @param {Uint8Array | ReadableStream<Uint8Array>} bytes Payload of a tag 8 packet
    */
-  async read(bytes, streaming) {
+  async read(bytes, config, streaming) {
     await stream.parse(bytes, async reader => {
 
       // One octet that gives the algorithm used to compress the packet.

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -42,7 +42,7 @@ class PacketList extends Array {
               const packet = packets.newPacketFromTag(tag, allowedPackets);
               packet.packets = new PacketList();
               packet.fromStream = util.isStream(parsed.packet);
-              await packet.read(parsed.packet, parsed.tag === enums.packet.compressedData ? streaming : config);
+              await packet.read(parsed.packet, config, streaming);
               await writer.write(packet);
             } catch (e) {
               if (!config.tolerant || supportsStreaming(parsed.tag)) {

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -14,9 +14,9 @@ import {
   writeTag, writeHeader,
   writePartialLength, writeSimpleLength
 } from './packet';
-import config from '../config';
 import enums from '../enums';
 import util from '../util';
+import defaultConfig from '../config';
 
 /**
  * This class represents a list of openpgp packets.
@@ -30,7 +30,7 @@ class PacketList extends Array {
    * Reads a stream of binary data and interprets it as a list of packets.
    * @param {Uint8Array | ReadableStream<Uint8Array>} bytes A Uint8Array of bytes.
    */
-  async read(bytes, allowedPackets, streaming) {
+  async read(bytes, allowedPackets, streaming, config = defaultConfig) {
     this.stream = stream.transformPair(bytes, async (readable, writable) => {
       const writer = stream.getWriter(writable);
       try {
@@ -42,7 +42,7 @@ class PacketList extends Array {
               const packet = packets.newPacketFromTag(tag, allowedPackets);
               packet.packets = new PacketList();
               packet.fromStream = util.isStream(parsed.packet);
-              await packet.read(parsed.packet, streaming);
+              await packet.read(parsed.packet, parsed.tag === enums.packet.compressedData ? streaming : config);
               await writer.write(packet);
             } catch (e) {
               if (!config.tolerant || supportsStreaming(parsed.tag)) {

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -46,6 +46,10 @@ import util from '../util';
  * @memberof module:packet
  */
 class PublicKeyPacket {
+  /**
+   * @param {Date} date      (optional) creation date
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
+   */
   constructor(date = new Date(), config = defaultConfig) {
     /**
      * Packet type

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -28,7 +28,7 @@
 import { Sha1 } from 'asmcrypto.js/dist_es8/hash/sha1/sha1';
 import { Sha256 } from 'asmcrypto.js/dist_es8/hash/sha256/sha256';
 import type_keyid from '../type/keyid';
-import config from '../config';
+import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
@@ -46,7 +46,7 @@ import util from '../util';
  * @memberof module:packet
  */
 class PublicKeyPacket {
-  constructor(date = new Date()) {
+  constructor(date = new Date(), config = defaultConfig) {
     /**
      * Packet type
      * @type {module:enums.packet}

--- a/src/packet/public_subkey.js
+++ b/src/packet/public_subkey.js
@@ -33,6 +33,10 @@ import enums from '../enums';
  * @extends PublicKeyPacket
  */
 class PublicSubkeyPacket extends PublicKeyPacket {
+  /**
+   * @param {Date} date      (optional) creation date
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
+   */
   constructor(date, config) {
     super(date, config);
     this.tag = enums.packet.publicSubkey;

--- a/src/packet/public_subkey.js
+++ b/src/packet/public_subkey.js
@@ -33,8 +33,8 @@ import enums from '../enums';
  * @extends PublicKeyPacket
  */
 class PublicSubkeyPacket extends PublicKeyPacket {
-  constructor() {
-    super();
+  constructor(date, config) {
+    super(date, config);
     this.tag = enums.packet.publicSubkey;
   }
 }

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -39,6 +39,10 @@ import defaultConfig from '../config';
  * @extends PublicKeyPacket
  */
 class SecretKeyPacket extends PublicKeyPacket {
+  /**
+   * @param {Date} date      (optional) creation date
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
+   */
   constructor(date = new Date(), config = defaultConfig) {
     super(date, config);
     /**
@@ -248,6 +252,7 @@ class SecretKeyPacket extends PublicKeyPacket {
   /**
    * Remove private key material, converting the key to a dummy one.
    * The resulting key cannot be used for signing/decrypting but can still verify signatures.
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    */
   makeDummy(config = defaultConfig) {
     if (this.isDummy()) {
@@ -272,10 +277,11 @@ class SecretKeyPacket extends PublicKeyPacket {
    * and the passphrase is empty or undefined, the key will be set as not encrypted.
    * This can be used to remove passphrase protection after calling decrypt().
    * @param {String} passphrase
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(passphrase, config) {
+  async encrypt(passphrase, config = defaultConfig) {
     if (this.isDummy()) {
       return;
     }

--- a/src/packet/secret_subkey.js
+++ b/src/packet/secret_subkey.js
@@ -22,6 +22,7 @@
 
 import SecretKeyPacket from './secret_key';
 import enums from '../enums';
+import defaultConfig from '../config';
 
 /**
  * A Secret-Subkey packet (tag 7) is the subkey analog of the Secret
@@ -30,8 +31,8 @@ import enums from '../enums';
  * @extends SecretKeyPacket
  */
 class SecretSubkeyPacket extends SecretKeyPacket {
-  constructor(date = new Date()) {
-    super(date);
+  constructor(date = new Date(), config = defaultConfig) {
+    super(date, config);
     this.tag = enums.packet.secretSubkey;
   }
 }

--- a/src/packet/secret_subkey.js
+++ b/src/packet/secret_subkey.js
@@ -31,6 +31,10 @@ import defaultConfig from '../config';
  * @extends SecretKeyPacket
  */
 class SecretSubkeyPacket extends SecretKeyPacket {
+  /**
+   * @param {Date} date      (optional) creation date
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
+   */
   constructor(date = new Date(), config = defaultConfig) {
     super(date, config);
     this.tag = enums.packet.secretSubkey;

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -99,9 +99,10 @@ class SignaturePacket {
   /**
    * parsing function for a signature packet (tag 2).
    * @param {String} bytes payload of a tag 2 packet
+   * @param {Object} config  (optional) full configuration, defaults to openpgp.config
    * @returns {SignaturePacket} object representation
    */
-  read(bytes, config) {
+  read(bytes, config = defaultConfig) {
     let i = 0;
     this.version = bytes[i++];
 
@@ -671,6 +672,7 @@ class SignaturePacket {
    * @param {String|Object} data data which on the signature applies
    * @param {Boolean} detached (optional) whether to verify a detached signature
    * @param {Boolean} streaming (optional) whether to process data as a stream
+   * @param {Object}  config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if signature validation failed
    * @async
    */

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -30,7 +30,7 @@ import type_keyid from '../type/keyid.js';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
-import config from '../config';
+import defaultConfig from '../config';
 
 /**
  * Implementation of the Signature Packet (Tag 2)
@@ -101,7 +101,7 @@ class SignaturePacket {
    * @param {String} bytes payload of a tag 2 packet
    * @returns {SignaturePacket} object representation
    */
-  read(bytes) {
+  read(bytes, config) {
     let i = 0;
     this.version = bytes[i++];
 
@@ -114,7 +114,7 @@ class SignaturePacket {
     this.hashAlgorithm = bytes[i++];
 
     // hashed subpackets
-    i += this.read_sub_packets(bytes.subarray(i, bytes.length), true);
+    i += this.read_sub_packets(bytes.subarray(i, bytes.length), true, config);
 
     // A V4 signature hashes the packet body
     // starting from its first field, the version number, through the end
@@ -125,7 +125,7 @@ class SignaturePacket {
     this.signatureData = bytes.subarray(0, i);
 
     // unhashed subpackets
-    i += this.read_sub_packets(bytes.subarray(i, bytes.length), false);
+    i += this.read_sub_packets(bytes.subarray(i, bytes.length), false, config);
 
     // Two-octet field holding left 16 bits of signed hash value.
     this.signedHashValue = bytes.subarray(i, i + 2);
@@ -340,7 +340,7 @@ class SignaturePacket {
 
   // V4 signature sub packets
 
-  read_sub_packet(bytes, trusted = true) {
+  read_sub_packet(bytes, trusted = true, config) {
     let mypos = 0;
 
     const read_array = (prop, bytes) => {
@@ -536,7 +536,7 @@ class SignaturePacket {
     }
   }
 
-  read_sub_packets(bytes, trusted = true) {
+  read_sub_packets(bytes, trusted = true, config) {
     // Two-octet scalar octet count for following subpacket data.
     const subpacket_length = util.readNumber(bytes.subarray(0, 2));
 
@@ -547,7 +547,7 @@ class SignaturePacket {
       const len = readSimpleLength(bytes.subarray(i, bytes.length));
       i += len.offset;
 
-      this.read_sub_packet(bytes.subarray(i, i + len.len), trusted);
+      this.read_sub_packet(bytes.subarray(i, i + len.len), trusted, config);
 
       i += len.len;
     }
@@ -674,7 +674,7 @@ class SignaturePacket {
    * @throws {Error} if signature validation failed
    * @async
    */
-  async verify(key, signatureType, data, detached = false, streaming = false) {
+  async verify(key, signatureType, data, detached = false, streaming = false, config = defaultConfig) {
     const publicKeyAlgorithm = enums.write(enums.publicKey, this.publicKeyAlgorithm);
     const hashAlgorithm = enums.write(enums.hash, this.hashAlgorithm);
 

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -35,6 +35,7 @@ import {
   OnePassSignaturePacket,
   SignaturePacket
 } from '../packet';
+import defaultConfig from '../config';
 
 const VERSION = 1; // A one-octet version number of the data packet.
 
@@ -89,10 +90,11 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @param  {String} sessionKeyAlgorithm   The selected symmetric encryption algorithm to be used e.g. 'aes128'
    * @param  {Uint8Array} key               The key of cipher blocksize length to be used
    * @param  {Boolean} streaming            Whether to set this.encrypted to a stream
+   * @param  {Object} config                (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}
    * @async
    */
-  async encrypt(sessionKeyAlgorithm, key, streaming, config) {
+  async encrypt(sessionKeyAlgorithm, key, streaming, config = defaultConfig) {
     let bytes = this.packets.write();
     if (!streaming) bytes = await stream.readToEnd(bytes);
     const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
@@ -111,10 +113,11 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @param  {String} sessionKeyAlgorithm   The selected symmetric encryption algorithm to be used e.g. 'aes128'
    * @param  {Uint8Array} key               The key of cipher blocksize length to be used
    * @param  {Boolean} streaming            Whether to read this.encrypted as a stream
+   * @param  {Object} config               (optional) full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}
    * @async
    */
-  async decrypt(sessionKeyAlgorithm, key, streaming, config) {
+  async decrypt(sessionKeyAlgorithm, key, streaming, config = defaultConfig) {
     let encrypted = stream.clone(this.encrypted);
     if (!streaming) encrypted = await stream.readToEnd(encrypted);
     const decrypted = await crypto.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize));

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -26,7 +26,6 @@
  */
 
 import stream from 'web-stream-tools';
-import config from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
@@ -93,7 +92,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @returns {Promise<Boolean>}
    * @async
    */
-  async encrypt(sessionKeyAlgorithm, key, streaming) {
+  async encrypt(sessionKeyAlgorithm, key, streaming, config) {
     let bytes = this.packets.write();
     if (!streaming) bytes = await stream.readToEnd(bytes);
     const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
@@ -103,7 +102,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
     const hash = await crypto.hash.sha1(stream.passiveClone(tohash));
     const plaintext = util.concat([tohash, hash]);
 
-    this.encrypted = await crypto.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize));
+    this.encrypted = await crypto.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize), config);
     return true;
   }
 
@@ -115,7 +114,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @returns {Promise<Boolean>}
    * @async
    */
-  async decrypt(sessionKeyAlgorithm, key, streaming) {
+  async decrypt(sessionKeyAlgorithm, key, streaming, config) {
     let encrypted = stream.clone(this.encrypted);
     if (!streaming) encrypted = await stream.readToEnd(encrypted);
     const decrypted = await crypto.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize));

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -44,6 +44,9 @@ import util from '../util';
  * @memberof module:packet
  */
 class SymEncryptedSessionKeyPacket {
+  /**
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
+   */
   constructor(config = defaultConfig) {
     this.tag = enums.packet.symEncryptedSessionKey;
     this.version = config.aeadProtect ? 5 : 4;
@@ -154,10 +157,11 @@ class SymEncryptedSessionKeyPacket {
   /**
    * Encrypts the session key
    * @param {String} passphrase The passphrase in string form
+   * @param {Object} config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(passphrase, config) {
+  async encrypt(passphrase, config = defaultConfig) {
     const algo = this.sessionKeyEncryptionAlgorithm !== null ?
       this.sessionKeyEncryptionAlgorithm :
       this.sessionKeyAlgorithm;

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -24,7 +24,7 @@
  */
 
 import type_s2k from '../type/s2k';
-import config from '../config';
+import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
@@ -44,7 +44,7 @@ import util from '../util';
  * @memberof module:packet
  */
 class SymEncryptedSessionKeyPacket {
-  constructor() {
+  constructor(config = defaultConfig) {
     this.tag = enums.packet.symEncryptedSessionKey;
     this.version = config.aeadProtect ? 5 : 4;
     this.sessionKey = null;
@@ -157,14 +157,14 @@ class SymEncryptedSessionKeyPacket {
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(passphrase) {
+  async encrypt(passphrase, config) {
     const algo = this.sessionKeyEncryptionAlgorithm !== null ?
       this.sessionKeyEncryptionAlgorithm :
       this.sessionKeyAlgorithm;
 
     this.sessionKeyEncryptionAlgorithm = algo;
 
-    this.s2k = new type_s2k();
+    this.s2k = new type_s2k(config);
     this.s2k.salt = await crypto.random.getRandomBytes(8);
 
     const length = crypto.cipher[algo].keySize;
@@ -183,7 +183,7 @@ class SymEncryptedSessionKeyPacket {
     } else {
       const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
       const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
-      this.encrypted = await crypto.cfb.encrypt(algo, key, private_key, new Uint8Array(crypto.cipher[algo].blockSize));
+      this.encrypted = await crypto.cfb.encrypt(algo, key, private_key, new Uint8Array(crypto.cipher[algo].blockSize), config);
     }
   }
 }

--- a/src/packet/symmetrically_encrypted_data.js
+++ b/src/packet/symmetrically_encrypted_data.js
@@ -34,6 +34,7 @@ import {
   OnePassSignaturePacket,
   SignaturePacket
 } from '../packet';
+import defaultConfig from '../config';
 
 /**
  * Implementation of the Symmetrically Encrypted Data Packet (Tag 9)
@@ -77,10 +78,12 @@ class SymmetricallyEncryptedDataPacket {
    * See {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC 4880 9.2} for algorithms.
    * @param {module:enums.symmetric} sessionKeyAlgorithm Symmetric key algorithm to use
    * @param {Uint8Array} key    The key of cipher blocksize length to be used
+   * @param {Object}     config (optional) full configuration, defaults to openpgp.config
+
    * @throws {Error} if decryption was not successful
    * @async
    */
-  async decrypt(sessionKeyAlgorithm, key, streaming, config) {
+  async decrypt(sessionKeyAlgorithm, key, streaming, config = defaultConfig) {
     // If MDC errors are not being ignored, all missing MDC packets in symmetrically encrypted data should throw an error
     if (!config.ignoreMdcError) {
       throw new Error('Decryption failed due to missing MDC.');
@@ -105,10 +108,11 @@ class SymmetricallyEncryptedDataPacket {
    * See {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC 4880 9.2} for algorithms.
    * @param {module:enums.symmetric} sessionKeyAlgorithm Symmetric key algorithm to use
    * @param {Uint8Array} key    The key of cipher blocksize length to be used
+   * @param {Object}     config (optional) full configuration, defaults to openpgp.config
    * @throws {Error} if encryption was not successful
    * @async
    */
-  async encrypt(algo, key, streaming, config) {
+  async encrypt(algo, key, streaming, config = defaultConfig) {
     const data = this.packets.write();
 
     const prefix = await crypto.getPrefixRandom(algo);

--- a/src/packet/userid.js
+++ b/src/packet/userid.js
@@ -23,7 +23,6 @@ import emailAddresses from 'email-addresses';
 
 import enums from '../enums';
 import util from '../util';
-import config from '../config';
 
 /**
  * Implementation of the User ID Packet (Tag 13)
@@ -76,7 +75,7 @@ class UserIDPacket {
    * Parsing function for a user id packet (tag 13).
    * @param {Uint8Array} input payload of a tag 13 packet
    */
-  read(bytes) {
+  read(bytes, config) {
     const userid = util.decodeUtf8(bytes);
     if (userid.length > config.maxUseridLength) {
       throw new Error('User ID string is too long');

--- a/src/packet/userid.js
+++ b/src/packet/userid.js
@@ -23,6 +23,7 @@ import emailAddresses from 'email-addresses';
 
 import enums from '../enums';
 import util from '../util';
+import defaultConfig from '../config';
 
 /**
  * Implementation of the User ID Packet (Tag 13)
@@ -75,7 +76,7 @@ class UserIDPacket {
    * Parsing function for a user id packet (tag 13).
    * @param {Uint8Array} input payload of a tag 13 packet
    */
-  read(bytes, config) {
+  read(bytes, config = defaultConfig) {
     const userid = util.decodeUtf8(bytes);
     if (userid.length > config.maxUseridLength) {
       throw new Error('User ID string is too long');

--- a/src/signature.js
+++ b/src/signature.js
@@ -59,11 +59,13 @@ export class Signature {
  * reads an (optionally armored) OpenPGP signature and returns a signature object
  * @param {String | ReadableStream<String>} armoredSignature armored signature to be parsed
  * @param {Uint8Array | ReadableStream<Uint8Array>} binarySignature binary signature to be parsed
+ * @param {Object} config (optional) custom configuration settings to overwrite those in openpgp.config
  * @returns {Signature} new signature object
  * @async
  * @static
  */
-export async function readSignature({ armoredSignature, binarySignature, config = defaultConfig }) {
+export async function readSignature({ armoredSignature, binarySignature, config }) {
+  config = { ...defaultConfig, ...config };
   let input = armoredSignature || binarySignature;
   if (!input) {
     throw new Error('readSignature: must pass options object containing `armoredSignature` or `binarySignature`');

--- a/src/signature.js
+++ b/src/signature.js
@@ -48,6 +48,7 @@ export class Signature {
 
   /**
    * Returns ASCII armored text of signature
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
    * @returns {ReadableStream<String>} ASCII armor
    */
   armor(config = defaultConfig) {

--- a/src/signature.js
+++ b/src/signature.js
@@ -25,6 +25,7 @@
 import { armor, unarmor } from './encoding/armor';
 import { PacketList, SignaturePacket } from './packet';
 import enums from './enums';
+import defaultConfig from './config';
 
 /**
  * Class that represents an OpenPGP signature.
@@ -49,8 +50,8 @@ export class Signature {
    * Returns ASCII armored text of signature
    * @returns {ReadableStream<String>} ASCII armor
    */
-  armor() {
-    return armor(enums.armor.signature, this.write());
+  armor(config = defaultConfig) {
+    return armor(enums.armor.signature, this.write(), undefined, undefined, undefined, config);
   }
 }
 
@@ -62,19 +63,19 @@ export class Signature {
  * @async
  * @static
  */
-export async function readSignature({ armoredSignature, binarySignature }) {
+export async function readSignature({ armoredSignature, binarySignature, config = defaultConfig }) {
   let input = armoredSignature || binarySignature;
   if (!input) {
     throw new Error('readSignature: must pass options object containing `armoredSignature` or `binarySignature`');
   }
   if (armoredSignature) {
-    const { type, data } = await unarmor(input);
+    const { type, data } = await unarmor(input, config);
     if (type !== enums.armor.signature) {
       throw new Error('Armored text not of type signature');
     }
     input = data;
   }
   const packetlist = new PacketList();
-  await packetlist.read(input, { SignaturePacket });
+  await packetlist.read(input, { SignaturePacket }, undefined, config);
   return new Signature(packetlist);
 }

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -31,13 +31,13 @@
  * @module type/s2k
  */
 
-import config from '../config';
+import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums.js';
 import util from '../util.js';
 
 class S2K {
-  constructor() {
+  constructor(config = defaultConfig) {
     /** @type {module:enums.hash} */
     this.algorithm = 'sha256';
     /** @type {module:enums.s2k} */

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -37,6 +37,9 @@ import enums from '../enums.js';
 import util from '../util.js';
 
 class S2K {
+  /**
+   * @param  {Object} config (optional) full configuration, defaults to openpgp.config
+   */
   constructor(config = defaultConfig) {
     /** @type {module:enums.hash} */
     this.algorithm = 'sha256';

--- a/src/util.js
+++ b/src/util.js
@@ -31,6 +31,8 @@ import config from './config';
 import util from './util'; // re-import module to access util functions
 import { getBigInteger } from './biginteger';
 
+const debugMode = globalThis.process && globalThis.process.env.NODE_ENV === 'development';
+
 export default {
   isString: function(data) {
     return typeof data === 'string' || String.prototype.isPrototypeOf(data);
@@ -358,11 +360,10 @@ export default {
   /**
    * Helper function to print a debug message. Debug
    * messages are only printed if
-   * @link module:config/config.debug is set to true.
    * @param {String} str String of the debug message
    */
   printDebug: function (str) {
-    if (config.debug) {
+    if (debugMode) {
       console.log(str);
     }
   },
@@ -370,12 +371,11 @@ export default {
   /**
    * Helper function to print a debug message. Debug
    * messages are only printed if
-   * @link module:config/config.debug is set to true.
    * Different than print_debug because will call Uint8ArrayToHex iff necessary.
    * @param {String} str String of the debug message
    */
   printDebugHexArrayDump: function (str, arrToHex) {
-    if (config.debug) {
+    if (debugMode) {
       str += ': ' + util.uint8ArrayToHex(arrToHex);
       console.log(str);
     }
@@ -384,12 +384,11 @@ export default {
   /**
    * Helper function to print a debug message. Debug
    * messages are only printed if
-   * @link module:config/config.debug is set to true.
    * Different than print_debug because will call strToHex iff necessary.
    * @param {String} str String of the debug message
    */
   printDebugHexStrDump: function (str, strToHex) {
-    if (config.debug) {
+    if (debugMode) {
       str += util.strToHex(strToHex);
       console.log(str);
     }
@@ -398,11 +397,10 @@ export default {
   /**
    * Helper function to print a debug error. Debug
    * messages are only printed if
-   * @link module:config/config.debug is set to true.
    * @param {String} str String of the debug message
    */
   printDebugError: function (error) {
-    if (config.debug) {
+    if (debugMode) {
       console.error(error);
     }
   },

--- a/src/util.js
+++ b/src/util.js
@@ -21,13 +21,11 @@
  * This object contains utility functions
  * @requires email-addresses
  * @requires web-stream-tools
- * @requires config
  * @requires encoding/base64
  * @module util
  */
 
 import stream from 'web-stream-tools';
-import config from './config';
 import { getBigInteger } from './biginteger';
 
 const debugMode = globalThis.process && globalThis.process.env.NODE_ENV === 'development';
@@ -487,38 +485,10 @@ const util = {
 
   /**
    * Get native Web Cryptography api, only the current version of the spec.
-   * The default configuration is to use the api when available. But it can
-   * be deactivated with config.useNative
    * @returns {Object}   The SubtleCrypto api or 'undefined'
    */
   getWebCrypto: function() {
-    if (!config.useNative) {
-      return;
-    }
-
     return typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.subtle;
-  },
-
-  /**
-   * Get native Web Cryptography api for all browsers, including legacy
-   * implementations of the spec e.g IE11 and Safari 8/9. The default
-   * configuration is to use the api when available. But it can be deactivated
-   * with config.useNative
-   * @returns {Object}   The SubtleCrypto api or 'undefined'
-   */
-  getWebCryptoAll: function() {
-    if (!config.useNative) {
-      return;
-    }
-
-    if (typeof globalThis !== 'undefined') {
-      if (globalThis.crypto) {
-        return globalThis.crypto.subtle || globalThis.crypto.webkitSubtle;
-      }
-      if (globalThis.msCrypto) {
-        return globalThis.msCrypto.subtle;
-      }
-    }
   },
 
   /**
@@ -544,23 +514,14 @@ const util = {
   getBigInteger,
 
   /**
-   * Get native Node.js crypto api. The default configuration is to use
-   * the api when available. But it can also be deactivated with config.useNative
+   * Get native Node.js crypto api.
    * @returns {Object}   The crypto module or 'undefined'
    */
   getNodeCrypto: function() {
-    if (!config.useNative) {
-      return;
-    }
-
     return require('crypto');
   },
 
   getNodeZlib: function() {
-    if (!config.useNative) {
-      return;
-    }
-
     return require('zlib');
   },
 

--- a/src/util.js
+++ b/src/util.js
@@ -28,12 +28,11 @@
 
 import stream from 'web-stream-tools';
 import config from './config';
-import util from './util'; // re-import module to access util functions
 import { getBigInteger } from './biginteger';
 
 const debugMode = globalThis.process && globalThis.process.env.NODE_ENV === 'development';
 
-export default {
+const util = {
   isString: function(data) {
     return typeof data === 'string' || String.prototype.isPrototypeOf(data);
   },
@@ -741,3 +740,5 @@ export default {
     return error;
   }
 };
+
+export default util;

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -247,72 +247,11 @@ module.exports = () => describe('API functional testing', function() {
         expect(text).to.equal(plaintext);
       }));
     }
-
-    function testAESGCM(plaintext, nativeDecrypt) {
-      symmAlgos.forEach(function(algo) {
-        if (algo.substr(0,3) === 'aes') {
-          it(algo, async function() {
-            const key = await crypto.generateSessionKey(algo);
-            const iv = await crypto.random.getRandomBytes(crypto.gcm.ivLength);
-            let modeInstance = await crypto.gcm(algo, key);
-
-            const ciphertext = await modeInstance.encrypt(util.strToUint8Array(plaintext), iv);
-
-            openpgp.config.useNative = nativeDecrypt;
-            modeInstance = await crypto.gcm(algo, key);
-
-            const decrypted = await modeInstance.decrypt(util.strToUint8Array(util.uint8ArrayToStr(ciphertext)), iv);
-            const decryptedStr = util.uint8ArrayToStr(decrypted);
-            expect(decryptedStr).to.equal(plaintext);
-          });
-        }
-      });
-    }
-
     it("Symmetric with OpenPGP CFB", async function () {
       await testCFB("hello");
       await testCFB("1234567");
       await testCFB("foobarfoobar1234567890");
       await testCFB("12345678901234567890123456789012345678901234567890");
-    });
-
-    describe('Symmetric AES-GCM (native)', function() {
-      let useNativeVal;
-      beforeEach(function() {
-        useNativeVal = openpgp.config.useNative;
-        openpgp.config.useNative = true;
-      });
-      afterEach(function() {
-        openpgp.config.useNative = useNativeVal;
-      });
-
-      testAESGCM("12345678901234567890123456789012345678901234567890", true);
-    });
-
-    describe('Symmetric AES-GCM (asm.js fallback)', function() {
-      let useNativeVal;
-      beforeEach(function() {
-        useNativeVal = openpgp.config.useNative;
-        openpgp.config.useNative = false;
-      });
-      afterEach(function() {
-        openpgp.config.useNative = useNativeVal;
-      });
-
-      testAESGCM("12345678901234567890123456789012345678901234567890", false);
-    });
-
-    describe('Symmetric AES-GCM (native encrypt, asm.js decrypt)', function() {
-      let useNativeVal;
-      beforeEach(function() {
-        useNativeVal = openpgp.config.useNative;
-        openpgp.config.useNative = true;
-      });
-      afterEach(function() {
-        openpgp.config.useNative = useNativeVal;
-      });
-
-      testAESGCM("12345678901234567890123456789012345678901234567890", false);
     });
 
     it('Asymmetric using RSA with eme_pkcs1 padding', async function () {

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -242,7 +242,7 @@ module.exports = () => describe('API functional testing', function() {
       await Promise.all(symmAlgos.map(async function(algo) {
         const symmKey = await crypto.generateSessionKey(algo);
         const IV = new Uint8Array(crypto.cipher[algo].blockSize);
-        const symmencData = await crypto.cfb.encrypt(algo, symmKey, util.strToUint8Array(plaintext), IV);
+        const symmencData = await crypto.cfb.encrypt(algo, symmKey, util.strToUint8Array(plaintext), IV, openpgp.config);
         const text = util.uint8ArrayToStr(await crypto.cfb.decrypt(algo, symmKey, symmencData, new Uint8Array(crypto.cipher[algo].blockSize)));
         expect(text).to.equal(plaintext);
       }));

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -5,7 +5,7 @@
 const EAX = require('../../src/crypto/eax');
 const util = require('../../src/util');
 
-const stub = require('sinon/lib/sinon/stub');
+const sandbox = require('sinon/lib/sinon/sandbox');
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
@@ -126,14 +126,15 @@ function testAESEAX() {
 }
 
 module.exports = () => describe('Symmetric AES-EAX', function() {
+  let sinonSandbox;
   let getWebCryptoStub;
   let getNodeCryptoStub;
 
   const disableNative = () => {
     enableNative();
     // stubbed functions return undefined
-    getWebCryptoStub = stub(util, "getWebCrypto");
-    getNodeCryptoStub = stub(util, "getNodeCrypto");
+    getWebCryptoStub = sinonSandbox.stub(util, "getWebCrypto");
+    getNodeCryptoStub = sinonSandbox.stub(util, "getNodeCrypto");
   };
   const enableNative = () => {
     getWebCryptoStub && getWebCryptoStub.restore();
@@ -142,11 +143,12 @@ module.exports = () => describe('Symmetric AES-EAX', function() {
 
   describe('Symmetric AES-EAX (native)', function() {
     beforeEach(function () {
+      sinonSandbox = sandbox.create();
       enableNative();
     });
 
     afterEach(function () {
-      enableNative();
+      sinonSandbox.restore();
     });
 
     testAESEAX();
@@ -154,11 +156,12 @@ module.exports = () => describe('Symmetric AES-EAX', function() {
 
   describe('Symmetric AES-EAX (asm.js fallback)', function() {
     beforeEach(function () {
+      sinonSandbox = sandbox.create();
       disableNative();
     });
 
     afterEach(function () {
-      enableNative();
+      sinonSandbox.restore();
     });
 
     testAESEAX();

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -2,10 +2,10 @@
 
 // Adapted from https://github.com/artjomb/cryptojs-extension/blob/8c61d159/test/eax.js
 
-const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const EAX = require('../../src/crypto/eax');
 const util = require('../../src/util');
 
+const stub = require('sinon/lib/sinon/stub');
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
@@ -125,30 +125,42 @@ function testAESEAX() {
   });
 }
 
-module.exports = () => {
+module.exports = () => describe('Symmetric AES-EAX', function() {
+  let getWebCryptoStub;
+  let getNodeCryptoStub;
+
+  const disableNative = () => {
+    enableNative();
+    // stubbed functions return undefined
+    getWebCryptoStub = stub(util, "getWebCrypto");
+    getNodeCryptoStub = stub(util, "getNodeCrypto");
+  };
+  const enableNative = () => {
+    getWebCryptoStub && getWebCryptoStub.restore();
+    getNodeCryptoStub && getNodeCryptoStub.restore();
+  };
+
   describe('Symmetric AES-EAX (native)', function() {
-    let useNativeVal;
-    beforeEach(function() {
-      useNativeVal = openpgp.config.useNative;
-      openpgp.config.useNative = true;
+    beforeEach(function () {
+      enableNative();
     });
-    afterEach(function() {
-      openpgp.config.useNative = useNativeVal;
+
+    afterEach(function () {
+      enableNative();
     });
 
     testAESEAX();
   });
 
   describe('Symmetric AES-EAX (asm.js fallback)', function() {
-    let useNativeVal;
-    beforeEach(function() {
-      useNativeVal = openpgp.config.useNative;
-      openpgp.config.useNative = false;
+    beforeEach(function () {
+      disableNative();
     });
-    afterEach(function() {
-      openpgp.config.useNative = useNativeVal;
+
+    afterEach(function () {
+      enableNative();
     });
 
     testAESEAX();
   });
-};
+});

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -218,6 +218,9 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
         it(`NIST ${curveName}`, async function () {
           const nodeCrypto = util.getNodeCrypto();
           const webCrypto = util.getWebCrypto();
+          if (!nodeCrypto && !webCrypto) {
+            this.skip();
+          }
 
           const curve = new elliptic_curves.Curve(curveName);
           const oid = new OID(curve.oid);

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -4,6 +4,8 @@ const KDFParams = require('../../src/type/kdf_params');
 const elliptic_curves = require('../../src/crypto/public_key/elliptic');
 const util = require('../../src/util');
 
+const stub = require('sinon/lib/sinon/stub');
+const spy = require('sinon/lib/sinon/spy');
 const chai = require('chai');
 const elliptic_data = require('./elliptic_data');
 
@@ -133,133 +135,99 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   ]);
 
   describe('ECDHE key generation', function () {
+    const ecdh = elliptic_curves.ecdh;
+
     it('Invalid curve', async function () {
       if (!openpgp.config.useIndutnyElliptic && !util.getNodeCrypto()) {
         this.skip();
       }
-      const { key: publicKey } = await openpgp.generateKey({ curve: "secp256k1", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      await expect(
-        openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') })
+      const curve = new elliptic_curves.Curve('secp256k1');
+      const oid = new OID(curve.oid);
+      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+      const data = util.strToUint8Array('test');
+      expect(
+        ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1)
       ).to.be.rejectedWith(Error, /Public key is not valid for specified curve|Failed to translate Buffer to a EC_POINT|Unknown point format/);
     });
-    it('Invalid public part of ephemeral key and private key', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = Q2;
-      privateKey.subKeys[0].keyPacket.privateParams.d = d2;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+    it('Different keys', async function () {
+      const curve = new elliptic_curves.Curve('curve25519');
+      const oid = new OID(curve.oid);
+      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+      const data = util.strToUint8Array('test');
+      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
       await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).to.be.rejectedWith('Error decrypting message: Key Data Integrity failed');
+        ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint1)
+      ).to.be.rejectedWith(/Key Data Integrity failed/);
     });
     it('Invalid fingerprint', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = Q2;
-      privateKey.subKeys[0].keyPacket.privateParams.d = d2;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint2;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
+      const curve = new elliptic_curves.Curve('curve25519');
+      const oid = new OID(curve.oid);
+      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+      const data = util.strToUint8Array('test');
+      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q2, fingerprint1);
       await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).to.be.rejectedWith('Error decrypting message: Session key decryption failed');
-    });
-    it('Different keys', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = Q2;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      privateKey.subKeys[0].keyPacket.privateParams.d = d1;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-      await expect(
-        openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).to.be.rejectedWith('Error decrypting message: Key Data Integrity failed');
+        ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint2)
+      ).to.be.rejectedWith(/Key Data Integrity failed/);
     });
     it('Successful exchange curve25519', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "curve25519", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = Q1;
-      privateKey.subKeys[0].keyPacket.privateParams.d = d1;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-      expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).data).to.equal('test');
-    });
-    it('Successful exchange NIST P256', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "p256", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = key_data.p256.pub;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "p256", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p256.pub;
-      privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p256.priv;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-      expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).data).to.equal('test');
-    });
-    it('Successful exchange NIST P384', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "p384", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = key_data.p384.pub;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "p384", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p384.pub;
-      privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p384.priv;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-      expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).data).to.equal('test');
-    });
-    it('Successful exchange NIST P521', async function () {
-      const { key: publicKey } = await openpgp.generateKey({ curve: "p521", userIds: [{ name: 'Test' }] });
-      publicKey.subKeys[0].keyPacket.publicParams.Q = key_data.p521.pub;
-      publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const { key: privateKey } = await openpgp.generateKey({ curve: "p521", userIds: [{ name: 'Test' }] });
-      privateKey.subKeys[0].keyPacket.publicParams.Q = key_data.p521.pub;
-      privateKey.subKeys[0].keyPacket.privateParams.d = key_data.p521.priv;
-      privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-      const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-      expect((
-        await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-      ).data).to.equal('test');
+      const curve = new elliptic_curves.Curve('curve25519');
+      const oid = new OID(curve.oid);
+      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+      const data = util.strToUint8Array('test');
+      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
+      expect(await ecdh.decrypt(oid, kdfParams, V, C, Q1, d1, fingerprint1)).to.deep.equal(data);
     });
 
-    it('Comparing decrypting with useNative = true and false', async function () {
-      const names = ["p256", "p384", "p521"];
-      return Promise.all(names.map(async function (name) {
-        const { key: publicKey } = await openpgp.generateKey({ curve: name, userIds: [{ name: 'Test' }] });
-        publicKey.subKeys[0].keyPacket.publicParams.Q = key_data[name].pub;
-        publicKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-        const { key: privateKey } = await openpgp.generateKey({ curve: name, userIds: [{ name: 'Test' }] });
-        privateKey.subKeys[0].keyPacket.publicParams.Q = key_data[name].pub;
-        privateKey.subKeys[0].keyPacket.privateParams.d = key_data[name].priv;
-        privateKey.subKeys[0].keyPacket.fingerprint = fingerprint1;
-        const armoredMessage = await openpgp.encrypt({ publicKeys: [publicKey], message: openpgp.Message.fromText('test') });
-        expect((
-          await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-        ).data).to.equal('test');
-        const useNative = openpgp.config.useNative;
-        openpgp.config.useNative = !useNative;
+    let getWebCryptoStub;
+    let getNodeCryptoStub;
+    const disableNative = () => {
+      enableNative();
+      // stubbed functions return undefined
+      getWebCryptoStub = stub(util, "getWebCrypto");
+      getNodeCryptoStub = stub(util, "getNodeCrypto");
+    };
+    const enableNative = () => {
+      getWebCryptoStub && getWebCryptoStub.restore();
+      getNodeCryptoStub && getNodeCryptoStub.restore();
+    };
+
+    ['p256', 'p384', 'p521'].forEach(curveName => {
+      it(`NIST ${curveName} - Successful exchange`, async function () {
+        const curve = new elliptic_curves.Curve(curveName);
+        const oid = new OID(curve.oid);
+        const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+        const data = util.strToUint8Array('test');
+        const Q = key_data[curveName].pub;
+        const d = key_data[curveName].priv;
+        const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1);
+        expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
+      });
+
+      it(`NIST ${curveName} - Comparing decrypting with and without native crypto`, async function () {
+        const nodeCrypto = util.getNodeCrypto();
+        const webCrypto = util.getWebCrypto();
+
+        const curve = new elliptic_curves.Curve(curveName);
+        const oid = new OID(curve.oid);
+        const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+        const data = util.strToUint8Array('test');
+        const Q = key_data[curveName].pub;
+        const d = key_data[curveName].priv;
+        const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1);
+
+        const nativeDecryptSpy = webCrypto ? spy(webCrypto, 'deriveBits') : spy(nodeCrypto, 'createECDH');
+        expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
+        disableNative();
         try {
-          expect((
-            await openpgp.decrypt({ privateKeys: [privateKey], message: await openpgp.readMessage({ armoredMessage }) })
-          ).data).to.equal('test');
+          expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
+          if (curveName !== 'p521') { // safari does not implement p521 in webcrypto
+            expect(nativeDecryptSpy.calledOnce).to.be.true;
+          }
         } finally {
-          openpgp.config.useNative = useNative;
+          enableNative();
+          nativeDecryptSpy.restore();
         }
-      }));
+      });
     });
   });
 });

--- a/test/crypto/gcm.js
+++ b/test/crypto/gcm.js
@@ -39,11 +39,14 @@ module.exports = () => describe('Symmetric AES-GCM (experimental)', function() {
     );
     aesAlgos.forEach(function(algo) {
       it(algo, async function() {
+        const nodeCrypto = util.getNodeCrypto();
+        const webCrypto = util.getWebCrypto();
+        if (!nodeCrypto && !webCrypto) {
+          this.skip(); // eslint-disable-line no-invalid-this
+        }
         const key = await crypto.generateSessionKey(algo);
         const iv = await crypto.random.getRandomBytes(crypto.gcm.ivLength);
 
-        const nodeCrypto = util.getNodeCrypto();
-        const webCrypto = util.getWebCrypto();
         const nativeEncryptSpy = webCrypto ? sinonSandbox.spy(webCrypto, 'encrypt') : sinonSandbox.spy(nodeCrypto, 'createCipheriv');
         const nativeDecryptSpy = webCrypto ? sinonSandbox.spy(webCrypto, 'decrypt') : sinonSandbox.spy(nodeCrypto, 'createDecipheriv');
 

--- a/test/crypto/gcm.js
+++ b/test/crypto/gcm.js
@@ -1,0 +1,86 @@
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
+const crypto = require('../../src/crypto');
+const util = require('../../src/util');
+const stub = require('sinon/lib/sinon/stub');
+const spy = require('sinon/lib/sinon/spy');
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+module.exports = () => describe('Symmetric AES-GCM (experimental)', function() {
+  let getWebCryptoStub;
+  let getNodeCryptoStub;
+  let nativeEncryptSpy;
+  let nativeDecryptSpy;
+
+  const disableNative = () => {
+    enableNative();
+    getWebCryptoStub = stub(util, "getWebCrypto");
+    getNodeCryptoStub = stub(util, "getNodeCrypto");
+    getWebCryptoStub.returns(null);
+    getNodeCryptoStub.returns(null);
+  };
+  const enableNative = () => {
+    getWebCryptoStub && getWebCryptoStub.restore();
+    getNodeCryptoStub && getNodeCryptoStub.restore();
+  };
+
+  beforeEach(function () {
+    const nodeCrypto = util.getNodeCrypto();
+    const webCrypto = util.getWebCrypto();
+    nativeEncryptSpy = webCrypto ? spy(webCrypto, 'encrypt') : spy(nodeCrypto, 'createCipheriv');
+    nativeDecryptSpy = webCrypto ? spy(webCrypto, 'decrypt') : spy(nodeCrypto, 'createDecipheriv');
+    enableNative();
+  });
+
+  afterEach(function () {
+    nativeEncryptSpy.restore();
+    nativeDecryptSpy.restore();
+    enableNative();
+  });
+
+  function testAESGCM(plaintext, nativeEncrypt, nativeDecrypt) {
+    const aesAlgos = Object.keys(openpgp.enums.symmetric).filter(
+      algo => algo.substr(0,3) === 'aes'
+    );
+    aesAlgos.forEach(function(algo) {
+      it(algo, async function() {
+        const key = await crypto.generateSessionKey(algo);
+        const iv = await crypto.random.getRandomBytes(crypto.gcm.ivLength);
+
+        nativeEncrypt || disableNative();
+        let modeInstance = await crypto.gcm(algo, key);
+        const ciphertext = await modeInstance.encrypt(util.strToUint8Array(plaintext), iv);
+        enableNative();
+
+        nativeDecrypt || disableNative();
+        modeInstance = await crypto.gcm(algo, key);
+        const decrypted = await modeInstance.decrypt(util.strToUint8Array(util.uint8ArrayToStr(ciphertext)), iv);
+        enableNative();
+
+        const decryptedStr = util.uint8ArrayToStr(decrypted);
+        expect(decryptedStr).to.equal(plaintext);
+
+        if (algo !== 'aes192') { // not implemented by webcrypto
+          // sanity check: native crypto was indeed on/off
+          expect(nativeEncryptSpy.called).to.equal(nativeEncrypt);
+          expect(nativeDecryptSpy.called).to.equal(nativeDecrypt);
+        }
+      });
+    });
+  }
+
+  describe('Symmetric AES-GCM (native)', function() {
+    testAESGCM("12345678901234567890123456789012345678901234567890", true, true);
+  });
+
+  describe('Symmetric AES-GCM (asm.js fallback)', function() {
+    testAESGCM("12345678901234567890123456789012345678901234567890", false, false);
+  });
+
+  describe('Symmetric AES-GCM (native encrypt, asm.js decrypt)', function() {
+    testAESGCM("12345678901234567890123456789012345678901234567890", true, false);
+  });
+});

--- a/test/crypto/gcm.js
+++ b/test/crypto/gcm.js
@@ -1,9 +1,9 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const crypto = require('../../src/crypto');
 const util = require('../../src/util');
+
 const stub = require('sinon/lib/sinon/stub');
 const spy = require('sinon/lib/sinon/spy');
-
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
@@ -17,10 +17,9 @@ module.exports = () => describe('Symmetric AES-GCM (experimental)', function() {
 
   const disableNative = () => {
     enableNative();
+    // stubbed functions return undefined
     getWebCryptoStub = stub(util, "getWebCrypto");
     getNodeCryptoStub = stub(util, "getNodeCrypto");
-    getWebCryptoStub.returns(null);
-    getNodeCryptoStub.returns(null);
   };
   const enableNative = () => {
     getWebCryptoStub && getWebCryptoStub.restore();

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -7,6 +7,7 @@ module.exports = () => describe('Crypto', function () {
   require('./ecdh.js')();
   require('./pkcs5.js')();
   require('./aes_kw.js')();
+  require('./gcm.js')();
   require('./eax.js')();
   require('./ocb.js')();
   require('./rsa.js')();

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -244,13 +244,13 @@ EJ4QcD/oQ6x1M/8X/iKQCtxZP8RnlrbH7ExkNON5s5g=
   });
   it('Decrypt and verify message with leading zero in hash signed with old elliptic algorithm', async function () {
     //this test would not work with nodeCrypto, since message is signed with leading zero stripped from the hash
-    const useNative = openpgp.config.useNative;
-    openpgp.config.useNative = false;
+    if (util.getNodeCrypto()) {
+      this.skip(); // eslint-disable-line no-invalid-this
+    }
     const juliet = await load_priv_key('juliet');
     const romeo = await load_pub_key('romeo');
     const msg = await openpgp.readMessage({ armoredMessage: data.romeo.message_encrypted_with_leading_zero_in_hash_signed_by_elliptic_with_old_implementation });
     const result = await openpgp.decrypt({ privateKeys: juliet, publicKeys: [romeo], message: msg });
-    openpgp.config.useNative = useNative;
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message_with_leading_zero_in_hash_old_elliptic_implementation);
     expect(result.signatures).to.have.length(1);

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -1,0 +1,242 @@
+const { expect } = require('chai');
+
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
+
+module.exports = () => describe('Custom configuration', function() {
+  it('openpgp.generateKey', async function() {
+    const v5KeysVal = openpgp.config.v5Keys;
+    const preferHashAlgorithmVal = openpgp.config.preferHashAlgorithm;
+    const showCommentVal = openpgp.config.showComment;
+    openpgp.config.v5Keys = false;
+    openpgp.config.preferHashAlgorithm = openpgp.enums.hash.sha256;
+    openpgp.config.showComment = false;
+
+    try {
+      const opt = {
+        userIds: { name: 'Test User', email: 'text@example.com' }
+      };
+      const { key, privateKeyArmored } = await openpgp.generateKey(opt);
+      expect(key.keyPacket.version).to.equal(4);
+      expect(privateKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
+      expect(key.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(openpgp.config.preferHashAlgorithm);
+
+      const config = {
+        v5Keys: true,
+        showComment: true,
+        preferHashAlgorithm: openpgp.enums.hash.sha512
+      };
+      const opt2 = {
+        userIds: { name: 'Test User', email: 'text@example.com' },
+        config
+      };
+      const { key: key2, privateKeyArmored: privateKeyArmored2 } = await openpgp.generateKey(opt2);
+      expect(key2.keyPacket.version).to.equal(5);
+      expect(privateKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
+      expect(key2.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(config.preferHashAlgorithm);
+    } finally {
+      openpgp.config.v5Keys = v5KeysVal;
+      openpgp.config.preferHashAlgorithm = preferHashAlgorithmVal;
+      openpgp.config.showComment = showCommentVal;
+    }
+  });
+
+  it('openpgp.reformatKey', async function() {
+    const compressionVal = openpgp.config.compression;
+    const preferHashAlgorithmVal = openpgp.config.preferHashAlgorithm;
+    const showCommentVal = openpgp.config.showComment;
+    openpgp.config.compression = openpgp.enums.compression.bzip2;
+    openpgp.config.preferHashAlgorithm = openpgp.enums.hash.sha256;
+    openpgp.config.showComment = false;
+
+    try {
+      const userIds = { name: 'Test User', email: 'text2@example.com' };
+      const { key: origKey } = await openpgp.generateKey({ userIds });
+
+      const opt = { privateKey: origKey, userIds };
+      const { key: refKey, privateKeyArmored: refKeyArmored } = await openpgp.reformatKey(opt);
+      const prefs = refKey.users[0].selfCertifications[0];
+      expect(prefs.preferredCompressionAlgorithms[0]).to.equal(openpgp.config.compression);
+      expect(prefs.preferredHashAlgorithms[0]).to.equal(openpgp.config.preferHashAlgorithm);
+      expect(refKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
+
+      const config = {
+        showComment: true,
+        compression: openpgp.enums.compression.zip,
+        preferHashAlgorithm: openpgp.enums.hash.sha512
+      };
+      const opt2 = { privateKey: origKey, userIds, config };
+      const { key: refKey2, privateKeyArmored: refKeyArmored2 } = await openpgp.reformatKey(opt2);
+      const prefs2 = refKey2.users[0].selfCertifications[0];
+      expect(prefs2.preferredCompressionAlgorithms[0]).to.equal(config.compression);
+      expect(prefs2.preferredHashAlgorithms[0]).to.equal(config.preferHashAlgorithm);
+      expect(refKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
+    } finally {
+      openpgp.config.compression = compressionVal;
+      openpgp.config.preferHashAlgorithm = preferHashAlgorithmVal;
+      openpgp.config.showComment = showCommentVal;
+    }
+  });
+
+
+  it('openpgp.revokeKey', async function() {
+    const showCommentVal = openpgp.config.showComment;
+    openpgp.config.showComment = false;
+
+    try {
+      const userIds = { name: 'Test User', email: 'text2@example.com' };
+      const { key, revocationCertificate } = await openpgp.generateKey({ userIds });
+
+      const opt = { key };
+      const { privateKeyArmored: revKeyArmored } = await openpgp.revokeKey(opt);
+      expect(revKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
+
+      const opt2 = { key, config: { showComment: true } };
+      const { privateKeyArmored: revKeyArmored2 } = await openpgp.revokeKey(opt2);
+      expect(revKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
+
+      const opt3 = {
+        key,
+        revocationCertificate,
+        config: { rejectHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) }
+      };
+      await expect(openpgp.revokeKey(opt3)).to.be.rejectedWith(/Insecure hash algorithm/);
+    } finally {
+      openpgp.config.showComment = showCommentVal;
+    }
+  });
+
+  it('openpgp.decryptKey', async function() {
+    const userIds = { name: 'Test User', email: 'text2@example.com' };
+    const passphrase = '12345678';
+
+    const { key } = await openpgp.generateKey({ userIds, passphrase });
+    key.keyPacket.makeDummy();
+
+    const opt = {
+      privateKey: await openpgp.readKey({ armoredKey: key.armor() }),
+      passphrase,
+      config: { rejectHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) }
+    };
+    await expect(openpgp.decryptKey(opt)).to.be.rejectedWith(/Insecure hash algorithm/);
+  });
+
+  it('openpgp.encryptKey', async function() {
+    const s2kIterationCountByteVal = openpgp.config.s2kIterationCountByte;
+    openpgp.config.s2kIterationCountByte = 224;
+
+    try {
+      const passphrase = '12345678';
+      const userIds = { name: 'Test User', email: 'text2@example.com' };
+      const { key: privateKey } = await openpgp.generateKey({ userIds });
+
+      const encKey = await openpgp.encryptKey({ privateKey, userIds, passphrase });
+      expect(encKey.keyPacket.s2k.c).to.equal(openpgp.config.s2kIterationCountByte);
+
+      const config = { s2kIterationCountByte: 123 };
+      const encKey2 = await openpgp.encryptKey({ privateKey, userIds, passphrase, config });
+      expect(encKey2.keyPacket.s2k.c).to.equal(config.s2kIterationCountByte);
+    } finally {
+      openpgp.config.s2kIterationCountByte = s2kIterationCountByteVal;
+    }
+  });
+
+  it('openpgp.encrypt', async function() {
+    const aeadProtectVal = openpgp.config.aeadProtect;
+    const compressionVal = openpgp.config.compression;
+    openpgp.config.aeadProtect = false;
+    openpgp.config.compression = openpgp.enums.compression.uncompressed;
+
+    try {
+      const passwords = ['12345678'];
+      const message = openpgp.Message.fromText("test");
+
+      const armored = await openpgp.encrypt({ message, passwords });
+      const encrypted = await openpgp.readMessage({ armoredMessage: armored });
+      const { packets: [skesk, encData] } = encrypted;
+      expect(skesk.version).to.equal(4); // cfb
+      expect(encData.tag).to.equal(openpgp.enums.packet.symEncryptedIntegrityProtectedData);
+      const { packets: [literal] } = await encrypted.decrypt(null, passwords, null, encrypted.fromStream, openpgp.config);
+      expect(literal.tag).to.equal(openpgp.enums.packet.literalData);
+
+      const config = {
+        aeadProtect: true,
+        compression: openpgp.enums.compression.zip,
+        deflateLevel: 1
+      };
+      const armored2 = await openpgp.encrypt({ message, passwords, config });
+      const encrypted2 = await openpgp.readMessage({ armoredMessage: armored2 });
+      const { packets: [skesk2, encData2] } = encrypted2;
+      expect(skesk2.version).to.equal(5);
+      expect(encData2.tag).to.equal(openpgp.enums.packet.AEADEncryptedData);
+      const { packets: [compressed] } = await encrypted2.decrypt(null, passwords, null, encrypted2.fromStream, openpgp.config);
+      expect(compressed.tag).to.equal(openpgp.enums.packet.compressedData);
+      expect(compressed.algorithm).to.equal("zip");
+    } finally {
+      openpgp.config.aeadProtect = aeadProtectVal;
+      openpgp.config.compression = compressionVal;
+    }
+  });
+
+  it('openpgp.sign', async function() {
+    const userIds = { name: 'Test User', email: 'text2@example.com' };
+    const { privateKeyArmored } = await openpgp.generateKey({ userIds });
+    const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+
+    const message = openpgp.Message.fromText("test");
+    const opt = {
+      message,
+      privateKeys: key,
+      config: { rejectHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) }
+    };
+    await expect(openpgp.sign(opt)).to.be.rejectedWith(/Insecure hash algorithm/);
+    opt.detached = true;
+    await expect(openpgp.sign(opt)).to.be.rejectedWith(/Insecure hash algorithm/);
+
+    const clearText = openpgp.CleartextMessage.fromText("test");
+    const opt2 = {
+      message: clearText,
+      privateKeys: key,
+      config: { rejectHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) }
+    };
+    await expect(openpgp.sign(opt2)).to.be.rejectedWith(/Insecure hash algorithm/);
+  });
+
+  it('openpgp.verify', async function() {
+    const userIds = { name: 'Test User', email: 'text2@example.com' };
+    const { privateKeyArmored } = await openpgp.generateKey({ userIds });
+    const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    const config = { rejectMessageHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) };
+
+
+    const message = openpgp.Message.fromText("test");
+    const signed = await openpgp.sign({ message, privateKeys: key });
+    const opt = {
+      message: await openpgp.readMessage({ armoredMessage: signed }),
+      publicKeys: key,
+      config
+    };
+    const { signatures: [sig] } = await openpgp.verify(opt);
+    await expect(sig.error).to.match(/Insecure message hash algorithm/);
+    const armoredSignature = await openpgp.sign({ message, privateKeys: key, detached: true });
+    const opt2 = {
+      message,
+      signature: await openpgp.readSignature({ armoredSignature }),
+      publicKeys: key,
+      config
+    };
+    const { signatures: [sig2] } = await openpgp.verify(opt2);
+    await expect(sig2.error).to.match(/Insecure message hash algorithm/);
+
+    const cleartext = openpgp.CleartextMessage.fromText("test");
+    const signedCleartext = await openpgp.sign({ message: cleartext, privateKeys: key });
+    const opt3 = {
+      message: await openpgp.readCleartextMessage({ cleartextMessage: signedCleartext }),
+      publicKeys: key,
+      config
+    };
+    const { signatures: [sig3] } = await openpgp.verify(opt3);
+    await expect(sig3.error).to.match(/Insecure message hash algorithm/);
+
+  });
+
+});

--- a/test/general/index.js
+++ b/test/general/index.js
@@ -7,6 +7,7 @@ module.exports = () => describe('General', function () {
   require('./signature.js')();
   require('./key.js')();
   require('./openpgp.js')();
+  require('./config.js')();
   require('./hkp.js')();
   require('./wkd.js')();
   require('./oid.js')();

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2162,16 +2162,17 @@ function versionSpecificTests() {
     }
   });
 
-  it('Generated key is not unlocked by default', function() {
+  it('Generated key is not unlocked by default', async function() {
     const opt = { userIds: { name: 'test', email: 'a@b.com' }, passphrase: '123' };
-    let key;
-    return openpgp.generateKey(opt).then(function(newKey) {
-      key = newKey.key;
-      return openpgp.Message.fromText('hello').encrypt([key]);
-    }).then(function(msg) {
-      return msg.decrypt([key]);
-    }).catch(function(err) {
-      expect(err.message).to.equal('Private key is not decrypted.');
+    const { key } = await openpgp.generateKey(opt);
+    return openpgp.encrypt({
+      message: openpgp.Message.fromText('hello'),
+      publicKeys: key
+    }).then(async armoredMessage => openpgp.decrypt({
+      message: await openpgp.readMessage({ armoredMessage }),
+      privateKeys: key
+    })).catch(function(err) {
+      expect(err.message).to.match(/Private key is not decrypted./);
     });
   });
 
@@ -2725,7 +2726,7 @@ module.exports = () => describe('Key', function() {
     `.replace(/\s+/g, ''));
 
     const packetlist = new openpgp.PacketList();
-    await packetlist.read(packetBytes, { PublicKeyPacket: openpgp.PublicKeyPacket });
+    await packetlist.read(packetBytes, { PublicKeyPacket: openpgp.PublicKeyPacket }, undefined, openpgp.config);
     const key = packetlist[0];
     expect(key).to.exist;
   });
@@ -2755,7 +2756,7 @@ module.exports = () => describe('Key', function() {
 
     const packetlist = new openpgp.PacketList();
 
-    await packetlist.read((await openpgp.unarmor(pub_sig_test)).data, openpgp);
+    await packetlist.read((await openpgp.unarmor(pub_sig_test)).data, openpgp, undefined, openpgp.config);
 
     const subkeys = pubKey.getSubkeys();
     expect(subkeys).to.exist;
@@ -3233,7 +3234,7 @@ module.exports = () => describe('Key', function() {
 
     const input = await openpgp.unarmor(revocation_certificate_arm4);
     const packetlist = new openpgp.PacketList();
-    await packetlist.read(input.data, { SignaturePacket: openpgp.SignaturePacket });
+    await packetlist.read(input.data, { SignaturePacket: openpgp.SignaturePacket }, undefined, openpgp.config);
     const armored = openpgp.armor(openpgp.enums.armor.publicKey, packetlist.write());
 
     expect(revocationCertificate.replace(/^Comment: .*$\n/mg, '')).to.equal(armored.replace(/^Comment: .*$\n/mg, ''));

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2827,23 +2827,18 @@ module.exports = () => describe('Key', function() {
   });
 
   it('should not decrypt using a sign-only RSA key, unless explicitly configured', async function () {
-    const allowSigningKeyDecryption = openpgp.config.allowInsecureDecryptionWithSigningKeys;
     const key = await openpgp.readKey({ armoredKey: rsaSignOnly });
-    try {
-      openpgp.config.allowInsecureDecryptionWithSigningKeys = false;
-      await expect(openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
-        privateKeys: key
-      })).to.be.rejectedWith(/Session key decryption failed/);
 
-      openpgp.config.allowInsecureDecryptionWithSigningKeys = true;
-      await expect(openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
-        privateKeys: key
-      })).to.be.fulfilled;
-    } finally {
-      openpgp.config.allowInsecureDecryptionWithSigningKeys = allowSigningKeyDecryption;
-    }
+    await expect(openpgp.decrypt({
+      message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
+      privateKeys: key
+    })).to.be.rejectedWith(/Session key decryption failed/);
+
+    await expect(openpgp.decrypt({
+      message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
+      privateKeys: key,
+      config: { allowInsecureDecryptionWithSigningKeys: true }
+    })).to.be.fulfilled;
   });
 
   it('Method getExpirationTime V4 Key', async function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -798,31 +798,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
   });
 
   describe('generateKey - integration tests', function() {
-    let useNativeVal;
-
-    beforeEach(function() {
-      useNativeVal = openpgp.config.useNative;
-    });
-
-    afterEach(function() {
-      openpgp.config.useNative = useNativeVal;
-    });
-
-    it('should work in JS', function() {
-      openpgp.config.useNative = false;
-      const opt = {
-        userIds: [{ name: 'Test User', email: 'text@example.com' }]
-      };
-
-      return openpgp.generateKey(opt).then(function(newKey) {
-        expect(newKey.key.getUserIds()[0]).to.equal('Test User <text@example.com>');
-        expect(newKey.publicKeyArmored).to.match(/^-----BEGIN PGP PUBLIC/);
-        expect(newKey.privateKeyArmored).to.match(/^-----BEGIN PGP PRIVATE/);
-      });
-    });
-
-    it('should work in with native crypto', function() {
-      openpgp.config.useNative = true;
+    it('should work', function() {
       const opt = {
         userIds: [{ name: 'Test User', email: 'text@example.com' }]
       };
@@ -845,7 +821,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     let privateKey;
     let publicKey;
     let publicKeyNoAEAD;
-    let useNativeVal;
     let aeadProtectVal;
     let aeadModeVal;
     let aeadChunkSizeByteVal;
@@ -864,7 +839,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       publicKey_1337 = privateKey_1337.toPublic();
       privateKeyMismatchingParams = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
 
-      useNativeVal = openpgp.config.useNative;
       aeadProtectVal = openpgp.config.aeadProtect;
       aeadModeVal = openpgp.config.aeadMode;
       aeadChunkSizeByteVal = openpgp.config.aeadChunkSizeByte;
@@ -872,7 +846,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     });
 
     afterEach(function() {
-      openpgp.config.useNative = useNativeVal;
       openpgp.config.aeadProtect = aeadProtectVal;
       openpgp.config.aeadMode = aeadModeVal;
       openpgp.config.aeadChunkSizeByte = aeadChunkSizeByteVal;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -685,7 +685,7 @@ function withCompression(tests) {
 
       tests(
         function(options) {
-          options.config = { ...openpgp.config, compression };
+          options.config = { compression };
           return options;
         },
         function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -685,7 +685,7 @@ function withCompression(tests) {
 
       tests(
         function(options) {
-          options.compression = compression;
+          options.config = { ...openpgp.config, compression };
           return options;
         },
         function() {
@@ -2389,7 +2389,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
           const message = await openpgp.readMessage({ binaryMessage: encrypted });
-          return message.decrypt([privateKey_2038_2045]);
+          return message.decrypt([privateKey_2038_2045], undefined, undefined, undefined, openpgp.config);
         }).then(async function (packets) {
           const literals = packets.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
@@ -2410,7 +2410,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
           const message = await openpgp.readMessage({ binaryMessage: encrypted });
-          return message.decrypt([privateKey_2000_2008]);
+          return message.decrypt([privateKey_2000_2008], undefined, undefined, undefined, openpgp.config);
         }).then(async function (packets) {
           const literals = packets.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
@@ -2431,12 +2431,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
           const message = await openpgp.readMessage({ binaryMessage: encrypted });
-          return message.decrypt([privateKey_2000_2008]);
+          return message.decrypt([privateKey_2000_2008], undefined, undefined, undefined, openpgp.config);
         }).then(async function (message) {
           const literals = message.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
           expect(+literals[0].date).to.equal(+past);
-          const signatures = await message.verify([publicKey_2000_2008], past);
+          const signatures = await message.verify([publicKey_2000_2008], past, undefined, openpgp.config);
           expect(await openpgp.stream.readToEnd(message.getText())).to.equal(plaintext);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+past);
           expect(await signatures[0].verified).to.be.true;
@@ -2459,13 +2459,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
           const message = await openpgp.readMessage({ binaryMessage: encrypted });
-          return message.decrypt([privateKey_2038_2045]);
+          return message.decrypt([privateKey_2038_2045], undefined, undefined, undefined, openpgp.config);
         }).then(async function (message) {
           const literals = message.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
           expect(literals[0].format).to.equal('binary');
           expect(+literals[0].date).to.equal(+future);
-          const signatures = await message.verify([publicKey_2038_2045], future);
+          const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
           expect(await openpgp.stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+future);
           expect(await signatures[0].verified).to.be.true;
@@ -2488,13 +2488,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
           const message = await openpgp.readMessage({ binaryMessage: encrypted });
-          return message.decrypt([privateKey_2038_2045]);
+          return message.decrypt([privateKey_2038_2045], undefined, undefined, undefined, openpgp.config);
         }).then(async function (message) {
           const literals = message.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
           expect(literals[0].format).to.equal('mime');
           expect(+literals[0].date).to.equal(+future);
-          const signatures = await message.verify([publicKey_2038_2045], future);
+          const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
           expect(await openpgp.stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+future);
           expect(await signatures[0].verified).to.be.true;

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -305,7 +305,7 @@ module.exports = () => describe("Packet", function() {
 
   it('Public key encrypted symmetric key packet', function() {
     const rsa = openpgp.enums.publicKey.rsaEncryptSign;
-    const keySize = util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
+    const keySize = 1024;
 
     return crypto.generateParams(rsa, keySize, 65537).then(function({ publicParams, privateParams }) {
       const enc = new openpgp.PublicKeyEncryptedSessionKeyPacket();

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -65,49 +65,65 @@ module.exports = () => describe("Packet", function() {
       '=KXkj\n' +
       '-----END PGP PRIVATE KEY BLOCK-----';
 
-  it('Symmetrically encrypted packet', async function() {
+  it('Symmetrically encrypted packet without integrity protection - allow decryption', async function() {
+    const aeadProtectVal = openpgp.config.aeadProtect;
+    const ignoreMdcErrorVal = openpgp.config.ignoreMdcError;
+    openpgp.config.aeadProtect = false;
+    openpgp.config.ignoreMdcError = true;
+
     const message = new openpgp.PacketList();
     const testText = input.createSomeMessage();
 
     const literal = new openpgp.LiteralDataPacket();
     literal.setText(testText);
 
-    const enc = new openpgp.SymmetricallyEncryptedDataPacket();
-    message.push(enc);
-    enc.packets.push(literal);
+    try {
+      const enc = new openpgp.SymmetricallyEncryptedDataPacket();
+      message.push(enc);
+      enc.packets.push(literal);
 
-    const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
-    const algo = 'aes256';
+      const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
+      const algo = 'aes256';
 
-    await enc.encrypt(algo, key);
+      await enc.encrypt(algo, key, undefined, openpgp.config);
 
-    const msg2 = new openpgp.Message();
-    await msg2.packets.read(message.write(), { SymmetricallyEncryptedDataPacket: openpgp.SymmetricallyEncryptedDataPacket });
-    msg2.packets[0].ignoreMdcError = true;
-    const dec = await msg2.decrypt(null, null, [{ algorithm: algo, data: key }]);
+      const msg2 = new openpgp.PacketList();
+      await msg2.read(message.write(), { SymmetricallyEncryptedDataPacket: openpgp.SymmetricallyEncryptedDataPacket });
+      await msg2[0].decrypt(algo, key, undefined, openpgp.config);
 
-    expect(await stringify(dec.packets[0].data)).to.equal(stringify(literal.data));
+      expect(await stringify(msg2[0].packets[0].data)).to.equal(stringify(literal.data));
+    } finally {
+      openpgp.config.aeadProtect = aeadProtectVal;
+      openpgp.config.ignoreMdcError = ignoreMdcErrorVal;
+    }
   });
 
-  it('Symmetrically encrypted packet - MDC error for modern cipher', async function() {
-    const message = new openpgp.PacketList();
-    const testText = input.createSomeMessage();
+  it('Symmetrically encrypted packet without integrity protection - disallow decryption by default', async function() {
+    const aeadProtectVal = openpgp.config.aeadProtect;
+    openpgp.config.aeadProtect = false;
 
-    const literal = new openpgp.LiteralDataPacket();
-    literal.setText(testText);
+    try {
+      const message = new openpgp.PacketList();
+      const testText = input.createSomeMessage();
 
-    const enc = new openpgp.SymmetricallyEncryptedDataPacket();
-    message.push(enc);
-    await enc.packets.push(literal);
+      const literal = new openpgp.LiteralDataPacket();
+      literal.setText(testText);
 
-    const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
-    const algo = 'aes256';
+      const enc = new openpgp.SymmetricallyEncryptedDataPacket();
+      message.push(enc);
+      await enc.packets.push(literal);
 
-    await enc.encrypt(algo, key);
+      const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
+      const algo = 'aes256';
 
-    const msg2 = new openpgp.PacketList();
-    await msg2.read(message.write(), { SymmetricallyEncryptedDataPacket: openpgp.SymmetricallyEncryptedDataPacket });
-    await expect(msg2[0].decrypt(algo, key)).to.eventually.be.rejectedWith('Decryption failed due to missing MDC.');
+      await enc.encrypt(algo, key, undefined, openpgp.config);
+
+      const msg2 = new openpgp.PacketList();
+      await msg2.read(message.write(), { SymmetricallyEncryptedDataPacket: openpgp.SymmetricallyEncryptedDataPacket });
+      await expect(msg2[0].decrypt(algo, key, undefined, openpgp.config)).to.eventually.be.rejectedWith('Decryption failed due to missing MDC.');
+    } finally {
+      openpgp.config.aeadProtect = aeadProtectVal;
+    }
   });
 
   it('Sym. encrypted integrity protected packet', async function() {
@@ -122,61 +138,40 @@ module.exports = () => describe("Packet", function() {
     msg.push(enc);
     literal.setText(testText);
     enc.packets.push(literal);
-    await enc.encrypt(algo, key);
+    await enc.encrypt(algo, key, undefined, openpgp.config);
 
     const msg2 = new openpgp.PacketList();
     await msg2.read(msg.write(), openpgp);
 
-    await msg2[0].decrypt(algo, key);
+    await msg2[0].decrypt(algo, key, undefined, openpgp.config);
 
     expect(await stringify(msg2[0].packets[0].data)).to.equal(stringify(literal.data));
   });
 
   it('Sym. encrypted AEAD protected packet', function() {
-    const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
-    const algo = 'aes256';
-    const testText = input.createSomeMessage();
-    const literal = new openpgp.LiteralDataPacket();
-    const enc = new openpgp.AEADEncryptedDataPacket();
-    const msg = new openpgp.PacketList();
-
-    msg.push(enc);
-    literal.setText(testText);
-    enc.packets.push(literal);
-
-    const msg2 = new openpgp.PacketList();
-
-    return enc.encrypt(algo, key).then(async function() {
-      await msg2.read(msg.write(), openpgp);
-      return msg2[0].decrypt(algo, key);
-    }).then(async function() {
-      expect(await openpgp.stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
-    });
-  });
-
-  it('Sym. encrypted AEAD protected packet (AEAD)', async function() {
     const aeadProtectVal = openpgp.config.aeadProtect;
-    openpgp.config.aeadProtect = true;
-    const testText = input.createSomeMessage();
-
-    const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
-    const algo = 'aes256';
-
-    const literal = new openpgp.LiteralDataPacket();
-    const enc = new openpgp.AEADEncryptedDataPacket();
-    const msg = new openpgp.PacketList();
-
-    msg.push(enc);
-    literal.setText(testText);
-    enc.packets.push(literal);
-
-    const msg2 = new openpgp.PacketList();
+    openpgp.config.aeadProtect = false;
 
     try {
-      await enc.encrypt(algo, key);
-      await msg2.read(msg.write(), openpgp);
-      await msg2[0].decrypt(algo, key);
-      expect(await openpgp.stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
+      const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
+      const algo = 'aes256';
+      const testText = input.createSomeMessage();
+      const literal = new openpgp.LiteralDataPacket();
+      const enc = new openpgp.AEADEncryptedDataPacket();
+      const msg = new openpgp.PacketList();
+
+      msg.push(enc);
+      literal.setText(testText);
+      enc.packets.push(literal);
+
+      const msg2 = new openpgp.PacketList();
+
+      return enc.encrypt(algo, key, undefined, openpgp.config).then(async function() {
+        await msg2.read(msg.write(), openpgp);
+        return msg2[0].decrypt(algo, key);
+      }).then(async function() {
+        expect(await openpgp.stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
+      });
     } finally {
       openpgp.config.aeadProtect = aeadProtectVal;
     }
@@ -208,10 +203,6 @@ module.exports = () => describe("Packet", function() {
     const encryptStub = cryptStub(webCrypto, 'encrypt');
     const decryptStub = cryptStub(webCrypto, 'decrypt');
 
-    const aeadProtectVal = openpgp.config.aeadProtect;
-    const aeadChunkSizeByteVal = openpgp.config.aeadChunkSizeByte;
-    openpgp.config.aeadProtect = true;
-    openpgp.config.aeadChunkSizeByte = 0;
     const testText = input.createSomeMessage();
 
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
@@ -229,15 +220,13 @@ module.exports = () => describe("Packet", function() {
     const msg2 = new openpgp.PacketList();
 
     try {
-      await enc.encrypt(algo, key);
+      await enc.encrypt(algo, key, undefined, { ...openpgp.config, aeadChunkSizeByte: 0 });
       await msg2.read(msg.write(), openpgp);
       await msg2[0].decrypt(algo, key);
       expect(await openpgp.stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
       expect(encryptStub.callCount > 1).to.be.true;
       expect(decryptStub.callCount > 1).to.be.true;
     } finally {
-      openpgp.config.aeadProtect = aeadProtectVal;
-      openpgp.config.aeadChunkSizeByte = aeadChunkSizeByteVal;
       encryptStub.restore();
       decryptStub.restore();
     }
@@ -256,11 +245,6 @@ module.exports = () => describe("Packet", function() {
       26 55 de a8 8d 06 a8 14  86 80 1b 0f f3 87 bd 2e
       ab 01 3d e1 25 95 86 90  6e ab 24 76
     `.replace(/\s+/g, ''));
-
-    const aeadProtectVal = openpgp.config.aeadProtect;
-    const aeadChunkSizeByteVal = openpgp.config.aeadChunkSizeByte;
-    openpgp.config.aeadProtect = true;
-    openpgp.config.aeadChunkSizeByte = 14;
 
     const iv = util.hexToUint8Array('b7 32 37 9f 73 c4 92 8d e2 5f ac fe 65 17 ec 10'.replace(/\s+/g, ''));
     const key = util.hexToUint8Array('86 f1 ef b8 69 52 32 9f 24 ac d3 bf d0 e5 34 6d'.replace(/\s+/g, ''));
@@ -281,15 +265,13 @@ module.exports = () => describe("Packet", function() {
     randomBytesStub.returns(iv);
 
     try {
-      await enc.encrypt(algo, key);
+      await enc.encrypt(algo, key, undefined, { ...openpgp.config, aeadChunkSizeByte: 14 });
       const data = msg.write();
       expect(await openpgp.stream.readToEnd(openpgp.stream.clone(data))).to.deep.equal(packetBytes);
       await msg2.read(data, openpgp);
       await msg2[0].decrypt(algo, key);
       expect(await openpgp.stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
     } finally {
-      openpgp.config.aeadProtect = aeadProtectVal;
-      openpgp.config.aeadChunkSizeByte = aeadChunkSizeByteVal;
       randomBytesStub.restore();
     }
   });
@@ -453,36 +435,43 @@ module.exports = () => describe("Packet", function() {
     });
   });
 
-  it('Sym. encrypted session key reading/writing', async function() {
-    const passphrase = 'hello';
-    const algo = 'aes256';
-    const testText = input.createSomeMessage();
+  it('Sym. encrypted session key reading/writing (CFB)', async function() {
+    const aeadProtectVal = openpgp.config.aeadProtect;
+    openpgp.config.aeadProtect = false;
 
-    const literal = new openpgp.LiteralDataPacket();
-    const key_enc = new openpgp.SymEncryptedSessionKeyPacket();
-    const enc = new openpgp.SymEncryptedIntegrityProtectedDataPacket();
-    const msg = new openpgp.PacketList();
+    try {
+      const passphrase = 'hello';
+      const algo = 'aes256';
+      const testText = input.createSomeMessage();
 
-    msg.push(key_enc);
-    msg.push(enc);
+      const literal = new openpgp.LiteralDataPacket();
+      const skesk = new openpgp.SymEncryptedSessionKeyPacket();
+      const seip = new openpgp.SymEncryptedIntegrityProtectedDataPacket();
+      const msg = new openpgp.PacketList();
 
-    key_enc.sessionKeyAlgorithm = algo;
-    await key_enc.encrypt(passphrase);
+      msg.push(skesk);
+      msg.push(seip);
 
-    const key = key_enc.sessionKey;
+      skesk.sessionKeyAlgorithm = algo;
+      await skesk.encrypt(passphrase, openpgp.config);
 
-    literal.setText(testText);
-    enc.packets.push(literal);
-    await enc.encrypt(algo, key);
+      const key = skesk.sessionKey;
 
-    const msg2 = new openpgp.PacketList();
-    await msg2.read(msg.write(), openpgp);
+      literal.setText(testText);
+      seip.packets.push(literal);
+      await seip.encrypt(algo, key, undefined, openpgp.config);
 
-    await msg2[0].decrypt(passphrase);
-    const key2 = msg2[0].sessionKey;
-    await msg2[1].decrypt(msg2[0].sessionKeyAlgorithm, key2);
+      const msg2 = new openpgp.PacketList();
+      await msg2.read(msg.write(), openpgp);
 
-    expect(await stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
+      await msg2[0].decrypt(passphrase);
+      const key2 = msg2[0].sessionKey;
+      await msg2[1].decrypt(msg2[0].sessionKeyAlgorithm, key2);
+
+      expect(await stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
+    } finally {
+      openpgp.config.aeadProtect = aeadProtectVal;
+    }
   });
 
   it('Sym. encrypted session key reading/writing (AEAD)', async function() {
@@ -495,21 +484,21 @@ module.exports = () => describe("Packet", function() {
       const testText = input.createSomeMessage();
 
       const literal = new openpgp.LiteralDataPacket();
-      const key_enc = new openpgp.SymEncryptedSessionKeyPacket();
-      const enc = new openpgp.AEADEncryptedDataPacket();
+      const skesk = new openpgp.SymEncryptedSessionKeyPacket();
+      const aeadEnc = new openpgp.AEADEncryptedDataPacket();
       const msg = new openpgp.PacketList();
 
-      msg.push(key_enc);
-      msg.push(enc);
+      msg.push(skesk);
+      msg.push(aeadEnc);
 
-      key_enc.sessionKeyAlgorithm = algo;
-      await key_enc.encrypt(passphrase);
+      skesk.sessionKeyAlgorithm = algo;
+      await skesk.encrypt(passphrase, openpgp.config);
 
-      const key = key_enc.sessionKey;
+      const key = skesk.sessionKey;
 
       literal.setText(testText);
-      enc.packets.push(literal);
-      await enc.encrypt(algo, key);
+      aeadEnc.packets.push(literal);
+      await aeadEnc.encrypt(algo, key, undefined, openpgp.config);
 
       const msg2 = new openpgp.PacketList();
       await msg2.read(msg.write(), openpgp);
@@ -566,22 +555,22 @@ module.exports = () => describe("Packet", function() {
       const algo = 'aes128';
 
       const literal = new openpgp.LiteralDataPacket(0);
-      const key_enc = new openpgp.SymEncryptedSessionKeyPacket();
-      const enc = new openpgp.AEADEncryptedDataPacket();
+      const skesk = new openpgp.SymEncryptedSessionKeyPacket();
+      const encData = new openpgp.AEADEncryptedDataPacket();
       const msg = new openpgp.PacketList();
 
-      msg.push(key_enc);
-      msg.push(enc);
+      msg.push(skesk);
+      msg.push(encData);
 
-      key_enc.sessionKeyAlgorithm = algo;
-      await key_enc.encrypt(passphrase);
+      skesk.sessionKeyAlgorithm = algo;
+      await skesk.encrypt(passphrase, openpgp.config);
 
-      const key = key_enc.sessionKey;
+      const key = skesk.sessionKey;
 
       literal.setBytes(util.strToUint8Array('Hello, world!\n'), openpgp.enums.literal.binary);
       literal.filename = '';
-      enc.packets.push(literal);
-      await enc.encrypt(algo, key);
+      encData.packets.push(literal);
+      await encData.encrypt(algo, key, undefined, openpgp.config);
 
       const data = msg.write();
       expect(await openpgp.stream.readToEnd(openpgp.stream.clone(data))).to.deep.equal(packetBytes);
@@ -653,14 +642,14 @@ module.exports = () => describe("Packet", function() {
       msg.push(enc);
 
       key_enc.sessionKeyAlgorithm = algo;
-      await key_enc.encrypt(passphrase);
+      await key_enc.encrypt(passphrase, openpgp.config);
 
       const key = key_enc.sessionKey;
 
       literal.setBytes(util.strToUint8Array('Hello, world!\n'), openpgp.enums.literal.binary);
       literal.filename = '';
       enc.packets.push(literal);
-      await enc.encrypt(algo, key);
+      await enc.encrypt(algo, key, undefined, openpgp.config);
 
       const data = msg.write();
       expect(await openpgp.stream.readToEnd(openpgp.stream.clone(data))).to.deep.equal(packetBytes);
@@ -712,18 +701,18 @@ module.exports = () => describe("Packet", function() {
   });
 
   it('Secret key reading with signature verification.', async function() {
-    const key = new openpgp.PacketList();
-    await key.read((await openpgp.unarmor(armored_key)).data, openpgp);
+    const packets = new openpgp.PacketList();
+    await packets.read((await openpgp.unarmor(armored_key)).data, openpgp);
+    const [keyPacket, userIdPacket, keySigPacket, subkeyPacket, subkeySigPacket] = packets;
+    expect(keySigPacket.verified).to.be.null;
+    expect(subkeySigPacket.verified).to.be.null;
 
-    expect(key[2].verified).to.be.null;
-    expect(key[4].verified).to.be.null;
-
-    await key[2].verify(
-      key[0], openpgp.enums.signature.certGeneric, { userId: key[1], key: key[0] }
-    ).then(async () => expect(key[2].verified).to.be.true);
-    await key[4].verify(
-      key[0], openpgp.enums.signature.keyBinding, { key: key[0], bind: key[3] }
-    ).then(async () => expect(key[4].verified).to.be.true);
+    await keySigPacket.verify(
+      keyPacket, openpgp.enums.signature.certGeneric, { userId: userIdPacket, key: keyPacket }
+    ).then(async () => expect(keySigPacket.verified).to.be.true);
+    await subkeySigPacket.verify(
+      keyPacket, openpgp.enums.signature.keyBinding, { key: keyPacket, bind: subkeyPacket }
+    ).then(async () => expect(subkeySigPacket.verified).to.be.true);
   });
 
   it('Reading a signed, encrypted message.', async function() {
@@ -743,22 +732,27 @@ module.exports = () => describe("Packet", function() {
         '=htrB\n' +
         '-----END PGP MESSAGE-----';
 
-    const key = new openpgp.PacketList();
-    await key.read((await openpgp.unarmor(armored_key)).data, openpgp);
-    await key[3].decrypt('test');
+    const packets = new openpgp.PacketList();
+    await packets.read((await openpgp.unarmor(armored_key)).data, openpgp);
+    const keyPacket = packets[0];
+    const subkeyPacket = packets[3];
+    await subkeyPacket.decrypt('test');
 
     const msg = new openpgp.PacketList();
     await msg.read((await openpgp.unarmor(armored_msg)).data, openpgp);
+    const [pkesk, encData] = msg;
 
-    return msg[0].decrypt(key[3]).then(async () => {
-      await msg[1].decrypt(msg[0].sessionKeyAlgorithm, msg[0].sessionKey);
+    return pkesk.decrypt(subkeyPacket).then(async () => {
+      await encData.decrypt(pkesk.sessionKeyAlgorithm, pkesk.sessionKey);
 
-      const payload = msg[1].packets[0].packets;
+      const payload = encData.packets[0].packets;
       payload.concat(await openpgp.stream.readToEnd(payload.stream, arr => arr));
+      const literal = payload[1];
+      const signature = payload[2];
 
       await Promise.all([
-        payload[2].verify(key[0], openpgp.enums.signature.binary, payload[1]),
-        openpgp.stream.pipe(payload[1].getBytes(),new openpgp.stream.WritableStream())
+        signature.verify(keyPacket, openpgp.enums.signature.binary, literal),
+        openpgp.stream.pipe(literal.getBytes(), new openpgp.stream.WritableStream())
       ]);
     });
   });
@@ -842,20 +836,20 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
   it('Writing and encryption of a secret key packet (AEAD)', async function() {
     const rsa = openpgp.enums.publicKey.rsaEncryptSign;
-    const keySize = util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
-    const { privateParams, publicParams } = await crypto.generateParams(rsa, keySize, 65537);
+    const { privateParams, publicParams } = await crypto.generateParams(rsa, 1024, 65537);
 
-    const secretKeyPacket = new openpgp.SecretKeyPacket();
+    const secretKeyPacket = new openpgp.SecretKeyPacket(undefined, { ...openpgp.config, v5Keys: true });
     secretKeyPacket.privateParams = privateParams;
     secretKeyPacket.publicParams = publicParams;
     secretKeyPacket.algorithm = "rsaSign";
     secretKeyPacket.isEncrypted = false;
-    await secretKeyPacket.encrypt('hello');
+    await secretKeyPacket.encrypt('hello', openpgp.config);
+    expect(secretKeyPacket.s2k_usage).to.equal(253);
 
     const raw = new openpgp.PacketList();
     raw.push(secretKeyPacket);
     const packetList = new openpgp.PacketList();
-    await packetList.read(raw.write(), openpgp);
+    await packetList.read(raw.write(), openpgp, undefined, openpgp.config);
     const secretKeyPacket2 = packetList[0];
     await secretKeyPacket2.decrypt('hello');
 
@@ -864,39 +858,29 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
   });
 
   it('Writing and encryption of a secret key packet (CFB)', async function() {
-    const aeadProtectVal = openpgp.config.aeadProtect;
-    openpgp.config.aeadProtect = false;
-
     const rsa = openpgp.enums.publicKey.rsaEncryptSign;
-    const keySize = util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
+    const { privateParams, publicParams } = await crypto.generateParams(rsa, 1024, 65537);
+    const secretKeyPacket = new openpgp.SecretKeyPacket(undefined, { ...openpgp.config, v5Keys: false });
+    secretKeyPacket.privateParams = privateParams;
+    secretKeyPacket.publicParams = publicParams;
+    secretKeyPacket.algorithm = "rsaSign";
+    secretKeyPacket.isEncrypted = false;
+    await secretKeyPacket.encrypt('hello', openpgp.config);
+    expect(secretKeyPacket.s2k_usage).to.equal(254);
 
-    try {
-      const { privateParams, publicParams } = await crypto.generateParams(rsa, keySize, 65537);
-      const secretKeyPacket = new openpgp.SecretKeyPacket();
-      secretKeyPacket.privateParams = privateParams;
-      secretKeyPacket.publicParams = publicParams;
-      secretKeyPacket.algorithm = "rsaSign";
-      secretKeyPacket.isEncrypted = false;
-      await secretKeyPacket.encrypt('hello');
-
-      const raw = new openpgp.PacketList();
-      raw.push(secretKeyPacket);
-      const packetList = new openpgp.PacketList();
-      await packetList.read(raw.write(), openpgp);
-      const secretKeyPacket2 = packetList[0];
-      await secretKeyPacket2.decrypt('hello');
-    } finally {
-      openpgp.config.aeadProtect = aeadProtectVal;
-    }
+    const raw = new openpgp.PacketList();
+    raw.push(secretKeyPacket);
+    const packetList = new openpgp.PacketList();
+    await packetList.read(raw.write(), openpgp, undefined, openpgp.config);
+    const secretKeyPacket2 = packetList[0];
+    await secretKeyPacket2.decrypt('hello');
   });
 
   it('Writing and verification of a signature packet', function() {
+    const rsa = openpgp.enums.publicKey.rsaEncryptSign;
     const key = new openpgp.SecretKeyPacket();
 
-    const rsa = openpgp.enums.publicKey.rsaEncryptSign;
-    const keySize = util.getWebCryptoAll() ? 2048 : 512; // webkit webcrypto accepts minimum 2048 bit keys
-
-    return crypto.generateParams(rsa, keySize, 65537).then(function({ privateParams, publicParams }) {
+    return crypto.generateParams(rsa, 1024, 65537).then(function({ privateParams, publicParams }) {
       const testText = input.createSomeMessage();
 
       key.publicParams = publicParams;

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -919,8 +919,8 @@ hUhMKMuiM3pRwdIyDOItkUWQmjEEw7/XmhgInkXsCw==
 
   it('Checks for critical bit in non-human-readable notations', async function() {
     try {
-      openpgp.config.tolerant = false;
       await openpgp.readSignature({
+        config: { tolerant: false },
         armoredSignature: `-----BEGIN PGP SIGNATURE-----
 
 wsEfBAABCABJBYJfKDH0K5QAAAAAAB0ABXVua25vd25AdGVzdHMuc2VxdW9pYS1w
@@ -940,8 +940,6 @@ bwM=
       throw new Error('openpgp.readSignature should throw but it did not.');
     } catch (e) {
       expect(e.message).to.equal('Unknown critical notation: unknown@tests.sequoia-pgp.org');
-    } finally {
-      openpgp.config.tolerant = true;
     }
   });
 

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1638,9 +1638,8 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
     const opt = { userIds: { name:'test', email:'a@b.com' }, passphrase: null };
     return openpgp.generateKey(opt).then(function(gen) {
       const key = gen.key;
-      let message = openpgp.Message.fromText('hello world');
-      message = message.sign([key]);
-      expect(message).to.exist;
+      const message = openpgp.Message.fromText('hello world');
+      return message.sign([key]);
     });
   });
 

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1623,8 +1623,7 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
     const privKey2 = await openpgp.readKey({ armoredKey: priv_key_arm2 });
     await privKey2.decrypt('hello world');
 
-    const opt = { rsaBits: 512, userIds: { name:'test', email:'a@b.com' }, passphrase: null };
-    if (util.getWebCryptoAll()) { opt.rsaBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys
+    const opt = { rsaBits: 2048, userIds: { name:'test', email:'a@b.com' }, passphrase: null };
     const { key: generatedKey } = await openpgp.generateKey(opt);
     const detachedSig = await msg.signDetached([generatedKey, privKey2]);
     const result = await msg.verifyDetached(detachedSig, [generatedKey.toPublic(), pubKey2]);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -80,7 +80,7 @@ module.exports = function(config) {
       build: process.env.GITHUB_SHA,
       name: process.env.GITHUB_WORKFLOW,
       project: `openpgpjs/${process.env.GITHUB_EVENT_NAME || 'push'}${process.env.LIGHTWEIGHT ? '/lightweight' : ''}`,
-      timeout: 600
+      timeout: 450
     },
 
     // define browsers

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
     basePath: '..',
 
     // hostname for local
-    hostname: 'localhost',
+    hostname: '127.0.0.1',
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -79,15 +79,16 @@ module.exports = function(config) {
       accessKey: process.env.BROWSERSTACK_KEY,
       build: process.env.GITHUB_SHA,
       name: process.env.GITHUB_WORKFLOW,
-      project: `openpgpjs/${process.env.GITHUB_EVENT_NAME || 'push'}${process.env.LIGHTWEIGHT ? '/lightweight' : ''}`
+      project: `openpgpjs/${process.env.GITHUB_EVENT_NAME || 'push'}${process.env.LIGHTWEIGHT ? '/lightweight' : ''}`,
+      timeout: 600
     },
 
     // define browsers
     customLaunchers: {
-      bs_firefox_84: {
+      bs_firefox_85: {
         base: 'BrowserStack',
         browser: 'Firefox',
-        browser_version: '84.0',
+        browser_version: '85.0',
         os: 'OS X',
         os_version: 'Big Sur'
       },
@@ -130,7 +131,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: [
-      'bs_firefox_84',
+      'bs_firefox_85',
       'bs_chrome_88',
       'bs_safari_13_1',
       'bs_safari_14',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -84,10 +84,10 @@ module.exports = function(config) {
 
     // define browsers
     customLaunchers: {
-      bs_firefox_85: {
+      bs_firefox_84: {
         base: 'BrowserStack',
         browser: 'Firefox',
-        browser_version: '85.0',
+        browser_version: '84.0',
         os: 'OS X',
         os_version: 'Big Sur'
       },
@@ -130,7 +130,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: [
-      'bs_firefox_85',
+      'bs_firefox_84',
       'bs_chrome_88',
       'bs_safari_13_1',
       'bs_safari_14',

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -1,7 +1,6 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 
 const { readKey, Key, readCleartextMessage, CleartextMessage, enums, PacketList, SignaturePacket } = openpgp;
-const key = require('../../src/key');
 
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
@@ -9,23 +8,23 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 async function generateTestData() {
-  const victimPrivKey = await key.generate({
+  const victimPrivKey = (await openpgp.generateKey({
     userIds: [{ name: 'Victim', email: 'victim@example.com' }],
     type: 'rsa',
-    rsaBits: 1024,
+    rsaBits: 2048,
     subkeys: [{
       sign: true
     }]
-  });
+  })).key;
   victimPrivKey.revocationSignatures = [];
 
-  const attackerPrivKey = await key.generate({
+  const attackerPrivKey = (await openpgp.generateKey({
     userIds: [{ name: 'Attacker', email: 'attacker@example.com' }],
     type: 'rsa',
-    rsaBits: 1024,
+    rsaBits: 2048,
     subkeys: [],
     sign: false
-  });
+  })).key;
   attackerPrivKey.revocationSignatures = [];
   const signed = await openpgp.sign({
     message: await CleartextMessage.fromText('I am batman'),

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -6,16 +6,18 @@
  *  - if it fails to run, edit this file to match the actual library API, then edit the definitions file (openpgp.d.ts) accordingly.
  */
 
-import { generateKey, readKey, readKeys, Key, readMessage, Message, CleartextMessage, encrypt, decrypt, sign, verify } from '../..';
+import { generateKey, readKey, readKeys, Key, readMessage, Message, CleartextMessage, encrypt, decrypt, sign, verify, config } from '../..';
+
 import { expect } from 'chai';
 
 (async () => {
 
   // Generate keys
-  const { publicKeyArmored, key } = await generateKey({ userIds: [{ email: "user@corp.co" }] });
+  const { publicKeyArmored, key } = await generateKey({ userIds: [{ email: "user@corp.co" }], config: { v5Keys: true } });
   expect(key).to.be.instanceOf(Key);
   const privateKeys = [key];
   const publicKeys = [key.toPublic()];
+  expect(key.toPublic().armor(config)).to.equal(publicKeyArmored);
 
   // Parse keys
   expect(await readKey({ armoredKey: publicKeyArmored })).to.be.instanceOf(Key);


### PR DESCRIPTION
Fix #1166: refactor functions to take the configuration as parameter. `openpgp.config` is now used as default configuration in top-level functions: if no configuration is specified, then `openpgp.config` is applied.
This change avoids concurrency-related issues when `openpgp.config` is modified and read by different async functions.

Other changes:
- remove `config.rsaBlinding`: blinding is now always applied to RSA decryption.
- remove `config.debug`: debugging mode can be enabled by setting `process.env.NODE_ENV = 'development'`
- remove `config.useNative`: native crypto is always used when available

TODO:
- [x] remove config.useNative
- [x] add config tests for top-level functions
- [x] all functions in the public API should default to `openpgp.config`
- [x] update docs
- [x] update TS