### PR TITLE
Fixed createMessage return type

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -146,8 +146,8 @@ export class CleartextMessage {
 export function readMessage<T extends MaybeStream<string>>(options: { armoredMessage: T, config?: PartialConfig }): Promise<Message<T>>;
 export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binaryMessage: T, config?: PartialConfig }): Promise<Message<T>>;
 
-export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Message<T>;
-export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Message<T>;
+export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
+export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 
 export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, armor: false }): Promise<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :


### PR DESCRIPTION
The `createMessage` function is async (see [`message.js:838`](https://github.com/openpgpjs/openpgpjs/blob/eb496d2018f8f6a8957a5022f1fd3b606aa39c7a/src/message.js)), so its type definition should return a `Promise`

