### PR TITLE
Unexport openpgp.stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,9 +261,9 @@
       "dev": true
     },
     "@openpgp/web-stream-tools": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.4.tgz",
-      "integrity": "sha512-u6KEn/J4A2ojBkQ0qc9Jgs4nNVK+u7snY3h/SlvwdE8+STh/R3vVXJgkIgsAmWfweE0Ng4TjakrNY9tBI31VJQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.5.tgz",
+      "integrity": "sha512-tdUCdiMi5ogmZlAbR4cQXZDbK34QB8iEnJ434m9bj4P7sxvKg2KKKbEiB4EQb2AWhj/SNKcoNUHhT9WxTqKimQ==",
       "dev": true,
       "requires": {
         "@mattiasbuelens/web-streams-adapter": "0.1.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@openpgp/pako": "^1.0.11",
     "@openpgp/seek-bzip": "^1.0.5-git",
     "@openpgp/tweetnacl": "^1.0.3",
-    "@openpgp/web-stream-tools": "0.0.4",
+    "@openpgp/web-stream-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -340,6 +340,11 @@ export function unarmor(input, config = defaultConfig) {
     } catch (e) {
       reject(e);
     }
+  }).then(async result => {
+    if (stream.isArrayStream(result.data)) {
+      result.data = await stream.readToEnd(result.data);
+    }
+    return result;
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,6 @@ export { CleartextMessage, readCleartextMessage, createCleartextMessage } from '
 
 export * from './packet';
 
-import * as streamMod from '@openpgp/web-stream-tools'; // eslint-disable-line
-export const stream = streamMod;
-
 export * from './encoding/armor';
 
 export { default as enums } from './enums';

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -382,7 +382,7 @@ NJCB6+LWtabSoVIjNVgKwyKqyTLaESNwC2ogZwkdE8qPGiDFEHo4Gg9zuRof
 `;
 
     const { type, data } = await openpgp.unarmor(pubKey);
-    const armor = await openpgp.stream.readToEnd(openpgp.armor(type, data));
+    const armor = await openpgp.armor(type, data);
     expect(
       armor
         .replace(/^(Version|Comment): .*$\n/mg, '')

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -7,6 +7,8 @@ const random = require('../../src/crypto/random');
 const util = require('../../src/util');
 const keyIDType = require('../../src/type/keyid');
 
+const stream = require('@openpgp/web-stream-tools');
+
 const spy = require('sinon/lib/sinon/spy');
 const input = require('./testInputs.js');
 const chai = require('chai');
@@ -1065,12 +1067,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         publicKeys: publicKey
       });
       const { data: streamedData, signatures } = await openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
+        message: await openpgp.readMessage({ armoredMessage: stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: publicKey,
         expectSigned: true
       });
-      const data = await openpgp.stream.readToEnd(streamedData);
+      const data = await stream.readToEnd(streamedData);
       expect(data).to.equal(plaintext);
       expect(await signatures[0].verified).to.be.true;
     });
@@ -1088,7 +1090,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKeys: privateKey
       });
       await expect(openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
+        message: await openpgp.readMessage({ armoredMessage: stream.toStream(encrypted) }),
         privateKeys: privateKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Public keys are required/);
@@ -1106,7 +1108,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         publicKeys: publicKey
       });
       await expect(openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
+        message: await openpgp.readMessage({ armoredMessage: stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: publicKey,
         expectSigned: true
@@ -1127,13 +1129,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKeys: privateKey
       });
       const { data: streamedData } = await openpgp.decrypt({
-        message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
+        message: await openpgp.readMessage({ armoredMessage: stream.toStream(encrypted) }),
         privateKeys: privateKey,
         publicKeys: wrongPublicKey,
         expectSigned: true
       });
       await expect(
-        openpgp.stream.readToEnd(streamedData)
+        stream.readToEnd(streamedData)
       ).to.be.eventually.rejectedWith(/Could not find signing key/);
     });
   });
@@ -1229,11 +1231,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           privateKeys: privateKey
         });
         const { data: streamedData, signatures } = await openpgp.verify({
-          message: await readMessage({ armoredMessage: openpgp.stream.toStream(signed) }),
+          message: await readMessage({ armoredMessage: stream.toStream(signed) }),
           publicKeys: publicKey,
           expectSigned: true
         });
-        const data = await openpgp.stream.readToEnd(streamedData);
+        const data = await stream.readToEnd(streamedData);
         expect(data).to.equal(text);
         expect(await signatures[0].verified).to.be.true;
       });
@@ -1244,7 +1246,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const publicKey = await openpgp.readKey({ armoredKey: pub_key });
 
         await expect(openpgp.verify({
-          message: await createMessage({ text: openpgp.stream.toStream(text) }),
+          message: await createMessage({ text: stream.toStream(text) }),
           publicKeys: publicKey,
           expectSigned: true
         })).to.be.eventually.rejectedWith(/Message is not signed/);
@@ -1264,12 +1266,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           privateKeys: privateKey
         });
         const { data: streamedData } = await openpgp.verify({
-          message: await readMessage({ armoredMessage: openpgp.stream.toStream(signed) }),
+          message: await readMessage({ armoredMessage: stream.toStream(signed) }),
           publicKeys: wrongPublicKey,
           expectSigned: true
         });
         await expect(
-          openpgp.stream.readToEnd(streamedData)
+          stream.readToEnd(streamedData)
         ).to.be.eventually.rejectedWith(/Could not find signing key/);
       });
     }
@@ -2152,13 +2154,19 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
             throw new Error("Was not able to successfully modify checksum");
           }
           const badBodyEncrypted = data.replace(/\n=([a-zA-Z0-9/+]{4})/, 'aaa\n=$1');
+          await stream.loadStreamsPonyfill();
           for (let allow_streaming = 1; allow_streaming >= 0; allow_streaming--) {
             openpgp.config.allowUnauthenticatedStream = !!allow_streaming;
             await Promise.all([badSumEncrypted, badBodyEncrypted].map(async (encrypted, i) => {
               await Promise.all([
                 encrypted,
-                openpgp.stream.toStream(encrypted),
-                new openpgp.stream.ReadableStream({
+                new stream.ReadableStream({
+                  start(controller) {
+                    controller.enqueue(encrypted);
+                    controller.close();
+                  }
+                }),
+                new stream.ReadableStream({
                   start() {
                     this.remaining = encrypted.split('\n');
                   },
@@ -2178,7 +2186,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
                   stepReached = 1;
                   const { data: decrypted } = await openpgp.decrypt({ message: message, privateKeys: [key] });
                   stepReached = 2;
-                  await openpgp.stream.readToEnd(decrypted);
+                  await stream.readToEnd(decrypted);
                 } catch (e) {
                   expect(e.message).to.match(/Ascii armor integrity check on message failed/);
                   expect(stepReached).to.equal(
@@ -2407,7 +2415,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
             const plaintext = [];
             let i = 0;
             const useNativeStream = (() => { try { new global.ReadableStream(); return true; } catch (e) { return false; } })(); // eslint-disable-line no-new
-            const ReadableStream = useNativeStream ? global.ReadableStream : openpgp.stream.ReadableStream;
+            await stream.loadStreamsPonyfill();
+            const ReadableStream = useNativeStream ? global.ReadableStream : stream.ReadableStream;
             const data = new ReadableStream({
               async pull(controller) {
                 if (i++ < 4) {
@@ -2423,7 +2432,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
               message: await openpgp.createMessage({ binary: data }),
               passwords: ['test']
             }));
-            expect(openpgp.stream.isStream(encrypted)).to.equal(useNativeStream ? 'web' : 'ponyfill');
+            expect(stream.isStream(encrypted)).to.equal(useNativeStream ? 'web' : 'web-like');
 
             const message = await openpgp.readMessage({ armoredMessage: encrypted });
             const decrypted = await openpgp.decrypt({
@@ -2431,8 +2440,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
               message,
               format: 'binary'
             });
-            expect(openpgp.stream.isStream(decrypted.data)).to.equal(useNativeStream ? 'web' : 'ponyfill');
-            expect(await openpgp.stream.readToEnd(decrypted.data)).to.deep.equal(util.concatUint8Array(plaintext));
+            expect(stream.isStream(decrypted.data)).to.equal(useNativeStream ? 'web' : 'web-like');
+            expect(await stream.readToEnd(decrypted.data)).to.deep.equal(util.concatUint8Array(plaintext));
           });
         });
       });
@@ -2719,7 +2728,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         };
         return openpgp.sign(signOpt).then(async function (signed) {
           const message = await openpgp.readMessage({ binaryMessage: signed });
-          message.packets.push(...await openpgp.stream.readToEnd(message.packets.stream, _ => _));
+          message.packets.push(...await stream.readToEnd(message.packets.stream, _ => _));
           const packets = new openpgp.PacketList();
           packets.push(message.packets.findPacket(openpgp.enums.packet.signature));
           packets.push(message.packets.findPacket(openpgp.enums.packet.literalData));
@@ -2757,21 +2766,21 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           format: 'binary'
         };
         return openpgp.sign(signOpt).then(async function (signed) {
-          expect(openpgp.stream.isStream(signed)).to.equal(global.ReadableStream ? 'web' : 'node');
+          expect(stream.isStream(signed)).to.equal(global.ReadableStream ? 'web' : 'node');
           const message = await openpgp.readMessage({ binaryMessage: signed });
-          message.packets.push(...await openpgp.stream.readToEnd(message.packets.stream, _ => _));
+          message.packets.push(...await stream.readToEnd(message.packets.stream, _ => _));
           const packets = new openpgp.PacketList();
           packets.push(message.packets.findPacket(openpgp.enums.packet.signature));
           packets.push(message.packets.findPacket(openpgp.enums.packet.literalData));
           verifyOpt.message = await openpgp.readMessage({
-            binaryMessage: openpgp.stream[
-              global.ReadableStream ? (global.ReadableStream === openpgp.stream.ReadableStream ? 'toStream' : 'toNativeReadable') : 'webToNode'
+            binaryMessage: stream[
+              global.ReadableStream ? (global.ReadableStream === stream.ReadableStream ? 'toStream' : 'toNativeReadable') : 'webToNode'
             ](packets.write())
           });
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
-          expect(openpgp.stream.isStream(verified.data)).to.equal(global.ReadableStream ? 'web' : 'node');
-          expect([].slice.call(await openpgp.stream.readToEnd(verified.data))).to.deep.equal([].slice.call(data));
+          expect(stream.isStream(verified.data)).to.equal(global.ReadableStream ? 'web' : 'node');
+          expect([].slice.call(await stream.readToEnd(verified.data))).to.deep.equal([].slice.call(data));
           expect(await verified.signatures[0].verified).to.be.true;
           expect(await privateKey.getSigningKey(verified.signatures[0].keyID))
             .to.be.not.null;
@@ -2795,7 +2804,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const literals = packets.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
           expect(+literals[0].date).to.equal(+future);
-          expect(await openpgp.stream.readToEnd(packets.getText())).to.equal(plaintext);
+          expect(await stream.readToEnd(packets.getText())).to.equal(plaintext);
         });
       });
 
@@ -2816,7 +2825,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const literals = packets.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
           expect(+literals[0].date).to.equal(+past);
-          expect(await openpgp.stream.readToEnd(packets.getLiteralData())).to.deep.equal(data);
+          expect(await stream.readToEnd(packets.getLiteralData())).to.deep.equal(data);
         });
       });
 
@@ -2838,7 +2847,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           expect(literals.length).to.equal(1);
           expect(+literals[0].date).to.equal(+past);
           const signatures = await message.verify([publicKey_2000_2008], past, undefined, openpgp.config);
-          expect(await openpgp.stream.readToEnd(message.getText())).to.equal(plaintext);
+          expect(await stream.readToEnd(message.getText())).to.equal(plaintext);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+past);
           expect(await signatures[0].verified).to.be.true;
           expect(await privateKey_2000_2008.getSigningKey(signatures[0].keyID, past))
@@ -2867,7 +2876,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           expect(literals[0].format).to.equal('binary');
           expect(+literals[0].date).to.equal(+future);
           const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
-          expect(await openpgp.stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
+          expect(await stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+future);
           expect(await signatures[0].verified).to.be.true;
           expect(await privateKey_2038_2045.getSigningKey(signatures[0].keyID, future))
@@ -2896,7 +2905,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           expect(literals[0].format).to.equal('mime');
           expect(+literals[0].date).to.equal(+future);
           const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
-          expect(await openpgp.stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
+          expect(await stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
           expect(+(await signatures[0].signature).packets[0].created).to.equal(+future);
           expect(await signatures[0].verified).to.be.true;
           expect(await privateKey_2038_2045.getSigningKey(signatures[0].keyID, future))
@@ -3202,7 +3211,7 @@ Bw==
 -----END PGP PRIVATE KEY BLOCK-----`
         });
         const message = await openpgp.readMessage({
-          armoredMessage: openpgp.stream.toStream(`-----BEGIN PGP MESSAGE-----
+          armoredMessage: stream.toStream(`-----BEGIN PGP MESSAGE-----
 
 wV4D+3VwOibHmagSAQdATlMJlvrkaq46zMkbIuKBOJO5X3ugVwZpEyAterQC
 /RUw0OPWeO+4swh/U7ZurV8cRr/fPnyGUUKI7rI+va3kWUZv4RRpUs7eYE57
@@ -3214,7 +3223,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
 -----END PGP MESSAGE-----`)
         });
         const decrypted = await openpgp.decrypt({ message, privateKeys: key, publicKeys: key, config: { allowUnauthenticatedMessages: true } });
-        const data = await openpgp.stream.readToEnd(decrypted.data);
+        const data = await stream.readToEnd(decrypted.data);
         expect(data).to.equal('test');
       });
     });

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -4,6 +4,8 @@
 const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const util = require('../../src/util');
 
+const stream = require('@openpgp/web-stream-tools');
+
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 
@@ -946,7 +948,7 @@ hUhMKMuiM3pRwdIyDOItkUWQmjEEw7/XmhgInkXsCw==
       const sMsg = await openpgp.readMessage({ armoredMessage: signedArmor });
       const pub_key = await openpgp.readKey({ armoredKey: pub_key_arm2 });
       const verified = await sMsg.verify([pub_key]);
-      openpgp.stream.readToEnd(sMsg.getLiteralData());
+      stream.readToEnd(sMsg.getLiteralData());
       expect(verified).to.exist;
       expect(verified).to.have.length(1);
       expect(await verified[0].verified).to.be.true;
@@ -1115,7 +1117,7 @@ PAAeuQTUrcJdZeJ86eQ9cCUB216HCwSKOWTQRzL+hBWKXij4WD4=
     const pubKey = await openpgp.readKey({ armoredKey: pub_latin1_msg });
 
     return message.verify([pubKey]).then(async verifiedSig => {
-      expect(await openpgp.stream.readToEnd(message.getLiteralData())).to.equal(latin1Binary);
+      expect(await stream.readToEnd(message.getLiteralData())).to.equal(latin1Binary);
       expect(verifiedSig).to.exist;
       expect(verifiedSig).to.have.length(1);
       expect(await verifiedSig[0].verified).to.be.true;
@@ -1210,25 +1212,13 @@ yYDnCgA=
 -----END PGP MESSAGE-----`.split('');
 
       const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+      await stream.loadStreamsPonyfill();
       const message = await openpgp.readMessage({
-        armoredMessage: globalThis.ReadableStream ? new globalThis.ReadableStream({
+        armoredMessage: new stream.ReadableStream({
           async pull(controller) {
             await new Promise(setTimeout);
             controller.enqueue(armoredMessage.shift());
             if (!armoredMessage.length) controller.close();
-          }
-        }) : new (require('stream').Readable)({
-          encoding: 'utf8',
-          async read() {
-            while (true) {
-              await new Promise(setTimeout);
-              if (!armoredMessage.length) {
-                return this.push(null);
-              }
-              if (!this.push(armoredMessage.shift())) {
-                break;
-              }
-            }
           }
         })
       });
@@ -1239,7 +1229,7 @@ yYDnCgA=
 
       return openpgp.verify({ publicKeys: [pubKey], message, config: { minRSABits: 1024 } }).then(async function(cleartextSig) {
         expect(cleartextSig).to.exist;
-        expect(await openpgp.stream.readToEnd(cleartextSig.data)).to.equal(plaintext);
+        expect(await stream.readToEnd(cleartextSig.data)).to.equal(plaintext);
         expect(cleartextSig.signatures).to.have.length(1);
         if (!openpgp.config.rejectMessageHashAlgorithms.has(openpgp.enums.hash.sha1)) {
           expect(await cleartextSig.signatures[0].verified).to.be.true;
@@ -1288,8 +1278,9 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
 -----END PGP MESSAGE-----`.split('');
 
       const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+      await stream.loadStreamsPonyfill();
       const message = await openpgp.readMessage({
-        armoredMessage: new openpgp.stream.ReadableStream({
+        armoredMessage: new stream.ReadableStream({
           async pull(controller) {
             await new Promise(setTimeout);
             controller.enqueue(armoredMessage.shift());
@@ -1303,7 +1294,7 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
       expect(pubKey.getKeys(keyIDs[0])).to.not.be.empty;
 
       return openpgp.verify({ publicKeys: [pubKey], message, config: { minRSABits: 1024 } }).then(async ({ data, signatures }) => {
-        expect(await openpgp.stream.readToEnd(data)).to.equal(plaintext);
+        expect(await stream.readToEnd(data)).to.equal(plaintext);
         expect(signatures).to.have.length(1);
         await expect(signatures[0].verified).to.be.rejectedWith('Corresponding signature packet missing');
         expect((await signatures[0].signature).packets.length).to.equal(0);

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -11,10 +11,9 @@ const input = require('./testInputs.js');
 
 const { expect } = chai;
 
-const { stream } = openpgp;
+const stream = require('@openpgp/web-stream-tools');
 
 const useNativeStream = (() => { try { new global.ReadableStream(); return true; } catch (e) { return false; } })(); // eslint-disable-line no-new
-const ReadableStream = useNativeStream ? global.ReadableStream : openpgp.stream.ReadableStream;
 const NodeReadableStream = useNativeStream ? undefined : require('stream').Readable;
 
 const pub_key = [
@@ -180,7 +179,7 @@ let dataArrived;
 function tests() {
   it('Encrypt small message', async function() {
     dataArrived(); // Do not wait until data arrived.
-    const data = ReadableStream ? new ReadableStream({
+    const data = global.ReadableStream ? new global.ReadableStream({
       start(controller) {
         controller.enqueue(util.stringToUint8Array('hello '));
         controller.enqueue(util.stringToUint8Array('world'));
@@ -197,7 +196,7 @@ function tests() {
       message: await openpgp.createMessage({ binary: data }),
       passwords: ['test']
     });
-    const msgAsciiArmored = await openpgp.stream.readToEnd(encrypted);
+    const msgAsciiArmored = await stream.readToEnd(encrypted);
     const message = await openpgp.readMessage({ armoredMessage: msgAsciiArmored });
     const decrypted = await openpgp.decrypt({
       passwords: ['test'],
@@ -211,11 +210,11 @@ function tests() {
       message: await openpgp.createMessage({ binary: data }),
       passwords: ['test']
     });
-    const reader = openpgp.stream.getReader(encrypted);
+    const reader = stream.getReader(encrypted);
     expect(await reader.peekBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
-    const msgAsciiArmored = await openpgp.stream.readToEnd(encrypted);
+    const msgAsciiArmored = await stream.readToEnd(encrypted);
     const message = await openpgp.readMessage({ armoredMessage: msgAsciiArmored });
     const decrypted = await openpgp.decrypt({
       passwords: ['test'],
@@ -230,11 +229,11 @@ function tests() {
       message: await openpgp.createMessage({ binary: data }),
       passwords: ['test']
     });
-    const reader = openpgp.stream.getReader(encrypted);
+    const reader = stream.getReader(encrypted);
     expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
-    await openpgp.stream.cancel(encrypted);
+    await stream.cancel(encrypted);
     expect(canceled).to.be.true;
   });
 
@@ -244,11 +243,11 @@ function tests() {
       privateKeys: privKey,
       config: { minRSABits: 1024 }
     });
-    const reader = openpgp.stream.getReader(signed);
+    const reader = stream.getReader(signed);
     expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     reader.releaseLock();
-    await openpgp.stream.cancel(signed);
+    await stream.cancel(signed);
     expect(canceled).to.be.true;
   });
 
@@ -260,7 +259,7 @@ function tests() {
       passwords: ['test'],
       armor: false
     });
-    expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+    expect(stream.isStream(encrypted)).to.equal(expectedType);
 
     const message = await openpgp.readMessage({ binaryMessage: encrypted });
     setTimeout(dataArrived, 3000); // Do not wait until data arrived, but wait a bit to check that it doesn't arrive early.
@@ -269,8 +268,8 @@ function tests() {
       message,
       format: 'binary'
     });
-    expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(decrypted.data);
+    expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+    const reader = stream.getReader(decrypted.data);
     expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
     if (i <= 10) throw new Error('Data arrived early.');
     expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -288,7 +287,7 @@ function tests() {
         passwords: ['test'],
         armor: false
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -296,9 +295,9 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      expect(openpgp.stream.isStream(decrypted.signatures)).to.be.false;
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      expect(stream.isStream(decrypted.signatures)).to.be.false;
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -320,7 +319,7 @@ function tests() {
         armor: false,
         config: { minRSABits: 1024 }
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -329,8 +328,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -355,7 +354,7 @@ function tests() {
         privateKeys: priv,
         armor: false
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -364,8 +363,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -390,7 +389,7 @@ function tests() {
         privateKeys: priv,
         armor: false
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -399,8 +398,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -419,10 +418,10 @@ function tests() {
         message: await openpgp.createMessage({ binary: data, filename: 'msg.bin' }),
         passwords: ['test']
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({
-        armoredMessage: openpgp.stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === openpgp.stream.ReadableStream ? 'toStream' : 'toNativeReadable'](openpgp.stream.transform(encrypted, value => {
+        armoredMessage: stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === stream.ReadableStream ? 'toStream' : 'toNativeReadable'](stream.transform(encrypted, value => {
           value += '';
           if (value === '=' || value.length === 5) return; // Remove checksum
           const newlineIndex = value.indexOf('\n', 500);
@@ -435,8 +434,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
       dataArrived();
       await expect(reader.readToEnd()).to.be.rejectedWith('Modification detected.');
@@ -457,10 +456,10 @@ function tests() {
         privateKeys: privKey,
         config: { minRSABits: 1024 }
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({
-        armoredMessage: openpgp.stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === openpgp.stream.ReadableStream ? 'toStream' : 'toNativeReadable'](openpgp.stream.transform(encrypted, value => {
+        armoredMessage: stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === stream.ReadableStream ? 'toStream' : 'toNativeReadable'](stream.transform(encrypted, value => {
           value += '';
           const newlineIndex = value.indexOf('\n', 500);
           if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
@@ -473,8 +472,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
       dataArrived();
       await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
@@ -494,10 +493,10 @@ function tests() {
         privateKeys: privKey,
         config: { minRSABits: 1024 }
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({
-        armoredMessage: openpgp.stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === openpgp.stream.ReadableStream ? 'toStream' : 'toNativeReadable'](openpgp.stream.transform(encrypted, value => {
+        armoredMessage: stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === stream.ReadableStream ? 'toStream' : 'toNativeReadable'](stream.transform(encrypted, value => {
           value += '';
           const newlineIndex = value.indexOf('\n', 500);
           if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
@@ -509,8 +508,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
       dataArrived();
       await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
@@ -527,10 +526,10 @@ function tests() {
       privateKeys: privKey,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
+    expect(stream.isStream(signed)).to.equal(expectedType);
 
     const message = await openpgp.readMessage({
-      armoredMessage: openpgp.stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === openpgp.stream.ReadableStream ? 'toStream' : 'toNativeReadable'](openpgp.stream.transform(signed, value => {
+      armoredMessage: stream[expectedType === 'node' ? 'webToNode' : global.ReadableStream === stream.ReadableStream ? 'toStream' : 'toNativeReadable'](stream.transform(signed, value => {
         value += '';
         const newlineIndex = value.indexOf('\n', 500);
         if (value.length > 1000) return value.slice(0, newlineIndex - 1) + (value[newlineIndex - 1] === 'a' ? 'b' : 'a') + value.slice(newlineIndex);
@@ -543,8 +542,8 @@ function tests() {
       format: 'binary',
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(verified.data)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(verified.data);
+    expect(stream.isStream(verified.data)).to.equal(expectedType);
+    const reader = stream.getReader(verified.data);
     expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
     dataArrived();
     await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
@@ -582,7 +581,7 @@ function tests() {
       privateKeys: privKey,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
+    expect(stream.isStream(signed)).to.equal(expectedType);
 
     const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
@@ -591,12 +590,12 @@ function tests() {
       format: 'binary',
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(verified.data)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(verified.data);
+    expect(stream.isStream(verified.data)).to.equal(expectedType);
+    const reader = stream.getReader(verified.data);
     expect(await reader.readBytes(1024)).to.deep.equal(plaintext[0]);
     dataArrived();
     reader.releaseLock();
-    await openpgp.stream.cancel(verified.data, new Error('canceled by test'));
+    await stream.cancel(verified.data, new Error('canceled by test'));
     expect(canceled).to.be.true;
     expect(verified.signatures).to.exist.and.have.length(1);
     await expect(verified.signatures[0].verified).to.be.rejectedWith('canceled');
@@ -607,9 +606,9 @@ function tests() {
       message: await openpgp.createMessage({ binary: data }),
       passwords: ['test']
     });
-    expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+    expect(stream.isStream(encrypted)).to.equal(expectedType);
 
-    const reader = openpgp.stream.getReader(encrypted);
+    const reader = stream.getReader(encrypted);
     expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
@@ -622,9 +621,9 @@ function tests() {
       privateKeys: privKey,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
+    expect(stream.isStream(signed)).to.equal(expectedType);
 
-    const reader = openpgp.stream.getReader(signed);
+    const reader = stream.getReader(signed);
     expect(await reader.readBytes(1024)).to.match(/^-----BEGIN PGP MESSAGE-----\n/);
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
@@ -637,15 +636,15 @@ function tests() {
       privateKeys: privKey,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
+    expect(stream.isStream(signed)).to.equal(expectedType);
     const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
       publicKeys: pubKey,
       message,
       format: 'binary'
     });
-    expect(openpgp.stream.isStream(verified.data)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(verified.data);
+    expect(stream.isStream(verified.data)).to.equal(expectedType);
+    const reader = stream.getReader(verified.data);
     expect(await reader.readBytes(1024)).to.deep.equal(plaintext[0]);
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
@@ -654,7 +653,7 @@ function tests() {
 
   it('Detached sign small message', async function() {
     dataArrived(); // Do not wait until data arrived.
-    const data = ReadableStream ? new ReadableStream({
+    const data = global.ReadableStream ? new global.ReadableStream({
       start(controller) {
         controller.enqueue(util.stringToUint8Array('hello '));
         controller.enqueue(util.stringToUint8Array('world'));
@@ -673,8 +672,8 @@ function tests() {
       detached: true,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    expect(stream.isStream(signed)).to.equal(expectedType);
+    const armoredSignature = await stream.readToEnd(signed);
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
@@ -689,7 +688,7 @@ function tests() {
 
   it('Detached sign small message using brainpool curve keys', async function() {
     dataArrived(); // Do not wait until data arrived.
-    const data = ReadableStream ? new ReadableStream({
+    const data = global.ReadableStream ? new global.ReadableStream({
       start(controller) {
         controller.enqueue(util.stringToUint8Array('hello '));
         controller.enqueue(util.stringToUint8Array('world'));
@@ -713,8 +712,8 @@ function tests() {
       privateKeys: priv,
       detached: true
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    expect(stream.isStream(signed)).to.equal(expectedType);
+    const armoredSignature = await stream.readToEnd(signed);
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
@@ -728,7 +727,7 @@ function tests() {
 
   it('Detached sign small message using x25519 curve keys', async function() {
     dataArrived(); // Do not wait until data arrived.
-    const data = ReadableStream ? new ReadableStream({
+    const data = global.ReadableStream ? new global.ReadableStream({
       async start(controller) {
         controller.enqueue(util.stringToUint8Array('hello '));
         controller.enqueue(util.stringToUint8Array('world'));
@@ -752,8 +751,8 @@ function tests() {
       privateKeys: priv,
       detached: true
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const armoredSignature = await openpgp.stream.readToEnd(signed);
+    expect(stream.isStream(signed)).to.equal(expectedType);
+    const armoredSignature = await stream.readToEnd(signed);
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
@@ -772,8 +771,8 @@ function tests() {
       detached: true,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(signed);
+    expect(stream.isStream(signed)).to.equal(expectedType);
+    const reader = stream.getReader(signed);
     expect((await reader.readBytes(30)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n');
     dataArrived();
     await new Promise(resolve => setTimeout(resolve, 3000));
@@ -787,12 +786,12 @@ function tests() {
       detached: true,
       config: { minRSABits: 1024 }
     });
-    expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
-    const reader = openpgp.stream.getReader(signed);
+    expect(stream.isStream(signed)).to.equal(expectedType);
+    const reader = stream.getReader(signed);
     expect((await reader.readBytes(30)).toString('utf8')).to.equal('-----BEGIN PGP SIGNATURE-----\n');
     dataArrived();
     reader.releaseLock();
-    await openpgp.stream.cancel(signed, new Error('canceled by test'));
+    await stream.cancel(signed, new Error('canceled by test'));
     expect(canceled).to.be.true;
   });
 
@@ -817,7 +816,7 @@ function tests() {
         passwords: ['test'],
         armor: false
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -825,8 +824,8 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       expect(await reader.readToEnd()).to.deep.equal(util.concatUint8Array(plaintext));
@@ -837,7 +836,7 @@ function tests() {
 
       const plaintext = [];
       let i = 0;
-      const data = ReadableStream ? new ReadableStream({
+      const data = global.ReadableStream ? new global.ReadableStream({
         async pull(controller) {
           await new Promise(resolve => setTimeout(resolve, 10));
           if (i++ < 10) {
@@ -867,15 +866,15 @@ function tests() {
         message: await openpgp.createMessage({ text: data }),
         passwords: ['test']
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+      expect(stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect((await reader.peekBytes(plaintext[0].length * 4)).toString('utf8').substr(0, plaintext[0].length)).to.equal(plaintext[0]);
       dataArrived();
       expect((await reader.readToEnd()).toString('utf8')).to.equal(util.concat(plaintext));
@@ -896,15 +895,15 @@ function tests() {
           message: await openpgp.createMessage({ binary: data }),
           passwords: ['test']
         });
-        expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
+        expect(stream.isStream(encrypted)).to.equal(expectedType);
         const message = await openpgp.readMessage({ armoredMessage: encrypted });
         const decrypted = await openpgp.decrypt({
           passwords: ['test'],
           message,
           format: 'binary'
         });
-        expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-        const reader = openpgp.stream.getReader(decrypted.data);
+        expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+        const reader = stream.getReader(decrypted.data);
         expect(await reader.readBytes(1024)).to.deep.equal(plaintext[0]);
         dataArrived();
         await new Promise(resolve => setTimeout(resolve, 3000));
@@ -930,12 +929,12 @@ function tests() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal(expectedType);
-      const reader = openpgp.stream.getReader(decrypted.data);
+      expect(stream.isStream(decrypted.data)).to.equal(expectedType);
+      const reader = stream.getReader(decrypted.data);
       expect(await reader.readBytes(1024)).to.deep.equal(plaintext[0]);
       dataArrived();
       reader.releaseLock();
-      await openpgp.stream.cancel(decrypted.data, new Error('canceled by test'));
+      await stream.cancel(decrypted.data, new Error('canceled by test'));
       await new Promise(setTimeout);
       expect(canceled).to.be.true;
     });
@@ -951,6 +950,8 @@ module.exports = () => describe('Streaming', function() {
       privateKey: await openpgp.readKey({ armoredKey: priv_key }),
       passphrase: 'hello world'
     });
+
+    await stream.loadStreamsPonyfill();
   });
 
   beforeEach(function() {
@@ -962,7 +963,7 @@ module.exports = () => describe('Streaming', function() {
     plaintext = [];
     i = 0;
     canceled = false;
-    data = ReadableStream ? new ReadableStream({
+    data = global.ReadableStream ? new global.ReadableStream({
       async pull(controller) {
         await new Promise(setTimeout);
         if (test === currentTest && i < (expectedType === 'web' ? 100 : 500)) {
@@ -1000,7 +1001,7 @@ module.exports = () => describe('Streaming', function() {
         canceled = true;
       }
     });
-    expectedType = ReadableStream ? 'web' : 'node';
+    expectedType = global.ReadableStream ? 'web' : 'node';
   });
 
   tests();
@@ -1016,15 +1017,15 @@ module.exports = () => describe('Streaming', function() {
         message: await openpgp.createMessage({ text: data }),
         passwords: ['test']
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal('node');
+      expect(stream.isStream(encrypted)).to.equal('node');
 
       const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         passwords: ['test'],
         message
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal('node');
-      expect(await openpgp.stream.readToEnd(decrypted.data)).to.equal(plaintext);
+      expect(stream.isStream(decrypted.data)).to.equal('node');
+      expect(await stream.readToEnd(decrypted.data)).to.equal(plaintext);
     });
 
     it('Node: Encrypt and decrypt binary message roundtrip', async function() {
@@ -1036,7 +1037,7 @@ module.exports = () => describe('Streaming', function() {
         passwords: ['test'],
         armor: false
       });
-      expect(openpgp.stream.isStream(encrypted)).to.equal('node');
+      expect(stream.isStream(encrypted)).to.equal('node');
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
@@ -1044,8 +1045,8 @@ module.exports = () => describe('Streaming', function() {
         message,
         format: 'binary'
       });
-      expect(openpgp.stream.isStream(decrypted.data)).to.equal('node');
-      expect(await openpgp.stream.readToEnd(decrypted.data)).to.deep.equal(plaintext);
+      expect(stream.isStream(decrypted.data)).to.equal('node');
+      expect(await stream.readToEnd(decrypted.data)).to.deep.equal(plaintext);
     });
   }
 });


### PR DESCRIPTION
This change allows us to only load the ReadableStream polyfill when needed without behaving inconsistently in the external API.

Users of the library should use the global ReadableStream or Node.js stream.Readable instead, or import a polyfill if needed. This patch loosens the detection criteria such that polyfilled streams are better detected.