### PR TITLE
Add `config.rejectPublicKeyAlgorithms`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -344,7 +344,7 @@ module.exports = {
     "no-use-before-define": [ 2, { "functions": false, "classes": true, "variables": false }],
     "no-constant-condition": [ 2, { "checkLoops": false } ],
     "new-cap": [ 2, { "properties": false, "capIsNewExceptionPattern": "EAX|OCB|GCM|CMAC|CBC|OMAC|CTR", "newIsCapExceptionPattern": "type|hash*"}],
-    "max-lines": [ 2, { "max": 600, "skipBlankLines": true, "skipComments": true } ],
+    "max-lines": [ 2, { "max": 620, "skipBlankLines": true, "skipComments": true } ],
     "no-unused-expressions": 0,
     "chai-friendly/no-unused-expressions": [ 2, { "allowShortCircuit": true } ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,7 +215,7 @@ module.exports = {
     "no-restricted-imports": "error",
     "no-restricted-modules": "error",
     "no-restricted-properties": "error",
-    "no-restricted-syntax": "error",
+    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
     "no-return-assign": "error",
     "no-return-await": "error",
     "no-script-url": "error",

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -77,7 +77,9 @@ export class CleartextMessage {
    * @param {Array<Key>} keys - Array of keys to verify signatures
    * @param {Date} [date] - Verify the signature against the given date, i.e. check signature creation time < date < expiration time
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
-   * @returns {Array<{keyid: module:type/keyid~Keyid, valid: Boolean}>} List of signer's keyid and validity of signature.
+   * @returns {Array<{keyid: module:type/keyid~Keyid,
+   *                  signature: Promise<Signature>,
+   *                  verified: Promise<Boolean>}>} List of signer's keyid and validity of signature.
    * @async
    */
   verify(keys, date = new Date(), config = defaultConfig) {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -194,7 +194,7 @@ export default {
   /**
    * Reject insecure public key algorithms for message encryption, signing or verification
    * @memberof module:config
-   * @property {Set<Integer>} rejectPublicKeyAlgorithms {@link module:enums.publicKey} {@link module:enums.hash}
+   * @property {Set<Integer>} rejectPublicKeyAlgorithms {@link module:enums.publicKey}
    */
   rejectPublicKeyAlgorithms: new Set([enums.publicKey.elgamal, enums.publicKey.dsa])
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -105,7 +105,7 @@ export default {
   checksumRequired: false,
   /**
    * @memberof module:config
-   * @property {Number} minRsaBits Minimum RSA key size allowed for key generation
+   * @property {Number} minRsaBits Minimum RSA key size allowed for key generation and message signing, verification and encryption
    */
   minRsaBits: 2048,
   /**
@@ -180,13 +180,21 @@ export default {
    */
   useIndutnyElliptic: true,
   /**
+   * Reject insecure hash algorithms
    * @memberof module:config
-   * @property {Set<Integer>} reject_hash_algorithms Reject insecure hash algorithms {@link module:enums.hash}
+   * @property {Set<Integer>} rejectHashAlgorithms {@link module:enums.hash}
    */
-  rejectHashAlgorithms: new globalThis.Set([enums.hash.md5, enums.hash.ripemd]),
+  rejectHashAlgorithms: new Set([enums.hash.md5, enums.hash.ripemd]),
   /**
+   * Reject insecure message hash algorithms
    * @memberof module:config
-   * @property {Set<Integer>} reject_message_hash_algorithms Reject insecure message hash algorithms {@link module:enums.hash}
+   * @property {Set<Integer>} rejectMessageHashAlgorithms {@link module:enums.hash}
    */
-  rejectMessageHashAlgorithms: new globalThis.Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1])
+  rejectMessageHashAlgorithms: new Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1]),
+  /**
+   * Reject insecure public key algorithms for message encryption, signing or verification
+   * @memberof module:config
+   * @property {Set<Integer>} rejectPublicKeyAlgorithms {@link module:enums.publicKey} {@link module:enums.hash}
+   */
+  rejectPublicKeyAlgorithms: new Set([enums.publicKey.elgamal, enums.publicKey.dsa])
 };

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -93,7 +93,10 @@ export async function reformat(options, config) {
 
   if (!options.subkeys) {
     options.subkeys = await Promise.all(secretSubkeyPackets.map(async secretSubkeyPacket => ({
-      sign: await options.privateKey.getSigningKey(secretSubkeyPacket.getKeyId(), null, undefined, config).catch(() => {}) &&
+      sign: await options.privateKey.getSigningKey(
+        secretSubkeyPacket.getKeyId(), null, undefined,
+        { ...config, rejectPublicKeyAlgorithms: new Set([]) }
+      ).catch(() => {}) &&
           !await options.privateKey.getEncryptionKey(secretSubkeyPacket.getKeyId(), null, undefined, config).catch(() => {})
     })));
   }

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -88,7 +88,9 @@ export async function reformat(options, config) {
     options.subkeys = await Promise.all(privateKey.subKeys.map(async subkey => {
       const secretSubkeyPacket = subkey.keyPacket;
       const dataToVerify = { key: secretKeyPacket, bind: secretSubkeyPacket };
-      const bindingSignature = await helper.getLatestValidSignature(subkey.bindingSignatures, secretKeyPacket, enums.signature.subkeyBinding, dataToVerify, null, config);
+      const bindingSignature = await (
+        helper.getLatestValidSignature(subkey.bindingSignatures, secretKeyPacket, enums.signature.subkeyBinding, dataToVerify, null, config)
+      ).catch(() => ({}));
       return {
         sign: bindingSignature.keyFlags && (bindingSignature.keyFlags[0] & enums.keyFlags.signData)
       };

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -401,7 +401,7 @@ export function isValidDecryptionKeyPacket(signature, config) {
   }
 
   if (config.allowInsecureDecryptionWithSigningKeys) {
-    // This is only relevant for RSA keys, all other signing ciphers cannot decrypt
+    // This is only relevant for RSA keys, all other signing algorithms cannot decrypt
     return true;
   }
 

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -366,27 +366,25 @@ export function sanitizeKeyOptions(options, subkeyDefaults = {}) {
   return options;
 }
 
-export function isValidSigningKeyPacket(keyPacket, signature, config) {
+export function isValidSigningKeyPacket(keyPacket, signature) {
   if (!signature.verified || signature.revoked !== false) { // Sanity check
     throw new Error('Signature not verified');
   }
   const keyAlgo = enums.write(enums.publicKey, keyPacket.algorithm);
-  return checkKeyStrength(keyPacket, config) &&
-    keyAlgo !== enums.publicKey.rsaEncrypt &&
+  return keyAlgo !== enums.publicKey.rsaEncrypt &&
     keyAlgo !== enums.publicKey.elgamal &&
     keyAlgo !== enums.publicKey.ecdh &&
     (!signature.keyFlags ||
       (signature.keyFlags[0] & enums.keyFlags.signData) !== 0);
 }
 
-export function isValidEncryptionKeyPacket(keyPacket, signature, config) {
+export function isValidEncryptionKeyPacket(keyPacket, signature) {
   if (!signature.verified || signature.revoked !== false) { // Sanity check
     throw new Error('Signature not verified');
   }
 
   const keyAlgo = enums.write(enums.publicKey, keyPacket.algorithm);
-  return checkKeyStrength(keyPacket, config) &&
-    keyAlgo !== enums.publicKey.dsa &&
+  return keyAlgo !== enums.publicKey.dsa &&
     keyAlgo !== enums.publicKey.rsaSign &&
     keyAlgo !== enums.publicKey.ecdsa &&
     keyAlgo !== enums.publicKey.eddsa &&
@@ -410,7 +408,7 @@ export function isValidDecryptionKeyPacket(signature, config) {
     (signature.keyFlags[0] & enums.keyFlags.encryptStorage) !== 0;
 }
 
-function checkKeyStrength(keyPacket, config) {
+export function assertKeyStrength(keyPacket, config) {
   const keyAlgo = enums.write(enums.publicKey, keyPacket.algorithm);
   if (config.rejectPublicKeyAlgorithms.has(keyAlgo)) {
     throw new Error(`${keyPacket.algorithm} keys are considered too weak.`);

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -409,7 +409,7 @@ export function isValidDecryptionKeyPacket(signature, config) {
     (signature.keyFlags[0] & enums.keyFlags.encryptStorage) !== 0;
 }
 
-export function assertKeyStrength(keyPacket, config) {
+export function checkKeyStrength(keyPacket, config) {
   const keyAlgo = enums.write(enums.publicKey, keyPacket.algorithm);
   if (config.rejectPublicKeyAlgorithms.has(keyAlgo)) {
     throw new Error(`${keyPacket.algorithm} keys are considered too weak.`);

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -370,6 +370,7 @@ export function isValidSigningKeyPacket(keyPacket, signature) {
   if (!signature.verified || signature.revoked !== false) { // Sanity check
     throw new Error('Signature not verified');
   }
+
   const keyAlgo = enums.write(enums.publicKey, keyPacket.algorithm);
   return keyAlgo !== enums.publicKey.rsaEncrypt &&
     keyAlgo !== enums.publicKey.elgamal &&
@@ -417,5 +418,4 @@ export function assertKeyStrength(keyPacket, config) {
   if (rsaAlgos.has(keyAlgo) && util.uint8ArrayBitLength(keyPacket.publicParams.n) < config.minRsaBits) {
     throw new Error(`RSA keys shorter than ${config.minRsaBits} bits are considered too weak.`);
   }
-  return true;
 }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -309,7 +309,7 @@ class Key {
           await helper.getLatestValidSignature(
             [bindingSignature.embeddedSignature], subKey.keyPacket, enums.signature.keyBinding, dataToVerify, date, config
           );
-          helper.assertKeyStrength(subKey.keyPacket, config);
+          helper.checkKeyStrength(subKey.keyPacket, config);
           return subKey;
         } catch (e) {
           exception = e;
@@ -321,7 +321,7 @@ class Key {
       const primaryUser = await this.getPrimaryUser(date, userId, config);
       if ((!keyId || primaryKey.getKeyId().equals(keyId)) &&
           helper.isValidSigningKeyPacket(primaryKey, primaryUser.selfCertification, config)) {
-        helper.assertKeyStrength(primaryKey, config);
+        helper.checkKeyStrength(primaryKey, config);
         return this;
       }
     } catch (e) {
@@ -352,7 +352,7 @@ class Key {
           const dataToVerify = { key: primaryKey, bind: subKey.keyPacket };
           const bindingSignature = await helper.getLatestValidSignature(subKey.bindingSignatures, primaryKey, enums.signature.subkeyBinding, dataToVerify, date, config);
           if (helper.isValidEncryptionKeyPacket(subKey.keyPacket, bindingSignature)) {
-            helper.assertKeyStrength(subKey.keyPacket, config);
+            helper.checkKeyStrength(subKey.keyPacket, config);
             return subKey;
           }
         } catch (e) {
@@ -366,7 +366,7 @@ class Key {
       const primaryUser = await this.getPrimaryUser(date, userId, config);
       if ((!keyId || primaryKey.getKeyId().equals(keyId)) &&
           helper.isValidEncryptionKeyPacket(primaryKey, primaryUser.selfCertification)) {
-        helper.assertKeyStrength(primaryKey, config);
+        helper.checkKeyStrength(primaryKey, config);
         return this;
       }
     } catch (e) {

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -486,7 +486,7 @@ class Key {
        * It is enough to validate any signing keys
        * since its binding signatures are also checked
        */
-      const signingKey = await this.getSigningKey(null, null, undefined, config);
+      const signingKey = await this.getSigningKey(null, null, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 });
       // This could again be a dummy key
       if (signingKey && !signingKey.keyPacket.isDummy()) {
         signingKeyPacket = signingKey.keyPacket;
@@ -581,16 +581,16 @@ class Key {
     let expiry = keyExpiry < sigExpiry ? keyExpiry : sigExpiry;
     if (capabilities === 'encrypt' || capabilities === 'encrypt_sign') {
       const encryptKey =
-        await this.getEncryptionKey(keyId, expiry, userId, config).catch(() => {}) ||
-        await this.getEncryptionKey(keyId, null, userId, config).catch(() => {});
+        await this.getEncryptionKey(keyId, expiry, userId, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }).catch(() => {}) ||
+        await this.getEncryptionKey(keyId, null, userId, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }).catch(() => {});
       if (!encryptKey) return null;
       const encryptExpiry = await encryptKey.getExpirationTime(this.keyPacket, undefined, config);
       if (encryptExpiry < expiry) expiry = encryptExpiry;
     }
     if (capabilities === 'sign' || capabilities === 'encrypt_sign') {
       const signKey =
-        await this.getSigningKey(keyId, expiry, userId, { ...config, rejectPublicKeyAlgorithms: new Set([]) }).catch(() => {}) ||
-        await this.getSigningKey(keyId, null, userId, { ...config, rejectPublicKeyAlgorithms: new Set([]) }).catch(() => {});
+        await this.getSigningKey(keyId, expiry, userId, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }).catch(() => {}) ||
+        await this.getSigningKey(keyId, null, userId, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }).catch(() => {});
       if (!signKey) return null;
       const signExpiry = await signKey.getExpirationTime(this.keyPacket, undefined, config);
       if (signExpiry < expiry) expiry = signExpiry;

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -59,7 +59,10 @@ class User {
       if (privateKey.hasSameFingerprintAs(primaryKey)) {
         throw new Error('Not implemented for self signing');
       }
-      const signingKey = await privateKey.getSigningKey(undefined, undefined, undefined, config);
+      const signingKey = await privateKey.getSigningKey(
+        undefined, undefined, undefined,
+        { ...config, rejectPublicKeyAlgorithms: new Set([]) }
+      );
       return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,
@@ -117,7 +120,7 @@ class User {
       if (!key.getKeyIds().some(id => id.equals(keyid))) {
         return null;
       }
-      const signingKey = await key.getSigningKey(keyid, date, undefined, config);
+      const signingKey = await key.getSigningKey(keyid, date, undefined, { ...config, rejectPublicKeyAlgorithms: new Set([]) });
       if (certificate.revoked || await that.isRevoked(primaryKey, certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -59,10 +59,7 @@ class User {
       if (privateKey.hasSameFingerprintAs(primaryKey)) {
         throw new Error('Not implemented for self signing');
       }
-      const signingKey = await privateKey.getSigningKey(
-        undefined, undefined, undefined,
-        { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }
-      );
+      const signingKey = await privateKey.getSigningKey(undefined, undefined, undefined, config);
       return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -61,7 +61,7 @@ class User {
       }
       const signingKey = await privateKey.getSigningKey(
         undefined, undefined, undefined,
-        { ...config, rejectPublicKeyAlgorithms: new Set([]) }
+        { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 }
       );
       return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
@@ -120,7 +120,7 @@ class User {
       if (!key.getKeyIds().some(id => id.equals(keyid))) {
         return null;
       }
-      const signingKey = await key.getSigningKey(keyid, date, undefined, { ...config, rejectPublicKeyAlgorithms: new Set([]) });
+      const signingKey = await key.getSigningKey(keyid, date, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 });
       if (certificate.revoked || await that.isRevoked(primaryKey, certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -120,7 +120,7 @@ class User {
       if (!key.getKeyIds().some(id => id.equals(keyid))) {
         return null;
       }
-      const signingKey = await key.getSigningKey(keyid, date, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRsaBits: 0 });
+      const signingKey = await key.getSigningKey(keyid, date, undefined, config);
       if (certificate.revoked || await that.isRevoked(primaryKey, certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }

--- a/src/message.js
+++ b/src/message.js
@@ -523,7 +523,9 @@ export class Message {
    * @param {Date} [date] - Verify the signature against the given date, i.e. check signature creation time < date < expiration time
    * @param {Boolean} [streaming] - Whether to process data as a stream
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
-   * @returns {Array<({keyid: module:type/keyid~Keyid, valid: Boolean})>} List of signer's keyid and validity of signature.
+   * @returns {Array<{keyid: module:type/keyid~Keyid,
+   *                  signature: Promise<Signature>,
+   *                  verified: Promise<Boolean>}>} List of signer's keyid and validity of signatures.
    * @async
    */
   async verify(keys, date = new Date(), streaming, config = defaultConfig) {
@@ -576,7 +578,9 @@ export class Message {
    * @param {Signature} signature
    * @param {Date} date - Verify the signature against the given date, i.e. check signature creation time < date < expiration time
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
-   * @returns {Array<({keyid: module:type/keyid~Keyid, valid: Boolean})>} List of signer's keyid and validity of signature.
+   * @returns {Array<{keyid: module:type/keyid~Keyid,
+   *                  signature: Promise<Signature>,
+   *                  verified: Promise<Boolean>}>} List of signer's keyid and validity of signature.
    * @async
    */
   verifyDetached(signature, keys, date = new Date(), streaming, config = defaultConfig) {
@@ -733,14 +737,16 @@ export async function createSignaturePackets(literalDataPacket, privateKeys, sig
  *                    i.e. check signature creation time < date < expiration time
  * @param {Boolean} [detached] - Whether to verify detached signature packets
  * @param {Object} [config] - Full configuration, defaults to openpgp.config
- * @returns {Promise<Array<{keyid: module:type/keyid~Keyid,
- *                          valid: Boolean|null}>>} list of signer's keyid and validity of signature
+ * @returns {{keyid: module:type/keyid~Keyid,
+ *            signature: Promise<Signature>,
+ *            verified: Promise<Boolean>}} signer's keyid and validity of signature
  * @async
  * @private
  */
 async function createVerificationObject(signature, literalDataList, keys, date = new Date(), detached = false, streaming = false, config = defaultConfig) {
   let primaryKey;
   let signingKey;
+  let keyError;
 
   for (const key of keys) {
     const issuerKeys = key.getKeys(signature.issuerKeyId);
@@ -749,18 +755,21 @@ async function createVerificationObject(signature, literalDataList, keys, date =
       break;
     }
   }
-
+  if (!primaryKey) {
+    keyError = new Error(`Could not find key with id ${signature.issuerKeyId.toHex()}`);
+  } else {
+    try {
+      signingKey = await primaryKey.getSigningKey(signature.issuerKeyId, null, undefined, config);
+    } catch (e) {
+      keyError = new Error(`Key with id ${signature.issuerKeyId.toHex()} is not suitable for verification: ${e.message}`);
+    }
+  }
   const signaturePacket = signature.correspondingSig || signature;
   const verifiedSig = {
     keyid: signature.issuerKeyId,
     verified: (async () => {
-      if (!primaryKey) {
-        throw new Error(`Could not find key with id ${signature.issuerKeyId.toHex()}`);
-      }
-      try {
-        signingKey = await primaryKey.getSigningKey(signature.issuerKeyId, null, undefined, config);
-      } catch (e) {
-        throw new Error(`Key with id ${signature.issuerKeyId.toHex()} is not suitable for verification: ${e.message}`);
+      if (keyError) {
+        throw keyError;
       }
       await signature.verify(signingKey.keyPacket, signature.signatureType, literalDataList[0], detached, streaming, config);
       const sig = await signaturePacket;
@@ -802,8 +811,9 @@ async function createVerificationObject(signature, literalDataList, keys, date =
  *                    i.e. check signature creation time < date < expiration time
  * @param {Boolean} [detached] - Whether to verify detached signature packets
  * @param {Object} [config] - Full configuration, defaults to openpgp.config
- * @returns {Promise<Array<{keyid: module:type/keyid~Keyid,
- *                          valid: Boolean}>>} list of signer's keyid and validity of signature
+ * @returns {Array<{keyid: module:type/keyid~Keyid,
+ *            signature: Promise<Signature>,
+ *            verified: Promise<Boolean>}>} list of signer's keyid and validity of signatures
  * @async
  * @private
  */

--- a/src/message.js
+++ b/src/message.js
@@ -756,12 +756,12 @@ async function createVerificationObject(signature, literalDataList, keys, date =
     }
   }
   if (!primaryKey) {
-    keyError = new Error(`Could not find key with id ${signature.issuerKeyId.toHex()}`);
+    keyError = new Error(`Could not find signing key with key ID ${signature.issuerKeyId.toHex()}`);
   } else {
     try {
       signingKey = await primaryKey.getSigningKey(signature.issuerKeyId, null, undefined, config);
     } catch (e) {
-      keyError = new Error(`Key with id ${signature.issuerKeyId.toHex()} is not suitable for verification: ${e.message}`);
+      keyError = e;
     }
   }
   const signaturePacket = signature.correspondingSig || signature;

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -234,7 +234,7 @@ class PublicKeyPacket {
     // RSA, DSA or ElGamal public modulo
     const modulo = this.publicParams.n || this.publicParams.p;
     if (modulo) {
-      result.bits = modulo.length * 8;
+      result.bits = util.uint8ArrayBitLength(modulo);
     } else {
       result.curve = this.publicParams.oid.getName();
     }

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -652,7 +652,7 @@ class SignaturePacket {
   /**
    * verifies the signature packet. Note: not all signature types are implemented
    * @param {PublicSubkeyPacket|PublicKeyPacket|
-   *         SecretSubkeyPacket|SecretKeyPacket} key the public key to verify the signature
+   *         SecretSubkeyPacket|SecretKeyPacket} key - the public key to verify the signature
    * @param {module:enums.signature} signatureType - Expected signature type
    * @param {String|Object} data - Data which on the signature applies
    * @param {Boolean} [detached] - Whether to verify a detached signature

--- a/src/util.js
+++ b/src/util.js
@@ -196,7 +196,7 @@ const util = {
     if (bitSize === 0) {
       throw new Error('Zero MPI');
     }
-    const stripped = bin.subarray(bin.length - ((bitSize + 7) / 8));
+    const stripped = bin.subarray(bin.length - Math.ceil(bitSize / 8));
     const prefix = Uint8Array.from([(bitSize & 0xFF00) >> 8, bitSize & 0xFF]);
     return util.concatUint8Array([prefix, stripped]);
   },

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3381,7 +3381,7 @@ VYGdb3eNlV8CfoEC
     publicKey.users[1].selfCertifications[0].preferredSymmetricAlgorithms = [openpgp.enums.symmetric.aes128];
     const sessionKey = await openpgp.generateSessionKey({ publicKeys: publicKey, toUserIds: { name: 'Test User', email: 'b@c.com' } });
     expect(sessionKey.algorithm).to.equal('aes128');
-    const config = { minRsaBits: 1024 }
+    const config = { minRsaBits: 1024 };
     await openpgp.encrypt({
       message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, toUserIds: { name: 'Test User', email: 'b@c.com' }, armor: false, config
     });

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2423,8 +2423,8 @@ function versionSpecificTests() {
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signPrimaryUser([privateKey]);
     const signatures = await publicKey.verifyPrimaryUser([privateKey]);
-    const publicSigningKey = await publicKey.getSigningKey();
-    const privateSigningKey = await privateKey.getSigningKey();
+    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
+    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
     expect(signatures.length).to.equal(2);
     expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
     expect(signatures[0].valid).to.be.null;
@@ -2439,8 +2439,8 @@ function versionSpecificTests() {
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signPrimaryUser([privateKey]);
     const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
-    const publicSigningKey = await publicKey.getSigningKey();
-    const privateSigningKey = await privateKey.getSigningKey();
+    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
+    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
     expect(signatures.length).to.equal(2);
     expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
     expect(signatures[0].valid).to.be.null;
@@ -2454,8 +2454,8 @@ function versionSpecificTests() {
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signAllUsers([privateKey]);
     const signatures = await publicKey.verifyAllUsers([privateKey]);
-    const publicSigningKey = await publicKey.getSigningKey();
-    const privateSigningKey = await privateKey.getSigningKey();
+    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
+    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
     expect(signatures.length).to.equal(4);
     expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
     expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
@@ -2478,8 +2478,8 @@ function versionSpecificTests() {
     await privateKey.decrypt('hello world');
     publicKey = await publicKey.signAllUsers([privateKey]);
     const signatures = await publicKey.verifyAllUsers([wrongKey]);
-    const publicSigningKey = await publicKey.getSigningKey();
-    const privateSigningKey = await privateKey.getSigningKey();
+    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
+    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
     expect(signatures.length).to.equal(4);
     expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
     expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
@@ -2784,12 +2784,12 @@ module.exports = () => describe('Key', function() {
   it('Verify status of key with non-self revocation signature', async function() {
     const pubKey = await openpgp.readKey({ armoredKey: key_with_revoked_third_party_cert });
     const [selfCertification] = await pubKey.verifyPrimaryUser();
-    const publicSigningKey = await pubKey.getSigningKey();
+    const publicSigningKey = await pubKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, rejectPublicKeyAlgorithms: new Set() });
     expect(selfCertification.keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
     expect(selfCertification.valid).to.be.true;
 
     const certifyingKey = await openpgp.readKey({ armoredKey: certifying_key });
-    const certifyingSigningKey = await certifyingKey.getSigningKey();
+    const certifyingSigningKey = await certifyingKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, rejectPublicKeyAlgorithms: new Set() });
     const signatures = await pubKey.verifyPrimaryUser([certifyingKey]);
     expect(signatures.length).to.equal(2);
     expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
@@ -2798,13 +2798,13 @@ module.exports = () => describe('Key', function() {
     expect(signatures[1].valid).to.be.false;
 
     const { user } = await pubKey.getPrimaryUser();
-    await expect(user.verifyCertificate(pubKey.primaryKey, user.otherCertifications[0], [certifyingKey])).to.be.rejectedWith('User certificate is revoked');
+    await expect(user.verifyCertificate(pubKey.primaryKey, user.otherCertifications[0], [certifyingKey], undefined, openpgp.config)).to.be.rejectedWith('User certificate is revoked');
   });
 
   it('Verify certificate of key with future creation date', async function() {
     const pubKey = await openpgp.readKey({ armoredKey: key_created_2030 });
     const user = pubKey.users[0];
-    await user.verifyCertificate(pubKey.primaryKey, user.selfCertifications[0], [pubKey], pubKey.primaryKey.created);
+    await user.verifyCertificate(pubKey.primaryKey, user.selfCertifications[0], [pubKey], pubKey.primaryKey.created, openpgp.config);
     const verifyAllResult = await user.verifyAllCertifications(pubKey.primaryKey, [pubKey], pubKey.primaryKey.created);
     expect(verifyAllResult[0].valid).to.be.true;
     await user.verify(pubKey.primaryKey, pubKey.primaryKey.created);
@@ -2976,7 +2976,7 @@ module.exports = () => describe('Key', function() {
     expect(key.primaryKey.isDummy()).to.be.false;
     key.primaryKey.makeDummy();
     expect(key.primaryKey.isDummy()).to.be.true;
-    await expect(openpgp.sign({ message: openpgp.Message.fromText('test'), privateKeys: [key] })).to.be.fulfilled;
+    await expect(openpgp.sign({ message: openpgp.Message.fromText('test'), privateKeys: [key], config: { minRsaBits: 1024 } })).to.be.fulfilled;
   });
 
   it('makeDummy() - should work for encrypted keys', async function() {
@@ -3381,8 +3381,13 @@ VYGdb3eNlV8CfoEC
     publicKey.users[1].selfCertifications[0].preferredSymmetricAlgorithms = [openpgp.enums.symmetric.aes128];
     const sessionKey = await openpgp.generateSessionKey({ publicKeys: publicKey, toUserIds: { name: 'Test User', email: 'b@c.com' } });
     expect(sessionKey.algorithm).to.equal('aes128');
-    await openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, toUserIds: { name: 'Test User', email: 'b@c.com' }, armor: false });
-    await expect(openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, toUserIds: { name: 'Test User', email: 'c@c.com' }, armor: false })).to.be.rejectedWith('Could not find user that matches that user ID');
+    const config = { minRsaBits: 1024 }
+    await openpgp.encrypt({
+      message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, toUserIds: { name: 'Test User', email: 'b@c.com' }, armor: false, config
+    });
+    await expect(openpgp.encrypt({
+      message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, toUserIds: { name: 'Test User', email: 'c@c.com' }, armor: false, config
+    })).to.be.rejectedWith('Could not find user that matches that user ID');
   });
 
   it('Fails to encrypt to User ID-less key', async function() {
@@ -3406,18 +3411,25 @@ VYGdb3eNlV8CfoEC
     privateKey.users[0].userId = openpgp.UserIDPacket.fromObject({ name: 'Test User', email: 'b@c.com' });
     // Set second user to prefer aes128. We will select this user.
     privateKey.users[1].selfCertifications[0].preferredHashAlgorithms = [openpgp.enums.hash.sha512];
-    const signed = await openpgp.sign({ message: openpgp.Message.fromText('hello'), privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false });
+    const config = { minRsaBits: 1024 };
+    const signed = await openpgp.sign({
+      message: openpgp.Message.fromText('hello'), privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false, config
+    });
     const signature = await openpgp.readMessage({ binaryMessage: signed });
     expect(signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
-    const encrypted = await openpgp.encrypt({ message: openpgp.Message.fromText('hello'), passwords: 'test', privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false });
+    const encrypted = await openpgp.encrypt({
+      message: openpgp.Message.fromText('hello'), passwords: 'test', privateKeys: privateKey, fromUserIds: { name: 'Test McTestington', email: 'test@example.com' }, armor: false, config
+    });
     const { signatures } = await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), passwords: 'test' });
     expect(signatures[0].signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
-    await expect(openpgp.encrypt({ message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, fromUserIds: { name: 'Not Test McTestington', email: 'test@example.com' }, armor: false })).to.be.rejectedWith('Could not find user that matches that user ID');
+    await expect(openpgp.encrypt({
+      message: openpgp.Message.fromText('hello'), publicKeys: publicKey, privateKeys: privateKey, fromUserIds: { name: 'Not Test McTestington', email: 'test@example.com' }, armor: false, config
+    })).to.be.rejectedWith('Could not find user that matches that user ID');
   });
 
   it('Find a valid subkey binding signature among many invalid ones', async function() {
     const key = await openpgp.readKey({ armoredKey: valid_binding_sig_among_many_expired_sigs_pub });
-    expect(await key.getEncryptionKey()).to.not.be.null;
+    expect(await key.getEncryptionKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 })).to.not.be.null;
   });
 
   it('Selects the most recent subkey binding signature', async function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2421,15 +2421,22 @@ function versionSpecificTests() {
     let publicKey = await openpgp.readKey({ armoredKey: pub_sig_test });
     const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
-    publicKey = await publicKey.signPrimaryUser([privateKey]);
-    const signatures = await publicKey.verifyPrimaryUser([privateKey]);
-    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    expect(signatures.length).to.equal(2);
-    expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[0].valid).to.be.null;
-    expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[1].valid).to.be.true;
+
+    const { minRsaBits } = openpgp.config;
+    openpgp.config.minRsaBits = 1024;
+    try {
+      publicKey = await publicKey.signPrimaryUser([privateKey]);
+      const signatures = await publicKey.verifyPrimaryUser([privateKey]);
+      const publicSigningKey = await publicKey.getSigningKey();
+      const privateSigningKey = await privateKey.getSigningKey();
+      expect(signatures.length).to.equal(2);
+      expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[0].valid).to.be.null;
+      expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[1].valid).to.be.true;
+    } finally {
+      openpgp.config.minRsaBits = minRsaBits;
+    }
   });
 
   it('Sign key and verify with wrong key - primary user', async function() {
@@ -2437,38 +2444,52 @@ function versionSpecificTests() {
     const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
     await privateKey.decrypt('hello world');
-    publicKey = await publicKey.signPrimaryUser([privateKey]);
-    const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
-    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    expect(signatures.length).to.equal(2);
-    expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[0].valid).to.be.null;
-    expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[1].valid).to.be.null;
+
+    const { minRsaBits } = openpgp.config;
+    openpgp.config.minRsaBits = 1024;
+    try {
+      publicKey = await publicKey.signPrimaryUser([privateKey]);
+      const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
+      const publicSigningKey = await publicKey.getSigningKey();
+      const privateSigningKey = await privateKey.getSigningKey();
+      expect(signatures.length).to.equal(2);
+      expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[0].valid).to.be.null;
+      expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[1].valid).to.be.null;
+    } finally {
+      openpgp.config.minRsaBits = minRsaBits;
+    }
   });
 
   it('Sign and verify key - all users', async function() {
     let publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
     const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     await privateKey.decrypt('hello world');
-    publicKey = await publicKey.signAllUsers([privateKey]);
-    const signatures = await publicKey.verifyAllUsers([privateKey]);
-    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    expect(signatures.length).to.equal(4);
-    expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
-    expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[0].valid).to.be.null;
-    expect(signatures[1].userid).to.equal(publicKey.users[0].userId.userid);
-    expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[1].valid).to.be.true;
-    expect(signatures[2].userid).to.equal(publicKey.users[1].userId.userid);
-    expect(signatures[2].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[2].valid).to.be.null;
-    expect(signatures[3].userid).to.equal(publicKey.users[1].userId.userid);
-    expect(signatures[3].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[3].valid).to.be.true;
+
+    const { minRsaBits } = openpgp.config;
+    openpgp.config.minRsaBits = 1024;
+    try {
+      publicKey = await publicKey.signAllUsers([privateKey]);
+      const signatures = await publicKey.verifyAllUsers([privateKey]);
+      const publicSigningKey = await publicKey.getSigningKey();
+      const privateSigningKey = await privateKey.getSigningKey();
+      expect(signatures.length).to.equal(4);
+      expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
+      expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[0].valid).to.be.null;
+      expect(signatures[1].userid).to.equal(publicKey.users[0].userId.userid);
+      expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[1].valid).to.be.true;
+      expect(signatures[2].userid).to.equal(publicKey.users[1].userId.userid);
+      expect(signatures[2].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[2].valid).to.be.null;
+      expect(signatures[3].userid).to.equal(publicKey.users[1].userId.userid);
+      expect(signatures[3].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[3].valid).to.be.true;
+    } finally {
+      openpgp.config.minRsaBits = minRsaBits;
+    }
   });
 
   it('Sign key and verify with wrong key - all users', async function() {
@@ -2476,23 +2497,30 @@ function versionSpecificTests() {
     const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
     await privateKey.decrypt('hello world');
-    publicKey = await publicKey.signAllUsers([privateKey]);
-    const signatures = await publicKey.verifyAllUsers([wrongKey]);
-    const publicSigningKey = await publicKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    const privateSigningKey = await privateKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, minRsaBits: 1024 });
-    expect(signatures.length).to.equal(4);
-    expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
-    expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[0].valid).to.be.null;
-    expect(signatures[1].userid).to.equal(publicKey.users[0].userId.userid);
-    expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[1].valid).to.be.null;
-    expect(signatures[2].userid).to.equal(publicKey.users[1].userId.userid);
-    expect(signatures[2].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[2].valid).to.be.null;
-    expect(signatures[3].userid).to.equal(publicKey.users[1].userId.userid);
-    expect(signatures[3].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
-    expect(signatures[3].valid).to.be.null;
+
+    const { minRsaBits } = openpgp.config;
+    openpgp.config.minRsaBits = 1024;
+    try {
+      publicKey = await publicKey.signAllUsers([privateKey]);
+      const signatures = await publicKey.verifyAllUsers([wrongKey]);
+      const publicSigningKey = await publicKey.getSigningKey();
+      const privateSigningKey = await privateKey.getSigningKey();
+      expect(signatures.length).to.equal(4);
+      expect(signatures[0].userid).to.equal(publicKey.users[0].userId.userid);
+      expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[0].valid).to.be.null;
+      expect(signatures[1].userid).to.equal(publicKey.users[0].userId.userid);
+      expect(signatures[1].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[1].valid).to.be.null;
+      expect(signatures[2].userid).to.equal(publicKey.users[1].userId.userid);
+      expect(signatures[2].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[2].valid).to.be.null;
+      expect(signatures[3].userid).to.equal(publicKey.users[1].userId.userid);
+      expect(signatures[3].keyid.toHex()).to.equal(privateSigningKey.getKeyId().toHex());
+      expect(signatures[3].valid).to.be.null;
+    } finally {
+      openpgp.config.minRsaBits = minRsaBits;
+    }
   });
 
   it('Reformat key without passphrase', function() {
@@ -2782,23 +2810,30 @@ module.exports = () => describe('Key', function() {
   });
 
   it('Verify status of key with non-self revocation signature', async function() {
-    const pubKey = await openpgp.readKey({ armoredKey: key_with_revoked_third_party_cert });
-    const [selfCertification] = await pubKey.verifyPrimaryUser();
-    const publicSigningKey = await pubKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, rejectPublicKeyAlgorithms: new Set() });
-    expect(selfCertification.keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(selfCertification.valid).to.be.true;
+    const { rejectPublicKeyAlgorithms } = openpgp.config;
+    openpgp.config.rejectPublicKeyAlgorithms = new Set();
 
-    const certifyingKey = await openpgp.readKey({ armoredKey: certifying_key });
-    const certifyingSigningKey = await certifyingKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, rejectPublicKeyAlgorithms: new Set() });
-    const signatures = await pubKey.verifyPrimaryUser([certifyingKey]);
-    expect(signatures.length).to.equal(2);
-    expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
-    expect(signatures[0].valid).to.be.null;
-    expect(signatures[1].keyid.toHex()).to.equal(certifyingSigningKey.getKeyId().toHex());
-    expect(signatures[1].valid).to.be.false;
+    try {
+      const pubKey = await openpgp.readKey({ armoredKey: key_with_revoked_third_party_cert });
+      const [selfCertification] = await pubKey.verifyPrimaryUser();
+      const publicSigningKey = await pubKey.getSigningKey();
+      expect(selfCertification.keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(selfCertification.valid).to.be.true;
 
-    const { user } = await pubKey.getPrimaryUser();
-    await expect(user.verifyCertificate(pubKey.primaryKey, user.otherCertifications[0], [certifyingKey], undefined, openpgp.config)).to.be.rejectedWith('User certificate is revoked');
+      const certifyingKey = await openpgp.readKey({ armoredKey: certifying_key });
+      const certifyingSigningKey = await certifyingKey.getSigningKey();
+      const signatures = await pubKey.verifyPrimaryUser([certifyingKey]);
+      expect(signatures.length).to.equal(2);
+      expect(signatures[0].keyid.toHex()).to.equal(publicSigningKey.getKeyId().toHex());
+      expect(signatures[0].valid).to.be.null;
+      expect(signatures[1].keyid.toHex()).to.equal(certifyingSigningKey.getKeyId().toHex());
+      expect(signatures[1].valid).to.be.false;
+
+      const { user } = await pubKey.getPrimaryUser();
+      await expect(user.verifyCertificate(pubKey.primaryKey, user.otherCertifications[0], [certifyingKey], undefined, openpgp.config)).to.be.rejectedWith('User certificate is revoked');
+    } finally {
+      openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
+    }
   });
 
   it('Verify certificate of key with future creation date', async function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1630,7 +1630,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
             expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find key/);
+            expect(signatures[0].error).to.match(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
             expect(signatures[0].signature.packets.length).to.equal(1);
@@ -1653,7 +1653,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
             expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find key/);
+            expect(signatures[0].error).to.match(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
             expect(signatures[0].signature.packets.length).to.equal(1);
@@ -1676,7 +1676,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal('');
             expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find key/);
+            expect(signatures[0].error).to.match(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
             expect(signatures[0].signature.packets.length).to.equal(1);
@@ -1698,7 +1698,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
             expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find key/);
+            expect(signatures[0].error).to.match(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
             expect(signatures[0].signature.packets.length).to.equal(1);
@@ -1723,7 +1723,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           });
           expect(data).to.equal(plaintext);
           expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find key/);
+          expect(signatures[0].error).to.match(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
           expect(signatures[0].signature.packets.length).to.equal(1);
@@ -2184,7 +2184,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         }).then(async function ({ data, signatures }) {
           expect(data).to.equal(plaintext.replace(/[ \t]+$/mg, ''));
           expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find key/);
+          expect(signatures[0].error).to.match(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
           expect(signatures[0].signature.packets.length).to.equal(1);
@@ -2208,7 +2208,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         }).then(async function ({ data, signatures }) {
           expect(data).to.equal(plaintext);
           expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find key/);
+          expect(signatures[0].error).to.match(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyid.toHex()).to.equal(signingKey.getKeyId().toHex());
           expect(signatures[0].signature.packets.length).to.equal(1);

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1630,7 +1630,7 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
 
     const signedKey = await openpgp.readKey({ armoredKey: signedArmor });
     const signerKey = await openpgp.readKey({ armoredKey: priv_key_arm1 });
-    return signedKey.verifyPrimaryUser([signerKey]).then(signatures => {
+    return signedKey.verifyPrimaryUser([signerKey], undefined, undefined, { ...openpgp.config, rejectPublicKeyAlgorithms: new Set() }).then(signatures => {
       expect(signatures[0].valid).to.be.null;
       expect(signatures[0].keyid.toHex()).to.equal(signedKey.getKeyId().toHex());
       expect(signatures[1].valid).to.be.true;

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -508,7 +508,7 @@ function tests() {
       dataArrived();
       await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
       expect(decrypted.signatures).to.exist.and.have.length(1);
-      await expect(decrypted.signatures[0].verified).to.be.eventually.rejectedWith(/Could not find key/);
+      await expect(decrypted.signatures[0].verified).to.be.eventually.rejectedWith(/Could not find signing key/);
     } finally {
       openpgp.config.allowUnauthenticatedStream = allowUnauthenticatedStreamValue;
     }

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -237,7 +237,8 @@ function tests() {
   it('Sign: Input stream should be canceled when canceling encrypted stream', async function() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
-      privateKeys: privKey
+      privateKeys: privKey,
+      config: { minRsaBits: 1024 }
     });
     const reader = openpgp.stream.getReader(signed);
     expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
@@ -312,7 +313,8 @@ function tests() {
         message: openpgp.Message.fromBinary(data),
         publicKeys: pubKey,
         privateKeys: privKey,
-        armor: false
+        armor: false,
+        config: { minRsaBits: 1024 }
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -443,7 +445,8 @@ function tests() {
       const encrypted = await openpgp.encrypt({
         message: openpgp.Message.fromBinary(data),
         publicKeys: pubKey,
-        privateKeys: privKey
+        privateKeys: privKey,
+        config: { minRsaBits: 1024 }
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -480,7 +483,8 @@ function tests() {
       const encrypted = await openpgp.encrypt({
         message: openpgp.Message.fromBinary(data),
         publicKeys: pubKey,
-        privateKeys: privKey
+        privateKeys: privKey,
+        config: { minRsaBits: 1024 }
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -504,7 +508,7 @@ function tests() {
       dataArrived();
       await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
       expect(decrypted.signatures).to.exist.and.have.length(1);
-      expect(await decrypted.signatures[0].verified).to.be.null;
+      await expect(decrypted.signatures[0].verified).to.be.eventually.rejectedWith(/Could not find key/);
     } finally {
       openpgp.config.allowUnauthenticatedStream = allowUnauthenticatedStreamValue;
     }
@@ -513,7 +517,8 @@ function tests() {
   it('Sign/verify: Detect armor checksum error', async function() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
-      privateKeys: privKey
+      privateKeys: privKey,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
@@ -529,7 +534,8 @@ function tests() {
       publicKeys: pubKey,
       message,
       streaming: expectedType,
-      format: 'binary'
+      format: 'binary',
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(verified.data)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(verified.data);
@@ -567,7 +573,8 @@ function tests() {
   it('Sign/verify: Input stream should be canceled when canceling verified stream', async function() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
-      privateKeys: privKey
+      privateKeys: privKey,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
@@ -575,7 +582,8 @@ function tests() {
     const verified = await openpgp.verify({
       publicKeys: pubKey,
       message,
-      format: 'binary'
+      format: 'binary',
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(verified.data)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(verified.data);
@@ -605,7 +613,8 @@ function tests() {
   it("Sign: Don't pull entire input stream when we're not pulling signed stream", async function() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
-      privateKeys: privKey
+      privateKeys: privKey,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
@@ -619,7 +628,8 @@ function tests() {
   it("Sign/verify: Don't pull entire input stream when we're not pulling verified stream", async function() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
-      privateKeys: privKey
+      privateKeys: privKey,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const message = await openpgp.readMessage({ armoredMessage: signed });
@@ -649,7 +659,8 @@ function tests() {
       message: openpgp.Message.fromBinary(data),
       privateKeys: privKey,
       detached: true,
-      streaming: expectedType
+      streaming: expectedType,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const armoredSignature = await openpgp.stream.readToEnd(signed);
@@ -657,7 +668,8 @@ function tests() {
     const verified = await openpgp.verify({
       signature,
       publicKeys: pubKey,
-      message: openpgp.Message.fromText('hello world')
+      message: openpgp.Message.fromText('hello world'),
+      config: { minRsaBits: 1024 }
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);
@@ -678,14 +690,16 @@ function tests() {
       privateKeys: privKey,
       detached: true,
       streaming: false,
-      armor: false
+      armor: false,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.be.false;
     const signature = await openpgp.readMessage({ binaryMessage: signed });
     const verified = await openpgp.verify({
       signature,
       publicKeys: pubKey,
-      message: openpgp.Message.fromText('hello world')
+      message: openpgp.Message.fromText('hello world'),
+      config: { minRsaBits: 1024 }
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);
@@ -758,7 +772,8 @@ function tests() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
       privateKeys: privKey,
-      detached: true
+      detached: true,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);
@@ -772,7 +787,8 @@ function tests() {
     const signed = await openpgp.sign({
       message: openpgp.Message.fromBinary(data),
       privateKeys: privKey,
-      detached: true
+      detached: true,
+      config: { minRsaBits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const reader = openpgp.stream.getReader(signed);

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -409,7 +409,7 @@ function omnibus() {
 
       certificate.verified = null;
       await user.verifyCertificate(
-        primaryKey, certificate, [hi.toPublic()]
+        primaryKey, certificate, [hi.toPublic()], undefined, openpgp.config
       ).then(async () => expect(certificate.verified).to.be.true);
 
       const options = {
@@ -432,7 +432,7 @@ function omnibus() {
         ).then(async () => expect(certificate.verified).to.be.true);
         certificate.verified = null;
         await user.verifyCertificate(
-          bye.primaryKey, user.selfCertifications[0], [bye.toPublic()]
+          bye.primaryKey, user.selfCertifications[0], [bye.toPublic()], undefined, openpgp.config
         ).then(async () => expect(certificate.verified).to.be.true);
 
         return Promise.all([

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -72,7 +72,8 @@ async function testSubkeyTrust() {
     streaming: false
   });
   expect(verifyAttackerIsBatman.signatures[0].keyid.equals(victimPubKey.subKeys[0].getKeyId())).to.be.true;
-  expect(verifyAttackerIsBatman.signatures[0].valid).to.be.null;
+  expect(verifyAttackerIsBatman.signatures[0].valid).to.be.false;
+  expect(verifyAttackerIsBatman.signatures[0].error).to.match(/Could not find valid signing key packet/);
 }
 
 module.exports = () => it('Does not trust subkeys without Primary Key Binding Signature', testSubkeyTrust);


### PR DESCRIPTION
Changes:
- add `config.rejectPublicKeyAlgorithms` to disallow using the given algos to verify, sign or encrypt new messages or third-party certifications
- consider `config.minRsaBits` when signing, verifying and encrypting messages and third-party certifications, not just on key generation
- when verifying a message, if the verification key is not found (i.e. not provided or too weak), the corresponding `signature` will have `signature.valid=false` (used to be `signature.valid=null`). `signature.error` will detail whether the key is missing/too weak/other.

Generating and verifying key certification signatures is still permitted in all cases.