### PR TITLE
Type definitions

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -25,7 +25,7 @@ export class Key {
   public subKeys: SubKey[];
   public users: User[];
   public revocationSignatures: SignaturePacket[];
-  public keyPacket: PublicKeyPacket | SecretKeyPacket;
+  private keyPacket: PublicKeyPacket | SecretKeyPacket;
   public write(): Uint8Array;
   public armor(config?: Config): string;
   public decrypt(passphrase: string | string[], keyId?: Keyid, config?: Config): Promise<void>; // throws on error
@@ -42,7 +42,7 @@ export class Key {
   public signAllUsers(privateKeys: Key[], config?: Config): Promise<Key>
   public verifyPrimaryKey(date?: Date, userId?: UserID, config?: Config): Promise<void>; // throws on error
   public verifyPrimaryUser(publicKeys: Key[], date?: Date, userIds?: UserID, config?: Config): Promise<{ keyid: Keyid, valid: boolean | null }[]>;
-  public verifyAllUsers(publicKeys: Key[], config?: Config): Promise<{ userid:string, keyid: Keyid, valid: boolean | null }[]>;
+  public verifyAllUsers(publicKeys: Key[], config?: Config): Promise<{ userid: string, keyid: Keyid, valid: boolean | null }[]>;
   public isRevoked(signature: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public revoke(reason: { flag?: enums.reasonForRevocation; string?: string; }, date?: Date, config?: Config): Promise<Key>;
   public getRevocationCertificate(date?: Date, config?: Config): Promise<Stream<string> | string | undefined>;
@@ -60,7 +60,7 @@ export class Key {
 
 export class SubKey {
   constructor(subKeyPacket: SecretSubkeyPacket | PublicSubkeyPacket);
-  public keyPacket: SecretSubkeyPacket | PublicSubkeyPacket;
+  private keyPacket: SecretSubkeyPacket | PublicSubkeyPacket;
   public bindingSignatures: SignaturePacket[];
   public revocationSignatures: SignaturePacket[];
   public verify(primaryKey: PublicKeyPacket | SecretKeyPacket, date?: Date, config?: Config): Promise<SignaturePacket>;
@@ -96,7 +96,7 @@ export function readSignature(options: { armoredSignature: string, config?: Part
 export function readSignature(options: { binarySignature: Uint8Array, config?: PartialConfig }): Promise<Signature>;
 
 export class Signature {
-  public packets: PacketList<SignaturePacket>;
+  private packets: PacketList<SignaturePacket>;
   constructor(packetlist: PacketList<SignaturePacket>);
   public write(): MaybeStream<Uint8Array>;
   public armor(config?: Config): string;
@@ -243,7 +243,7 @@ export function verify<T extends MaybeStream<Data>>(options: VerifyOptions & { m
  */
 export class Message<T extends MaybeStream<Data>> {
 
-  public packets: PacketList<AnyPacket>;
+  private packets: PacketList<AnyPacket>;
   constructor(packetlist: PacketList<AnyPacket>);
 
   /** Returns binary representation of message

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -26,6 +26,7 @@ export class Key {
   public users: User[];
   public revocationSignatures: SignaturePacket[];
   public keyPacket: PublicKeyPacket | SecretKeyPacket;
+  public write(): Uint8Array;
   public armor(config?: Config): string;
   public decrypt(passphrase: string | string[], keyId?: Keyid, config?: Config): Promise<void>; // throws on error
   public encrypt(passphrase: string | string[], keyId?: Keyid, config?: Config): Promise<void>; // throws on error
@@ -93,6 +94,7 @@ export function readSignature(options: { binarySignature: Uint8Array, config?: P
 export class Signature {
   public packets: PacketList<SignaturePacket>;
   constructor(packetlist: PacketList<SignaturePacket>);
+  public write(): MaybeStream<Uint8Array>;
   public armor(config?: Config): string;
 }
 
@@ -239,6 +241,10 @@ export class Message<T extends MaybeStream<Data>> {
 
   public packets: PacketList<AnyPacket>;
   constructor(packetlist: PacketList<AnyPacket>);
+
+  /** Returns binary representation of message
+   */
+  public write(): MaybeStream<Uint8Array>;
 
   /** Returns ASCII armored text of message
    */

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -38,7 +38,11 @@ export class Key {
   public isPublic(): boolean;
   public toPublic(): Key;
   public update(key: Key, config?: Config): void;
+  public signPrimaryUser(privateKeys: Key[], date?: Date, userId?: UserID, config?: Config): Promise<Key>
+  public signAllUsers(privateKeys: Key[], config?: Config): Promise<Key>
   public verifyPrimaryKey(date?: Date, userId?: UserID, config?: Config): Promise<void>; // throws on error
+  public verifyPrimaryUser(publicKeys: Key[], date?: Date, userIds?: UserID, config?: Config): Promise<{ keyid: Keyid, valid: boolean | null }[]>;
+  public verifyAllUsers(publicKeys: Key[], config?: Config): Promise<{ userid:string, keyid: Keyid, valid: boolean | null }[]>;
   public isRevoked(signature: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public revoke(reason: { flag?: enums.reasonForRevocation; string?: string; }, date?: Date, config?: Config): Promise<Key>;
   public getRevocationCertificate(date?: Date, config?: Config): Promise<Stream<string> | string | undefined>;

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -260,6 +260,14 @@ class Key {
   }
 
   /**
+   * Returns binary encoded key
+   * @returns {Uint8Array} Binary key.
+   */
+  write() {
+    return this.toPacketlist().write();
+  }
+
+  /**
    * Returns ASCII armored text of key
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {ReadableStream<String>} ASCII armor.


### PR DESCRIPTION
- Added `key.write()`, returning binary representation of a Key.
- Added type definitions for `key.write()`, `signature.write()`, and `message.write()` to avoid dealing with packets.
- Added type definitions for key certification and verification

Should we hide `key.keyPacket`, `signature.packets` and `message.packets` from the type definitions?
