### PR TITLE
Add `expectSigned` option to `openpgp.decrypt` and `openpgp.verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ If you expect an encrypted message to be signed with one of the public keys you 
     const { data: decrypted, signatures } = await openpgp.decrypt({
         message,
         privateKeys: privateKey // for decryption
-        expectSign: true,
-        publicKeys: publicKey, // for verification (mandatory with expectSign=true)
+        expectSigned: true,
+        publicKeys: publicKey, // for verification (mandatory with expectSigned=true)
     });
     console.log(decrypted); // 'Hello, World!'
 })();

--- a/README.md
+++ b/README.md
@@ -225,16 +225,17 @@ const openpgp = require('openpgp'); // use as CommonJS, AMD, ES6 module or via w
     const message = await openpgp.readMessage({
         armoredMessage: encrypted // parse armored message
     });
-    const { data: decrypted } = await openpgp.decrypt({
+    const { data: decrypted, signatures } = await openpgp.decrypt({
         message,
         publicKeys: publicKey, // for verification (optional)
         privateKeys: privateKey // for decryption
     });
     console.log(decrypted); // 'Hello, World!'
+    console.log(signatures[0].valid) // signature validity (signed messages only)
 })();
 ```
 
-Encrypt with multiple public keys:
+Encrypt to multiple public keys:
 
 ```js
 (async () => {
@@ -264,6 +265,41 @@ Encrypt with multiple public keys:
         privateKeys: privateKey // for signing (optional)
     });
     console.log(encrypted); // '-----BEGIN PGP MESSAGE ... END PGP MESSAGE-----'
+})();
+```
+
+If you expect an encrypted message to be signed with one of the public keys you have, and do not want to trust the decrypted data otherwise, you can pass the decryption option `expectSigned = true`, so that the decryption operation will fail if no valid signature is found:
+```js
+(async () => {
+    // put keys in backtick (``) to avoid errors caused by spaces or tabs
+    const publicKeyArmored = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+...
+-----END PGP PUBLIC KEY BLOCK-----`;
+    const privateKeyArmored = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+...
+-----END PGP PRIVATE KEY BLOCK-----`; // encrypted private key
+    const passphrase = `yourPassphrase`; // what the private key is encrypted with
+
+    const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
+
+    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    await privateKey.decrypt(passphrase);
+
+    const encryptedAndSignedMessage = `-----BEGIN PGP MESSAGE-----
+...
+-----END PGP MESSAGE-----`;
+
+    const message = await openpgp.readMessage({
+        armoredMessage: encryptedAndSignedMessage // parse armored message
+    });
+    // decryption will fail if all signatures are invalid or missing
+    const { data: decrypted, signatures } = await openpgp.decrypt({
+        message,
+        privateKeys: privateKey // for decryption
+        expectSign: true,
+        publicKeys: publicKey, // for verification (mandatory with expectSign=true)
+    });
+    console.log(decrypted); // 'Hello, World!'
 })();
 ```
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -543,6 +543,8 @@ interface DecryptOptions {
   sessionKeys?: SessionKey | SessionKey[];
   /** (optional) array of public keys or single key, to verify signatures */
   publicKeys?: Key | Key[];
+  /** (optional) whether data decryption should fail if the message is not signed with the provided publicKeys */
+  expectSigned?: boolean;
   /** (optional) whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines. */
   format?: 'utf8' | 'binary';
   /** (optional) detached signature for verification */

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -566,10 +566,12 @@ interface SignOptions {
 }
 
 interface VerifyOptions {
-  /** array of publicKeys or single key, to verify signatures */
-  publicKeys: Key | Key[];
   /** (cleartext) message object with signatures */
   message: CleartextMessage | Message<MaybeStream<Data>>;
+  /** array of publicKeys or single key, to verify signatures */
+  publicKeys: Key | Key[];
+  /** (optional) whether verification should throw if the message is not signed with the provided publicKeys */
+  expectSigned?: boolean;
   /** (optional) whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines. */
   format?: 'utf8' | 'binary';
   /** (optional) detached signature for verification */

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -321,7 +321,7 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
       }
       result.data = stream.concat([
         result.data,
-        stream.fromAsync(() => Promise.any(
+        stream.fromAsync(() => util.promiseAny(
           result.signatures.map(sig => sig.verified)
         ).then(() => {}) // append nothing to the data
           .catch(() => { throw new Error('invalid message signature'); }))

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -321,7 +321,7 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
       }
       result.data = stream.concat([
         result.data,
-        stream.fromAsync(() => util.promiseAny(
+        stream.fromAsync(() => util.anyPromise(
           result.signatures.map(sig => sig.verified)
         ).then(() => {}) // append nothing to the data
           .catch(() => { throw new Error('invalid message signature'); }))

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -276,6 +276,7 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @param {String|Array<String>} [options.passwords] - Passwords to decrypt the message
  * @param {Object|Array<Object>} [options.sessionKeys] - Session keys in the form: { data:Uint8Array, algorithm:String }
  * @param {Key|Array<Key>} [options.publicKeys] - Array of public keys or single key, to verify signatures
+ * @param {Boolean} [options.enforceSigned=false] - If true, data decryption fails if message signatures are missing or invalid
  * @param {'utf8'|'binary'} [options.format='utf8'] - Whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines.
  * @param {Signature} [options.signature] - Detached signature for verification
  * @param {Date} [options.date=current date] - Use the given date for verification instead of the current time
@@ -297,7 +298,7 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @async
  * @static
  */
-export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, format = 'utf8', signature = null, date = new Date(), config }) {
+export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, enforceSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
 
@@ -311,6 +312,21 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
     result.data = format === 'binary' ? decrypted.getLiteralData() : decrypted.getText();
     result.filename = decrypted.getFilename();
     linkStreams(result, message);
+    if (enforceSigned) {
+      if (publicKeys.length === 0) {
+        throw new Error('public keys are required to verify message signatures');
+      }
+      if (result.signatures.length === 0) {
+        throw new Error('message is not signed');
+      }
+      result.data = stream.concat([
+        result.data,
+        stream.fromAsync(() => Promise.any(
+          result.signatures.map(sig => sig.verified)
+        ).then(() => {}) // append nothing to the data
+          .catch(() => { throw new Error('invalid message signature'); }))
+      ]);
+    }
     result.data = await convertStream(result.data, message.fromStream, format);
     if (!message.fromStream) await prepareSignatures(result.signatures);
     return result;

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -276,7 +276,7 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @param {String|Array<String>} [options.passwords] - Passwords to decrypt the message
  * @param {Object|Array<Object>} [options.sessionKeys] - Session keys in the form: { data:Uint8Array, algorithm:String }
  * @param {Key|Array<Key>} [options.publicKeys] - Array of public keys or single key, to verify signatures
- * @param {Boolean} [options.enforceSigned=false] - If true, data decryption fails if message signatures are missing or invalid
+ * @param {Boolean} [options.expectSigned=false] - If true, data decryption fails if message signatures are missing or invalid
  * @param {'utf8'|'binary'} [options.format='utf8'] - Whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines.
  * @param {Signature} [options.signature] - Detached signature for verification
  * @param {Date} [options.date=current date] - Use the given date for verification instead of the current time
@@ -298,7 +298,7 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @async
  * @static
  */
-export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, enforceSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
+export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
 
@@ -312,7 +312,7 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
     result.data = format === 'binary' ? decrypted.getLiteralData() : decrypted.getText();
     result.filename = decrypted.getFilename();
     linkStreams(result, message);
-    if (enforceSigned) {
+    if (expectSigned) {
       if (publicKeys.length === 0) {
         throw new Error('public keys are required to verify message signatures');
       }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -314,17 +314,16 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
     linkStreams(result, message);
     if (expectSigned) {
       if (publicKeys.length === 0) {
-        throw new Error('public keys are required to verify message signatures');
+        throw new Error('Public keys are required to verify message signatures');
       }
       if (result.signatures.length === 0) {
-        throw new Error('message is not signed');
+        throw new Error('Message is not signed');
       }
       result.data = stream.concat([
         result.data,
-        stream.fromAsync(() => util.anyPromise(
-          result.signatures.map(sig => sig.verified)
-        ).then(() => {}) // append nothing to the data
-          .catch(() => { throw new Error('invalid message signature'); }))
+        stream.fromAsync(async () => {
+          await util.anyPromise(result.signatures.map(sig => sig.verified));
+        })
       ]);
     }
     result.data = await convertStream(result.data, message.fromStream, format);

--- a/src/util.js
+++ b/src/util.js
@@ -564,27 +564,25 @@ const util = {
   },
 
   /**
-   * Given an array of promises, call Promise.any if available, otherwise
-   * resolve the promises sequentially and return the first fulfilled one
-   * (this second case is deterministic and it does not necessarily return the fastest fulfilled promise)
+   * Return a Promise that will resolve as soon as one of the promises in input resolves
+   * or will reject if all input promises all rejected
+   * (similar to Promise.any, but with slightly different error handling)
    * @param {Array<Promise>} promises
-   * @returns {Any} return value of one fullfilled promise
-   * @throws if all promises are rejected
-   * @async
+   * @return {Promise<Any>} Promise resolving to the result of the fastest fulfilled promise
+   *                          or rejected with the Error of the last resolved Promise (if all promises are rejected)
    */
-  anyPromise: async function(promises) {
-    if (Promise.any) return Promise.any(promises);
-
-    let exception;
-    for (const promise of promises) {
-      try {
-        const result = await promise;
-        return result;
-      } catch (e) {
-        exception = e;
-      }
-    }
-    throw exception;
+  anyPromise: function(promises) {
+    return new Promise(async (resolve, reject) => {
+      let exception;
+      await Promise.all(promises.map(async promise => {
+        try {
+          resolve(await promise);
+        } catch (e) {
+          exception = e;
+        }
+      }));
+      reject(exception);
+    });
   }
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -561,6 +561,19 @@ const util = {
       map[PacketClass.tag] = PacketClass;
     });
     return map;
+  },
+
+  promiseAny: async function(promises) {
+    let exception;
+    for (const promise of promises) {
+      try {
+        const result = await promise;
+        return result;
+      } catch (e) {
+        exception = e;
+      }
+    }
+    throw exception;
   }
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -563,7 +563,18 @@ const util = {
     return map;
   },
 
+  /**
+   * Given an array of promises, call Promise.any if available, otherwise
+   * resolve the promises sequentially and return the first fulfilled one
+   * (this second case is deterministic and it does not necessarily return the fastest fulfilled promise)
+   * @param {Array<Promise>} promises
+   * @returns {Any} return value of one fullfilled promise
+   * @throws if all promises are rejected
+   * @async
+   */
   promiseAny: async function(promises) {
+    if (Promise.any) return Promise.any(promises);
+
     let exception;
     for (const promise of promises) {
       try {

--- a/src/util.js
+++ b/src/util.js
@@ -572,7 +572,7 @@ const util = {
    * @throws if all promises are rejected
    * @async
    */
-  promiseAny: async function(promises) {
+  anyPromise: async function(promises) {
     if (Promise.any) return Promise.any(promises);
 
     let exception;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -965,7 +965,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         privateKeys: privateKey,
         publicKeys: publicKey,
-        enforceSigned: true
+        expectSigned: true
       });
       expect(data).to.equal(plaintext);
       expect(signatures[0].valid).to.be.true;
@@ -984,7 +984,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         privateKeys: privateKey,
-        enforceSigned: true
+        expectSigned: true
       })).to.be.eventually.rejectedWith(/public keys are required/);
     });
 
@@ -1001,7 +1001,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         privateKeys: privateKey,
         publicKeys: publicKey,
-        enforceSigned: true
+        expectSigned: true
       })).to.be.eventually.rejectedWith(/message is not signed/);
     });
 
@@ -1020,7 +1020,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         privateKeys: privateKey,
         publicKeys: wrongPublicKey,
-        enforceSigned: true
+        expectSigned: true
       })).to.be.eventually.rejectedWith(/invalid message signature/);
     });
 
@@ -1038,7 +1038,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: publicKey,
-        enforceSigned: true
+        expectSigned: true
       });
       const data = await openpgp.stream.readToEnd(streamedData);
       expect(data).to.equal(plaintext);
@@ -1058,7 +1058,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         privateKeys: privateKey,
-        enforceSigned: true
+        expectSigned: true
       })).to.be.eventually.rejectedWith(/public keys are required/);
     });
 
@@ -1075,7 +1075,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: publicKey,
-        enforceSigned: true
+        expectSigned: true
       })).to.be.eventually.rejectedWith(/message is not signed/);
     });
 
@@ -1094,7 +1094,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: wrongPublicKey,
-        enforceSigned: true
+        expectSigned: true
       });
       await expect(
         openpgp.stream.readToEnd(streamedData)
@@ -1595,7 +1595,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const decOpt = {
             privateKeys: privateKey,
             publicKeys: publicKey,
-            enforceSigned: true
+            expectSigned: true
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -985,7 +985,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         privateKeys: privateKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/public keys are required/);
+      })).to.be.eventually.rejectedWith(/Public keys are required/);
     });
 
     it('decrypt/verify should throw on missing signature (expectSigned=true)', async function () {
@@ -1002,7 +1002,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKeys: privateKey,
         publicKeys: publicKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/message is not signed/);
+      })).to.be.eventually.rejectedWith(/Message is not signed/);
     });
 
     it('decrypt/verify should throw on invalid signature (expectSigned=true)', async function () {
@@ -1021,7 +1021,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKeys: privateKey,
         publicKeys: wrongPublicKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/invalid message signature/);
+      })).to.be.eventually.rejectedWith(/Could not find signing key/);
     });
 
     it('decrypt/verify should succeed with valid signature (expectSigned=true, with streaming)', async function () {
@@ -1059,7 +1059,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         privateKeys: privateKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/public keys are required/);
+      })).to.be.eventually.rejectedWith(/Public keys are required/);
     });
 
     it('decrypt/verify should throw on missing signature (expectSigned=true, with streaming)', async function () {
@@ -1076,7 +1076,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKeys: privateKey,
         publicKeys: publicKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/message is not signed/);
+      })).to.be.eventually.rejectedWith(/Message is not signed/);
     });
 
     it('decrypt/verify should throw on invalid signature (expectSigned=true, with streaming)', async function () {
@@ -1098,7 +1098,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       });
       await expect(
         openpgp.stream.readToEnd(streamedData)
-      ).to.be.eventually.rejectedWith(/invalid message signature/);
+      ).to.be.eventually.rejectedWith(/Could not find signing key/);
     });
   });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -951,7 +951,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       openpgp.config.minRSABits = minRSABitsVal;
     });
 
-    it('enforce signed - decrypt/verify should succeed with valid signature', async function () {
+    it('decrypt/verify should succeed with valid signature  (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -971,7 +971,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       expect(signatures[0].valid).to.be.true;
     });
 
-    it('enforce signed - decrypt/verify should throw on missing public keys', async function () {
+    it('decrypt/verify should throw on missing public keys (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -988,7 +988,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       })).to.be.eventually.rejectedWith(/public keys are required/);
     });
 
-    it('enforce signed - decrypt/verify should throw on missing signature', async function () {
+    it('decrypt/verify should throw on missing signature (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -1005,7 +1005,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       })).to.be.eventually.rejectedWith(/message is not signed/);
     });
 
-    it('enforce signed - decrypt/verify should throw on invalid signature', async function () {
+    it('decrypt/verify should throw on invalid signature (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
@@ -1024,7 +1024,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       })).to.be.eventually.rejectedWith(/invalid message signature/);
     });
 
-    it('enforce signed - decrypt/verify should succeed with valid signature (with streaming)', async function () {
+    it('decrypt/verify should succeed with valid signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -1045,7 +1045,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       expect(await signatures[0].verified).to.be.true;
     });
 
-    it('enforce signed - decrypt/verify should throw on missing public keys (with streaming)', async function () {
+    it('decrypt/verify should throw on missing public keys (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -1062,7 +1062,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       })).to.be.eventually.rejectedWith(/public keys are required/);
     });
 
-    it('enforce signed - decrypt/verify should throw on missing signature (with streaming)', async function () {
+    it('decrypt/verify should throw on missing signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       await privateKey.decrypt(passphrase);
@@ -1079,7 +1079,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       })).to.be.eventually.rejectedWith(/message is not signed/);
     });
 
-    it('enforce signed - decrypt/verify should throw on invalid signature (with streaming)', async function () {
+    it('decrypt/verify should throw on invalid signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
@@ -1586,7 +1586,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           });
         });
 
-        it('should encrypt/sign and decrypt/verify (enforce signed)', async function () {
+        it('should encrypt/sign and decrypt/verify (expectSigned=true)', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
             publicKeys: publicKey,


### PR DESCRIPTION
Fix #1274 , changes: 
- add `expectSigned` option to `openpgp,decrypt` and `openpgp.verify` (defaulting to false)
- if `expectSigned = true`:
  - `openpgp.decrypt` throws immediately if public keys or signatures are missing, or if the decrypted data is not streamed & signatures are invalid
  - `openpgp.verify` throws immediately if signatures are missing, or if the decrypted data is not streamed & signatures are invalid
  - if the data is streamed, and signatures are invalid, reading the data stream will eventually throw
