### PR TITLE
Remove `Key.prototype.encrypt()` and `Key.prototype.decrypt()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ const openpgp = require('openpgp'); // use as CommonJS, AMD, ES6 module or via w
 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: 'Hello, World!' }), // input as Message object
@@ -255,8 +257,10 @@ Encrypt to multiple public keys:
 
     const publicKeys = await Promise.all(publicKeysArmored.map(armoredKey => openpgp.readKey({ armoredKey })));
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase)
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const message = await openpgp.createMessage({ text: message });
     const encrypted = await openpgp.encrypt({
@@ -282,8 +286,10 @@ If you expect an encrypted message to be signed with one of the public keys you 
 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const encryptedAndSignedMessage = `-----BEGIN PGP MESSAGE-----
 ...
@@ -386,8 +392,10 @@ its [Reader class](https://openpgpjs.org/web-stream-tools/Reader.html).
 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const readableStream = new openpgp.stream.ReadableStream({
         start(controller) {
@@ -490,8 +498,10 @@ Using the private key:
 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const unsignedMessage = await openpgp.createCleartextMessage({ text: 'Hello, World!' });
     const cleartextMessage = await openpgp.sign({
@@ -530,8 +540,10 @@ Using the private key:
 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const cleartextMessage = await openpgp.createCleartextMessage({ text: 'Hello, World!' });
     const detachedSignature = await openpgp.sign({
@@ -577,8 +589,10 @@ Using the private key:
 -----END PGP PRIVATE KEY BLOCK-----`; // encrypted private key
     const passphrase = `yourPassphrase`; // what the private key is encrypted with
 
-    const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-    await privateKey.decrypt(passphrase);
+    const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        passphrase
+    });
 
     const message = await openpgp.createMessage({ binary: readableStream }); // or createMessage({ text: ReadableStream<String> })
     const signatureArmored = await openpgp.sign({

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -28,8 +28,6 @@ export class Key {
   private keyPacket: PublicKeyPacket | SecretKeyPacket;
   public write(): Uint8Array;
   public armor(config?: Config): string;
-  public decrypt(passphrase: string | string[], keyID?: KeyID, config?: Config): Promise<void>; // throws on error
-  public encrypt(passphrase: string | string[], keyID?: KeyID, config?: Config): Promise<void>; // throws on error
   public getExpirationTime(capability?: 'encrypt' | 'encrypt_sign' | 'sign', keyID?: KeyID, userID?: UserID, config?: Config): Promise<Date | typeof Infinity | null>; // Returns null if `capabilities` is passed and the key does not have the specified capabilities or is revoked or invalid.
   public getKeyIDs(): KeyID[];
   public getPrimaryUser(date?: Date, userID?: UserID, config?: Config): Promise<PrimaryUser>; // throws on error

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -432,44 +432,6 @@ class Key {
   }
 
   /**
-   * Decrypts all secret key and subkey packets matching keyID
-   * @param {String|Array<String>} passphrases
-   * @param {module:type/keyid~KeyID} keyID
-   * @param {Object} [config] - Full configuration, defaults to openpgp.config
-   * @throws {Error} if any matching key or subkey packets did not decrypt successfully
-   * @async
-   */
-  async decrypt(passphrases, keyID = null, config = defaultConfig) {
-    if (!this.isPrivate()) {
-      throw new Error("Nothing to decrypt in a public key");
-    }
-    passphrases = util.isArray(passphrases) ? passphrases : [passphrases];
-
-    await Promise.all(this.getKeys(keyID).map(async function(key) {
-      let decrypted = false;
-      let error = null;
-      await Promise.all(passphrases.map(async function(passphrase) {
-        try {
-          await key.keyPacket.decrypt(passphrase);
-          // If we are decrypting a single key packet, we also validate it directly
-          if (keyID) await key.keyPacket.validate();
-          decrypted = true;
-        } catch (e) {
-          error = e;
-        }
-      }));
-      if (!decrypted) {
-        throw error;
-      }
-    }));
-
-    if (!keyID) {
-      // The full key should be decrypted and we can validate it all
-      await this.validate(config);
-    }
-  }
-
-  /**
    * Returns true if the primary key or any subkey is decrypted.
    * A dummy key is considered encrypted.
    */

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -432,32 +432,6 @@ class Key {
   }
 
   /**
-   * Encrypts all secret key and subkey packets matching keyID
-   * @param {String|Array<String>} passphrases - If multiple passphrases, then should be in same order as packets each should encrypt
-   * @param {module:type/keyid~KeyID} keyID
-   * @param {Object} [config] - Full configuration, defaults to openpgp.config
-   * @throws {Error} if encryption failed for any key or subkey
-   * @async
-   */
-  async encrypt(passphrases, keyID = null, config = defaultConfig) {
-    if (!this.isPrivate()) {
-      throw new Error("Nothing to encrypt in a public key");
-    }
-
-    const keys = this.getKeys(keyID);
-    passphrases = util.isArray(passphrases) ? passphrases : new Array(keys.length).fill(passphrases);
-    if (passphrases.length !== keys.length) {
-      throw new Error("Invalid number of passphrases for key");
-    }
-
-    await Promise.all(keys.map(async function(key, i) {
-      const { keyPacket } = key;
-      await keyPacket.encrypt(passphrases[i], config);
-      keyPacket.clearPrivateParams();
-    }));
-  }
-
-  /**
    * Decrypts all secret key and subkey packets matching keyID
    * @param {String|Array<String>} passphrases
    * @param {module:type/keyid~KeyID} keyID

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -312,10 +312,11 @@ class SecretKeyPacket extends PublicKeyPacket {
 
   /**
    * Decrypts the private key params which are needed to use the key.
+   * Successful decryption does not imply key integrity, call validate() to confirm that.
    * {@link SecretKeyPacket.isDecrypted} should be false, as
    * otherwise calls to this function will throw an error.
    * @param {String} passphrase - The passphrase for this private key as string
-   * @throws {Error} if decryption was not successful
+   * @throws {Error} if the key is already decrypted, or if decryption was not successful
    * @async
    */
   async decrypt(passphrase) {

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -182,10 +182,12 @@ EJ4QcD/oQ6x1M/8X/iKQCtxZP8RnlrbH7ExkNON5s5g=
     if (data[name].priv_key) {
       return data[name].priv_key;
     }
-    const pk = await openpgp.readKey({ armoredKey: data[name].priv });
+    const pk = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: data[name].priv }),
+      passphrase: data[name].pass
+    });
     expect(pk).to.exist;
     expect(pk.getKeyID().toHex()).to.equal(data[name].id);
-    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -150,10 +150,12 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     if (data[name].priv_key) {
       return data[name].priv_key;
     }
-    const pk = await openpgp.readKey({ armoredKey: data[name].priv });
+    const pk = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: data[name].priv }),
+      passphrase: data[name].pass
+    });
     expect(pk).to.exist;
     expect(pk.getKeyID().toHex()).to.equal(data[name].id);
-    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2340,9 +2340,8 @@ function versionSpecificTests() {
 
   it('Reformat key - one signing subkey', function() {
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: [userID], passphrase: '123', subkeys:[{}, { sign: true }] };
+    const opt = { userIDs: [userID], subkeys:[{}, { sign: true }] };
     return openpgp.generateKey(opt).then(async function({ key }) {
-      await key.decrypt('123');
       return openpgp.reformatKey({ privateKey: key, userIDs: [userID] });
     }).then(async function({ privateKeyArmored }) {
       const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
@@ -2426,8 +2425,10 @@ function versionSpecificTests() {
 
   it('Sign and verify key - primary user', async function() {
     let publicKey = await openpgp.readKey({ armoredKey: pub_sig_test });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
 
     const { minRSABits } = openpgp.config;
     openpgp.config.minRSABits = 1024;
@@ -2448,9 +2449,11 @@ function versionSpecificTests() {
 
   it('Sign key and verify with wrong key - primary user', async function() {
     let publicKey = await openpgp.readKey({ armoredKey: pub_sig_test });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
     const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
-    await privateKey.decrypt('hello world');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
 
     const { minRSABits } = openpgp.config;
     openpgp.config.minRSABits = 1024;
@@ -2471,8 +2474,10 @@ function versionSpecificTests() {
 
   it('Sign and verify key - all users', async function() {
     let publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
 
     const { minRSABits } = openpgp.config;
     openpgp.config.minRSABits = 1024;
@@ -2501,9 +2506,11 @@ function versionSpecificTests() {
 
   it('Sign key and verify with wrong key - all users', async function() {
     let publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     const wrongKey = await openpgp.readKey({ armoredKey: wrong_key });
-    await privateKey.decrypt('hello world');
 
     const { minRSABits } = openpgp.config;
     openpgp.config.minRSABits = 1024;
@@ -2611,18 +2618,15 @@ function versionSpecificTests() {
     const userID2 = { name: 'test2', email: 'b@c.com' };
     const userID3 = { name: 'test3', email: 'c@d.com' };
     const opt = { userIDs: userID1 };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
-      opt.privateKey = key;
-      opt.userIDs = [userID2, userID3];
-      opt.passphrase = '123';
-      return openpgp.reformatKey(opt).then(async function(newKey) {
-        newKey = newKey.key;
-        expect(newKey.users.length).to.equal(2);
-        expect(newKey.users[0].userID.userID).to.equal('test2 <b@c.com>');
-        expect(newKey.isDecrypted()).to.be.false;
-        await newKey.decrypt('123');
-        expect(newKey.isDecrypted()).to.be.true;
+    return openpgp.generateKey(opt).then(function ({ key }) {
+      const passphrase = '123';
+      const reformatOpt = { privateKey: key, userIDs: [userID2, userID3], passphrase };
+      return openpgp.reformatKey(reformatOpt).then(async ({ key: refKey }) => {
+        expect(refKey.users.length).to.equal(2);
+        expect(refKey.users[0].userID.userID).to.equal('test2 <b@c.com>');
+        expect(refKey.isDecrypted()).to.be.false;
+        const decryptedKey = await openpgp.decryptKey({ privateKey: refKey, passphrase });
+        expect(decryptedKey.isDecrypted()).to.be.true;
       });
     });
   });
@@ -2671,9 +2675,8 @@ function versionSpecificTests() {
   });
 
   it('Revoke generated key with private key', function() {
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234' };
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' } };
     return openpgp.generateKey(opt).then(async function(original) {
-      await original.key.decrypt('1234');
       return openpgp.revokeKey({ key: original.key, reasonForRevocation: { string: 'Testing key revocation' } }).then(async function(revKey) {
         revKey = revKey.publicKey;
         expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
@@ -2933,15 +2936,9 @@ module.exports = () => describe('Key', function() {
     expect(encryptExpirationTime).to.equal(Infinity);
   });
 
-  it("decrypt() - throw if key parameters don't correspond", async function() {
-    const key = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
-    await expect(key.decrypt('userpass')).to.be.rejectedWith('Key is invalid');
-  });
-
-  it("decrypt(keyID) - throw if key parameters don't correspond", async function() {
-    const key = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
-    const subKeyID = key.subKeys[0].getKeyID();
-    await expect(key.decrypt('userpass', subKeyID)).to.be.rejectedWith('Key is invalid');
+  it("decryptKey() - throw if key parameters don't correspond", async function() {
+    const privateKey = await openpgp.readKey({ armoredKey: mismatchingKeyParams });
+    await expect(openpgp.decryptKey({ privateKey, passphrase: 'userpass' })).to.be.rejectedWith('Key is invalid');
   });
 
   it("validate() - don't throw if key parameters correspond", async function() {
@@ -2973,7 +2970,7 @@ module.exports = () => describe('Key', function() {
     const passphrase = '12345678';
     const { key } = await openpgp.generateKey({ userIDs: {}, curve: 'ed25519', passphrase });
     expect(key.isDecrypted()).to.be.false;
-    await key.decrypt(passphrase, key.subKeys[0].getKeyID());
+    await key.subKeys[0].keyPacket.decrypt(passphrase);
     expect(key.isDecrypted()).to.be.true;
   });
 
@@ -3008,8 +3005,10 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - the converted key is valid but can no longer sign', async function() {
-    const parsedKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    const key = await openpgp.decryptKey({ privateKey: parsedKey, passphrase: 'hello world' });
+    const key = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     expect(key.primaryKey.isDummy()).to.be.false;
     key.primaryKey.makeDummy();
     expect(key.primaryKey.isDummy()).to.be.true;
@@ -3018,8 +3017,10 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - subkeys of the converted key can still sign', async function() {
-    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await key.decrypt('hello world');
+    const key = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     expect(key.primaryKey.isDummy()).to.be.false;
     key.primaryKey.makeDummy();
     expect(key.primaryKey.isDummy()).to.be.true;
@@ -3047,15 +3048,19 @@ module.exports = () => describe('Key', function() {
   });
 
   it('clearPrivateParams() - check that private key can no longer be used', async function() {
-    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await key.decrypt('hello world');
+    const key = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     await key.clearPrivateParams();
     await expect(key.validate()).to.be.rejectedWith('Key is not decrypted');
   });
 
   it('clearPrivateParams() - detect that private key parameters were removed', async function() {
-    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await key.decrypt('hello world');
+    const key = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     const signingKeyPacket = key.subKeys[0].keyPacket;
     const privateParams = signingKeyPacket.privateParams;
     await key.clearPrivateParams();
@@ -3067,8 +3072,10 @@ module.exports = () => describe('Key', function() {
   });
 
   it('clearPrivateParams() - detect that private key parameters were zeroed out', async function() {
-    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await key.decrypt('hello world');
+    const key = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     const signingKeyPacket = key.subKeys[0].keyPacket;
     const privateParams = {};
     Object.entries(signingKeyPacket.privateParams).forEach(([name, value]) => {
@@ -3228,8 +3235,10 @@ module.exports = () => describe('Key', function() {
   });
 
   it('revoke() - primary key', async function() {
-    const privKey = await openpgp.readKey({ armoredKey: priv_key_arm2 });
-    await privKey.decrypt('hello world');
+    const privKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
+      passphrase: 'hello world'
+    });
 
     await privKey.revoke({
       flag: openpgp.enums.reasonForRevocation.keyRetired,
@@ -3247,8 +3256,10 @@ module.exports = () => describe('Key', function() {
 
   it('revoke() - subkey', async function() {
     const pubKey = await openpgp.readKey({ armoredKey: pub_key_arm2 });
-    const privKey = await openpgp.readKey({ armoredKey: priv_key_arm2 });
-    await privKey.decrypt('hello world');
+    const privKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
+      passphrase: 'hello world'
+    });
 
     const subKey = pubKey.subKeys[0];
     await subKey.revoke(privKey.primaryKey, {
@@ -3400,8 +3411,6 @@ VYGdb3eNlV8CfoEC
 
   it('Generate session key - latest created user', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
     // Set second user to prefer aes128. We should select this user by default, since it was created later.
     publicKey.users[1].selfCertifications[0].preferredSymmetricAlgorithms = [openpgp.enums.symmetric.aes128];
     const sessionKey = await openpgp.generateSessionKey({ publicKeys: publicKey });
@@ -3410,8 +3419,6 @@ VYGdb3eNlV8CfoEC
 
   it('Generate session key - primary user', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
     // Set first user to primary. We should select this user by default.
     publicKey.users[0].selfCertifications[0].isPrimaryUserID = true;
     // Set first user to prefer aes128.
@@ -3422,8 +3429,10 @@ VYGdb3eNlV8CfoEC
 
   it('Generate session key - specific user', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     // Set first user to primary. We won't select this user, this is to test that.
     publicKey.users[0].selfCertifications[0].isPrimaryUserID = true;
     // Set second user to prefer aes128. We will select this user.
@@ -3442,15 +3451,19 @@ VYGdb3eNlV8CfoEC
   it('Fails to encrypt to User ID-less key', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: uidlessKey });
     expect(publicKey.users.length).to.equal(0);
-    const privateKey = await openpgp.readKey({ armoredKey: uidlessKey });
-    await privateKey.decrypt('correct horse battery staple');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: uidlessKey }),
+      passphrase: 'correct horse battery staple'
+    });
     await expect(openpgp.encrypt({ message: await openpgp.createMessage({ text: 'hello' }), publicKeys: publicKey, privateKeys: privateKey, armor: false })).to.be.rejectedWith('Could not find primary user');
   });
 
   it('Sign - specific user', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: multi_uid_key });
-    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-    await privateKey.decrypt('hello world');
+    const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+      passphrase: 'hello world'
+    });
     const privateKeyClone = await openpgp.readKey({ armoredKey: priv_key_rsa });
     // Duplicate user
     privateKey.users.push(privateKeyClone.users[0]);
@@ -3571,8 +3584,10 @@ VYGdb3eNlV8CfoEC
     });
 
     it('create and add a new rsa subkey to stored rsa key', async function() {
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      await privateKey.decrypt('hello world');
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey(rsaOpt);
       const armoredKey = newPrivateKey.armor();
@@ -3617,15 +3632,19 @@ VYGdb3eNlV8CfoEC
     });
 
     it('should throw when trying to encrypt a subkey separately from key', async function() {
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      await privateKey.decrypt('hello world');
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const opt = { rsaBits: rsaBits, passphrase: 'subkey passphrase' };
       await expect(privateKey.addSubkey(opt)).to.be.rejectedWith('Subkey could not be encrypted here, please encrypt whole key');
     });
 
     it('encrypt and decrypt key with added subkey', async function() {
-      const parsedKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      const privateKey = await openpgp.decryptKey({ privateKey: parsedKey, passphrase: 'hello world' });
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const total = privateKey.subKeys.length;
 
       const passphrase = '12345678';
@@ -3634,8 +3653,10 @@ VYGdb3eNlV8CfoEC
       expect(encNewPrivateKey.subKeys.length).to.be.equal(total + 1);
 
       const armoredKey = encNewPrivateKey.armor();
-      const importedParsedKey = await openpgp.readKey({ armoredKey });
-      const importedPrivateKey = await openpgp.decryptKey({ privateKey: importedParsedKey, passphrase });
+      const importedPrivateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey }),
+        passphrase
+      });
       const subKey = importedPrivateKey.subKeys[total];
       expect(subKey).to.exist;
       expect(importedPrivateKey.subKeys.length).to.be.equal(total + 1);
@@ -3687,8 +3708,10 @@ VYGdb3eNlV8CfoEC
     });
 
     it('create and add a new ecc subkey to a rsa key', async function() {
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      await privateKey.decrypt('hello world');
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const total = privateKey.subKeys.length;
       const opt2 = { type: 'ecc', curve: 'curve25519' };
       let newPrivateKey = await privateKey.addSubkey(opt2);
@@ -3782,8 +3805,10 @@ VYGdb3eNlV8CfoEC
     });
 
     it('sign/verify data with the new subkey correctly using rsa', async function() {
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      await privateKey.decrypt('hello world');
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const total = privateKey.subKeys.length;
       const opt2 = { sign: true, rsaBits: rsaBits };
       let newPrivateKey = await privateKey.addSubkey(opt2);
@@ -3803,8 +3828,10 @@ VYGdb3eNlV8CfoEC
     });
 
     it('encrypt/decrypt data with the new subkey correctly using rsa', async function() {
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
-      await privateKey.decrypt('hello world');
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
       const total = privateKey.subKeys.length;
       let newPrivateKey = await privateKey.addSubkey(rsaOpt);
       const armoredKey = newPrivateKey.armor();

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -795,6 +795,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         expect(newKey.publicKeyArmored).to.exist;
       });
     });
+
+    it('should throw if missing userIDs', async function() {
+      expect(() => openpgp.generateKey({})).to.throw(/UserIDs are required/);
+    });
   });
 
   describe('generateKey - integration tests', function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -363,7 +363,7 @@ bpOWdMhJ6Hy+JzGNY1qNXcHJPw==
 =99Fs
 -----END PGP MESSAGE-----`;
 
-const ecdh_dec_key_2 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+const ecdh_dec_key2 = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 Version: OpenPGP.js v4.4.9
 Comment: https://openpgpjs.org
 
@@ -835,6 +835,25 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       });
     });
 
+    it('should work with multiple passphrases', async function() {
+      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
+      const originalKey = await openpgp.readKey({ armoredKey: privateKey.armor() });
+      return openpgp.decryptKey({
+        privateKey: privateKey,
+        passphrase: ['rubbish', passphrase]
+      }).then(function(unlocked){
+        expect(unlocked.getKeyID().toHex()).to.equal(privateKey.getKeyID().toHex());
+        expect(unlocked.subKeys[0].getKeyID().toHex()).to.equal(privateKey.subKeys[0].getKeyID().toHex());
+        expect(unlocked.isDecrypted()).to.be.true;
+        expect(unlocked.keyPacket.privateParams).to.not.be.null;
+        // original key should be unchanged
+        expect(privateKey.isDecrypted()).to.be.false;
+        expect(privateKey.keyPacket.privateParams).to.be.null;
+        originalKey.subKeys[0].getKeyID(); // fill in keyID
+        expect(privateKey).to.deep.equal(originalKey);
+      });
+    });
+
     it('should fail for incorrect passphrase', async function() {
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       const originalKey = await openpgp.readKey({ armoredKey: privateKey.armor() });
@@ -957,8 +976,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should succeed with valid signature  (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -977,8 +998,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on missing public keys (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -994,8 +1017,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on missing signature (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1011,9 +1036,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on invalid signature (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1030,8 +1057,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should succeed with valid signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1051,8 +1080,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on missing public keys (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1068,8 +1099,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on missing signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1085,9 +1118,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
     it('decrypt/verify should throw on invalid signature (expectSigned=true, with streaming)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-      const privateKey = await openpgp.readKey({ armoredKey: priv_key });
       const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
-      await privateKey.decrypt(passphrase);
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase
+      });
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
@@ -1137,8 +1172,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       it('verify should succeed with valid signature (expectSigned=true)', async function () {
         const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-        await privateKey.decrypt(passphrase);
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+          passphrase
+        });
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
@@ -1155,8 +1192,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       it('verify should throw on missing signature (expectSigned=true)', async function () {
         const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-        await privateKey.decrypt(passphrase);
 
         await expect(openpgp.verify({
           message: await createMessage({ text }),
@@ -1166,9 +1201,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       });
 
       it('verify should throw on invalid signature (expectSigned=true)', async function () {
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
         const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
-        await privateKey.decrypt(passphrase);
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+          passphrase
+        });
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
@@ -1185,8 +1222,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         if (useCleartext) this.skip(); // eslint-disable-line no-invalid-this
 
         const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-        await privateKey.decrypt(passphrase);
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+          passphrase
+        });
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
@@ -1206,8 +1245,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         if (useCleartext) this.skip(); // eslint-disable-line no-invalid-this
 
         const publicKey = await openpgp.readKey({ armoredKey: pub_key });
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
-        await privateKey.decrypt(passphrase);
 
         await expect(openpgp.verify({
           message: await createMessage({ text: openpgp.stream.toStream(text) }),
@@ -1219,9 +1256,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       it('verify should throw on invalid signature (expectSigned=true, with streaming)', async function () {
         if (useCleartext) this.skip(); // eslint-disable-line no-invalid-this
 
-        const privateKey = await openpgp.readKey({ armoredKey: priv_key });
         const wrongPublicKey = (await openpgp.readKey({ armoredKey: priv_key_2000_2008 })).toPublic();
-        await privateKey.decrypt(passphrase);
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+          passphrase
+        });
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
@@ -1308,14 +1347,17 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       }
     });
 
-    it('Decrypting key with wrong passphrase rejected', async function () {
-      await expect(privateKey.decrypt('wrong passphrase')).to.eventually.be.rejectedWith('Incorrect key passphrase');
+    it('Decrypting key with wrong passphrase should be rejected', async function () {
+      await expect(openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+        passphrase: 'wrong passphrase'
+      })).to.eventually.be.rejectedWith('Incorrect key passphrase');
     });
 
     it('Can decrypt key with correct passphrase', async function () {
       expect(privateKey.isDecrypted()).to.be.false;
-      await privateKey.decrypt(passphrase);
-      expect(privateKey.isDecrypted()).to.be.true;
+      const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase });
+      expect(decryptedKey.isDecrypted()).to.be.true;
     });
 
     it('Calling decrypt with not decrypted key leads to exception', async function() {
@@ -1382,11 +1424,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       describe('encryptSessionKey, decryptSessionKeys', function() {
         const sk = new Uint8Array([0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01]);
 
-        let decryptedPrivateKey;
+        let decryptedPrivateKey; // to avoid decrypting key before each test
         beforeEach(async function() {
           if (!decryptedPrivateKey) {
-            await privateKey.decrypt(passphrase);
-            decryptedPrivateKey = privateKey;
+            decryptedPrivateKey = await openpgp.decryptKey({ privateKey, passphrase });
           }
           privateKey = decryptedPrivateKey;
         });
@@ -1542,11 +1583,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           '=6XMW\r\n' +
           '-----END PGP PUBLIC KEY BLOCK-----\r\n\r\n';
 
-        let decryptedPrivateKey;
+        let decryptedPrivateKey; // to avoid decrypting key before each test
         beforeEach(async function() {
           if (!decryptedPrivateKey) {
-            await privateKey.decrypt(passphrase);
-            decryptedPrivateKey = privateKey;
+            decryptedPrivateKey = await openpgp.decryptKey({ privateKey, passphrase });
           }
           privateKey = decryptedPrivateKey;
         });
@@ -1571,8 +1611,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
 
         it('should encrypt then decrypt with multiple private keys', async function () {
-          const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-          await privKeyDE.decrypt(passphrase);
+          const privKeyDE = await openpgp.decryptKey({
+            privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+            passphrase
+          });
 
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
@@ -1613,8 +1655,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
 
         it('should encrypt then decrypt with wildcard with multiple private keys', async function () {
-          const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-          await privKeyDE.decrypt(passphrase);
+          const privKeyDE = await openpgp.decryptKey({
+            privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+            passphrase
+          });
 
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
@@ -1884,8 +1928,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
             const plaintext = "  \t┍ͤ޵၂༫዇◧˘˻ᙑ᎚⏴ំந⛑nٓኵΉⅶ⋋ŵ⋲΂ͽᣏ₅ᄶɼ┋⌔û᬴Ƚᔡᧅ≃ṱἆ⃷݂૿ӌ᰹෇ٹჵ⛇໶⛌  \t\n한국어/조선말";
 
-            const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-            await privKeyDE.decrypt(passphrase);
+            const privKeyDE = await openpgp.decryptKey({
+              privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+              passphrase
+            });
 
             const pubKeyDE = await openpgp.readKey({ armoredKey: pub_key_de });
 
@@ -2059,8 +2105,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           try {
             openpgp.config.rejectPublicKeyAlgorithms = new Set();
 
-            const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-            await privKeyDE.decrypt(passphrase);
+            const privKeyDE = await openpgp.decryptKey({
+              privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+              passphrase
+            });
 
             const pubKeyDE = await openpgp.readKey({ armoredKey: pub_key_de });
 
@@ -2167,8 +2215,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
             openpgp.config.rejectPublicKeyAlgorithms = new Set();
 
             const pubKeyDE = await openpgp.readKey({ armoredKey: pub_key_de });
-            const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-            await privKeyDE.decrypt(passphrase);
+            const privKeyDE = await openpgp.decryptKey({
+              privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+              passphrase
+            });
             pubKeyDE.users[0].selfCertifications[0].features = [7]; // Monkey-patch AEAD feature flag
             await openpgp.encrypt({
               publicKeys: pubKeyDE,
@@ -2249,8 +2299,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         ].join('\n');
 
         it('Decrypt message', async function() {
-          const privKey = await openpgp.readKey({ armoredKey: priv_key });
-          await privKey.decrypt('1234');
+          const privKey = await openpgp.decryptKey({
+            privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+            passphrase: '1234'
+          });
           const message = await openpgp.readMessage({ armoredMessage: pgp_msg });
 
           return openpgp.decrypt({ privateKeys:privKey, message:message }).then(function(decrypted) {
@@ -2403,11 +2455,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         '=6XMW\r\n' +
         '-----END PGP PUBLIC KEY BLOCK-----\r\n\r\n';
 
-      let decryptedPrivateKey;
+      let decryptedPrivateKey; // to avoid decrypting key before each test
       beforeEach(async function() {
         if (!decryptedPrivateKey) {
-          await privateKey.decrypt(passphrase);
-          decryptedPrivateKey = privateKey;
+          decryptedPrivateKey = await openpgp.decryptKey({ privateKey, passphrase });
         }
         privateKey = decryptedPrivateKey;
       });
@@ -2439,8 +2490,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         try {
           openpgp.config.rejectPublicKeyAlgorithms = new Set();
 
-          const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-          await privKeyDE.decrypt(passphrase);
+          const privKeyDE = await openpgp.decryptKey({
+            privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+            passphrase
+          });
 
           const message = await openpgp.createCleartextMessage({ text: plaintext });
           const signOpt = {
@@ -2872,8 +2925,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       it('should fail to encrypt with revoked subkey', async function() {
         const pubKeyDE = await openpgp.readKey({ armoredKey: pub_key_de });
-        const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-        await privKeyDE.decrypt(passphrase);
+        const privKeyDE = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+          passphrase
+        });
         return privKeyDE.subKeys[0].revoke(privKeyDE.primaryKey).then(async function(revSubKey) {
           pubKeyDE.subKeys[0] = revSubKey;
           return openpgp.encrypt({
@@ -2890,8 +2945,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       it('should decrypt with revoked subkey', async function() {
         const pubKeyDE = await openpgp.readKey({ armoredKey: pub_key_de });
-        const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
-        await privKeyDE.decrypt(passphrase);
+        const privKeyDE = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: priv_key_de }),
+          passphrase
+        });
         const encrypted = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: plaintext }),
           publicKeys: pubKeyDE,
@@ -2912,8 +2969,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const privKeyDE = await openpgp.readKey({ armoredKey: priv_key_de });
         // corrupt the public key params
         privKeyDE.subKeys[0].keyPacket.publicParams.p[0]++;
-        // validation will not check the decryption subkey and will succeed
-        await privKeyDE.decrypt(passphrase);
+        // validation will check the primary key -- not the decryption subkey -- and will succeed (for now)
+        const decryptedKeyDE = await openpgp.decryptKey({
+          privateKey: privKeyDE,
+          passphrase
+        });
         const encrypted = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: plaintext }),
           publicKeys: pubKeyDE,
@@ -2921,7 +2981,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
         const decOpt = {
           message: await openpgp.readMessage({ armoredMessage: encrypted }),
-          privateKeys: privKeyDE
+          privateKeys: decryptedKeyDE
         };
         // binding signature is invalid
         await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith(/Session key decryption failed/);
@@ -2993,18 +3053,22 @@ J9I8AcH94nE77JUtCm7s1kOlo0EIshZsAqJwGveDGdAuabfViVwVxG4I24M6
       });
 
       it('should decrypt broken ECC message from old OpenPGP.js', async function() {
-        const key = await openpgp.readKey({ armoredKey: ecdh_dec_key });
+        const key = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: ecdh_dec_key }),
+          passphrase: '12345'
+        });
         const message = await openpgp.readMessage({ armoredMessage: ecdh_msg_bad });
-        await key.decrypt('12345');
-        const decrypted = await openpgp.decrypt({ message, privateKeys: [key] });
+        const decrypted = await openpgp.decrypt({ message, privateKeys: key });
         expect(decrypted.data).to.equal('\n');
       });
 
       it('should decrypt broken ECC message from old go crypto', async function() {
-        const key = await openpgp.readKey({ armoredKey: ecdh_dec_key_2 });
+        const key = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: ecdh_dec_key2 }),
+          passphrase: '12345'
+        });
         const message = await openpgp.readMessage({ armoredMessage: ecdh_msg_bad_2 });
-        await key.decrypt('12345');
-        const decrypted = await openpgp.decrypt({ message, privateKeys: [key] });
+        const decrypted = await openpgp.decrypt({ message, privateKeys: key });
         expect(decrypted.data).to.equal('Tesssst<br><br><br>Sent from ProtonMail mobile<br><br><br>');
       });
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -684,15 +684,15 @@ module.exports = () => describe("Packet", function() {
         '=pR+C\n' +
         '-----END PGP MESSAGE-----';
 
-    let key = new openpgp.PacketList();
-    await key.read((await openpgp.unarmor(armored_key)).data, allAllowedPackets);
-    key = key[3];
-    await key.decrypt('test');
+    const keyPackets = new openpgp.PacketList();
+    await keyPackets.read((await openpgp.unarmor(armored_key)).data, allAllowedPackets);
+    const keyPacket = keyPackets[3];
+    await keyPacket.decrypt('test');
 
     const msg = new openpgp.PacketList();
     await msg.read((await openpgp.unarmor(armored_msg)).data, allAllowedPackets);
 
-    return msg[0].decrypt(key).then(async () => {
+    return msg[0].decrypt(keyPacket).then(async () => {
       await msg[1].decrypt(msg[0].sessionKeyAlgorithm, msg[0].sessionKey);
 
       const text = await stringify(msg[1].packets[0].packets[0].data);

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -344,9 +344,12 @@ function tests() {
   it('Encrypt and decrypt larger message roundtrip using curve x25519 (allowUnauthenticatedStream=true)', async function() {
     const allowUnauthenticatedStreamValue = openpgp.config.allowUnauthenticatedStream;
     openpgp.config.allowUnauthenticatedStream = true;
-    const priv = await openpgp.readKey({ armoredKey: xPriv });
     const pub = await openpgp.readKey({ armoredKey: xPub });
-    await priv.decrypt(xPass);
+    const priv = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: xPriv }),
+      passphrase: xPass
+    });
+
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
@@ -376,9 +379,12 @@ function tests() {
   it('Encrypt and decrypt larger message roundtrip using curve brainpool (allowUnauthenticatedStream=true)', async function() {
     const allowUnauthenticatedStreamValue = openpgp.config.allowUnauthenticatedStream;
     openpgp.config.allowUnauthenticatedStream = true;
-    const priv = await openpgp.readKey({ armoredKey: brainpoolPriv });
     const pub = await openpgp.readKey({ armoredKey: brainpoolPub });
-    await priv.decrypt(brainpoolPass);
+    const priv = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: brainpoolPriv }),
+      passphrase: brainpoolPass
+    });
+
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
@@ -698,9 +704,12 @@ function tests() {
         this.push(null);
       }
     });
-    const priv = await openpgp.readKey({ armoredKey: brainpoolPriv });
     const pub = await openpgp.readKey({ armoredKey: brainpoolPub });
-    await priv.decrypt(brainpoolPass);
+    const priv = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: brainpoolPriv }),
+      passphrase: brainpoolPass
+    });
+
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
       privateKeys: priv,
@@ -734,9 +743,12 @@ function tests() {
         this.push(null);
       }
     });
-    const priv = await openpgp.readKey({ armoredKey: xPriv });
     const pub = await openpgp.readKey({ armoredKey: xPub });
-    await priv.decrypt(xPass);
+    const priv = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: xPriv }),
+      passphrase: xPass
+    });
+
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
       privateKeys: priv,
@@ -937,8 +949,10 @@ module.exports = () => describe('Streaming', function() {
 
   before(async function() {
     pubKey = await openpgp.readKey({ armoredKey: pub_key });
-    privKey = await openpgp.readKey({ armoredKey: priv_key });
-    await privKey.decrypt(passphrase);
+    privKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key }),
+      passphrase: 'hello world'
+    });
   });
 
   beforeEach(function() {

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -84,8 +84,6 @@ const priv_key = [
   '-----END PGP PRIVATE KEY BLOCK-----'
 ].join('\n');
 
-const passphrase = 'hello world';
-
 const brainpoolPub = [
   '-----BEGIN PGP PUBLIC KEY BLOCK-----',
   '',

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -137,10 +137,12 @@ module.exports = () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cr
     if (data[name].priv_key) {
       return data[name].priv_key;
     }
-    const pk = await openpgp.readKey({ armoredKey: data[name].priv });
+    const pk = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: data[name].priv }),
+      passphrase: data[name].pass
+    });
     expect(pk).to.exist;
     expect(pk.getKeyID().toHex()).to.equal(data[name].id);
-    await pk.decrypt(data[name].pass);
     data[name].priv_key = pk;
     return pk;
   }

--- a/test/worker/worker_example.js
+++ b/test/worker/worker_example.js
@@ -45,8 +45,10 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
     switch (action) {
       case 'encrypt': {
         const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
-        const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-        await privateKey.decrypt('test');
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+          passphrase: 'test'
+        });
         const data = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: message }),
           publicKeys: publicKey,
@@ -57,8 +59,10 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
       }
       case 'decrypt': {
         const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
-        const privateKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
-        await privateKey.decrypt('test');
+        const privateKey = await openpgp.decryptKey({
+          privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+          passphrase: 'test'
+        });
         const { data, signatures } = await openpgp.decrypt({
           message: await openpgp.readMessage({ armoredMessage: message }),
           publicKeys: publicKey,


### PR DESCRIPTION
Changes:
- remove `Key.prototype.encrypt` and `decrypt`, since these methods could leave the key object in an inconsistent state in case of errors, or when used in combination with `key.addSubkey()`.
- `openpgp.generateKey` now requires `options.userIDs`, since otherwise the key is basically unusable.

To encrypt/decrypt a key, the top-level functions `openpgp.encryptKey` and `openpgp.decryptKey` should be used instead: on success, these return a new encrypted/decrypted key object, and do not affect the original key.

Note that the `keyID` parameter is not supported by `encryptKey`/`decryptKey`, since partial key decryption is not recommended. If you still want to decrypt a single subkey or primary key `k`, you can call `k.keyPacket.decrypt(...)`, followed by `k.keyPacket.validate(...)`. Similarly, for encryption do `k.keyPacket.encrypt(...)`.