### PR TITLE
Properly encode length of key material in v5 keys

### DIFF
--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -205,17 +205,17 @@ class SecretKeyPacket extends PublicKeyPacket {
     if (!this.isDummy()) {
       if (!this.s2kUsage) {
         const algo = enums.write(enums.publicKey, this.algorithm);
-        const cleartextParams = crypto.serializeParams(algo, this.privateParams);
-        this.keyMaterial = util.concatUint8Array([
-          cleartextParams,
-          util.writeChecksum(cleartextParams)
-        ]);
+        this.keyMaterial = crypto.serializeParams(algo, this.privateParams);
       }
 
       if (this.version === 5) {
         arr.push(util.writeNumber(this.keyMaterial.length, 4));
       }
       arr.push(this.keyMaterial);
+
+      if (!this.s2kUsage) {
+        arr.push(util.writeChecksum(this.keyMaterial));
+      }
     }
 
     return util.concatUint8Array(arr);

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -858,6 +858,35 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
     expect(secretKeyPacket2.publicParams).to.deep.equal(secretKeyPacket.publicParams);
   });
 
+  it('Writing of unencrypted secret key packet', async function() {
+    openpgp.config.v5Keys = true;
+    const packet = new openpgp.SecretKeyPacket();
+
+    packet.privateParams = { key: new Uint8Array([1, 2, 3]) };
+    packet.publicParams = { pubKey: new Uint8Array([4, 5, 6]) };
+    packet.algorithm = "rsaSign";
+    packet.isEncrypted = false;
+    packet.s2kUsage = 0;
+
+    const written = packet.write();
+    expect(written.length).to.equal(28);
+
+    /* The serialized length of private data */
+    expect(written[17]).to.equal(0);
+    expect(written[18]).to.equal(0);
+    expect(written[19]).to.equal(0);
+    expect(written[20]).to.equal(5);
+
+    /**
+     * The private data
+     *
+     * The 2 bytes missing here are the length prefix of the MPI
+     */
+    expect(written[23]).to.equal(1);
+    expect(written[24]).to.equal(2);
+    expect(written[25]).to.equal(3);
+  });
+
   it('Writing and encryption of a secret key packet (CFB)', async function() {
     const rsa = openpgp.enums.publicKey.rsaEncryptSign;
     const { privateParams, publicParams } = await crypto.generateParams(rsa, 1024, 65537);

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -859,32 +859,38 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
   });
 
   it('Writing of unencrypted v5 secret key packet', async function() {
+    const originalV5KeysSetting = openpgp.config.v5Keys;
     openpgp.config.v5Keys = true;
-    const packet = new openpgp.SecretKeyPacket();
 
-    packet.privateParams = { key: new Uint8Array([1, 2, 3]) };
-    packet.publicParams = { pubKey: new Uint8Array([4, 5, 6]) };
-    packet.algorithm = "rsaSign";
-    packet.isEncrypted = false;
-    packet.s2kUsage = 0;
+    try {
+      const packet = new openpgp.SecretKeyPacket();
 
-    const written = packet.write();
-    expect(written.length).to.equal(28);
+      packet.privateParams = { key: new Uint8Array([1, 2, 3]) };
+      packet.publicParams = { pubKey: new Uint8Array([4, 5, 6]) };
+      packet.algorithm = "rsaSign";
+      packet.isEncrypted = false;
+      packet.s2kUsage = 0;
 
-    /* The serialized length of private data */
-    expect(written[17]).to.equal(0);
-    expect(written[18]).to.equal(0);
-    expect(written[19]).to.equal(0);
-    expect(written[20]).to.equal(5);
+      const written = packet.write();
+      expect(written.length).to.equal(28);
 
-    /**
-     * The private data
-     *
-     * The 2 bytes missing here are the length prefix of the MPI
-     */
-    expect(written[23]).to.equal(1);
-    expect(written[24]).to.equal(2);
-    expect(written[25]).to.equal(3);
+      /* The serialized length of private data */
+      expect(written[17]).to.equal(0);
+      expect(written[18]).to.equal(0);
+      expect(written[19]).to.equal(0);
+      expect(written[20]).to.equal(5);
+
+      /**
+       * The private data
+       *
+       * The 2 bytes missing here are the length prefix of the MPI
+       */
+      expect(written[23]).to.equal(1);
+      expect(written[24]).to.equal(2);
+      expect(written[25]).to.equal(3);
+    } finally {
+      openpgp.config.v5Keys = originalV5KeysSetting;
+    }
   });
 
   it('Writing and encryption of a secret key packet (CFB)', async function() {

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -858,7 +858,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
     expect(secretKeyPacket2.publicParams).to.deep.equal(secretKeyPacket.publicParams);
   });
 
-  it('Writing of unencrypted secret key packet', async function() {
+  it('Writing of unencrypted v5 secret key packet', async function() {
     openpgp.config.v5Keys = true;
     const packet = new openpgp.SecretKeyPacket();
 


### PR DESCRIPTION
When private keys are serialized unencrypted, a 2-byte checksum is
appended after the actual key material. According to spec, these 2
bytes are not included in the length of the key material. The openpgpjs
implementation, however, erroneously includes them.

Since version 5 packets contain this length, which is used when they
are parsed, correct implementation of the specification will not accept
secret keys from openpgpjs, when they are serialized using version 5
packets.

To fix this, calculate the length of the key material before appending
the checksum

Fixes #1155