### PR TITLE
Make key fingerprint computation async

### DIFF
--- a/src/crypto/public_key/elliptic/curves.js
+++ b/src/crypto/public_key/elliptic/curves.js
@@ -225,7 +225,7 @@ function getPreferredHashAlgo(oid) {
 }
 
 /**
- * Validate ECDH and EcDSA parameters
+ * Validate ECDH and ECDSA parameters
  * Not suitable for EdDSA (different secret key format)
  * @param {module:enums.publicKey} algo - EC algorithm, to filter supported curves
  * @param {module:type/oid} oid - EC object identifier

--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -117,10 +117,10 @@ export async function verify(oid, hashAlgo, signature, message, publicKey, hashe
 }
 
 /**
- * Validate EcDSA parameters
+ * Validate ECDSA parameters
  * @param {module:type/oid} oid - Elliptic curve object identifier
- * @param {Uint8Array} Q - EcDSA public point
- * @param {Uint8Array} d - EcDSA secret scalar
+ * @param {Uint8Array} Q - ECDSA public point
+ * @param {Uint8Array} d - ECDSA secret scalar
  * @returns {Promise<Boolean>} Whether params are valid.
  * @async
  */

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -76,7 +76,7 @@ export async function generate(options, config) {
  * @param {Array<String|Object>} options.userIDs  User IDs as strings or objects: 'Jo Doe <info@jo.com>' or { name:'Jo Doe', email:'info@jo.com' }
  * @param {String} options.passphrase             Passphrase used to encrypt the resulting private key
  * @param {Number} options.keyExpirationTime      Number of seconds from the key creation time after which the key expires
- * @param {Date}   options.date                   Override the creation date of the key and the key signatures
+ * @param {Date}   options.date                   Override the creation date of the key signatures
  * @param {Array<Object>} options.subkeys         (optional) options for each subkey, default to main key options. e.g. [{sign: true, passphrase: '123'}]
  * @param {Object} config - Full configuration
  *

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -21,7 +21,7 @@ export async function generateSecretSubkey(options, config) {
   secretSubkeyPacket.packets = null;
   secretSubkeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
   await secretSubkeyPacket.generate(options.rsaBits, options.curve);
-  await secretSubkeyPacket.computeKeyFingerprintAndID();
+  await secretSubkeyPacket.computeFingerprintAndKeyID();
   return secretSubkeyPacket;
 }
 
@@ -30,7 +30,7 @@ export async function generateSecretKey(options, config) {
   secretKeyPacket.packets = null;
   secretKeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
   await secretKeyPacket.generate(options.rsaBits, options.curve, options.config);
-  await secretKeyPacket.computeKeyFingerprintAndID();
+  await secretKeyPacket.computeFingerprintAndKeyID();
   return secretKeyPacket;
 }
 

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -21,6 +21,7 @@ export async function generateSecretSubkey(options, config) {
   secretSubkeyPacket.packets = null;
   secretSubkeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
   await secretSubkeyPacket.generate(options.rsaBits, options.curve);
+  await secretSubkeyPacket.computeKeyFingerprintAndID();
   return secretSubkeyPacket;
 }
 
@@ -29,6 +30,7 @@ export async function generateSecretKey(options, config) {
   secretKeyPacket.packets = null;
   secretKeyPacket.algorithm = enums.read(enums.publicKey, options.algorithm);
   await secretKeyPacket.generate(options.rsaBits, options.curve, options.config);
+  await secretKeyPacket.computeKeyFingerprintAndID();
   return secretKeyPacket;
 }
 

--- a/src/message.js
+++ b/src/message.js
@@ -694,7 +694,7 @@ export async function createSignaturePackets(literalDataPacket, privateKeys, sig
 
 /**
  * Create object containing signer's keyID and validity of signature
- * @param {SignaturePacket} signature - Signature packets
+ * @param {SignaturePacket} signature - Signature packet
  * @param {Array<LiteralDataPacket>} literalDataList - Array of literal data packets
  * @param {Array<Key>} keys - Array of keys to verify signatures
  * @param {Date} date - Verify the signature against the given date,

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -83,6 +83,7 @@ export function generateKey({ userIDs = [], passphrase = "", type = "ecc", rsaBi
  * @param {Object|Array<Object>} options.userIDs - User IDs as objects: `{ name: 'Jo Doe', email: 'info@jo.com' }`
  * @param {String} [options.passphrase=(not protected)] - The passphrase used to encrypt the generated private key
  * @param {Number} [options.keyExpirationTime=0 (never expires)] - Number of seconds from the key creation time after which the key expires
+ * @param {Date}   [options.date] - Override the creation date of the key signatures
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object>} The generated key object in the form:
  *                                     { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -134,7 +134,7 @@ class PublicKeyPacket {
       }
 
       // we set the fingerprint and keyID already to make it possible to put together the key packets directly in the Key constructor
-      await this.computeKeyFingerprintAndID();
+      await this.computeFingerprintAndKeyID();
       return pos;
     }
     throw new Error('Version ' + this.version + ' of the key packet is unsupported.');
@@ -204,7 +204,7 @@ class PublicKeyPacket {
    * Computes and set the key ID and fingerprint of the key
    * @async
    */
-  async computeKeyFingerprintAndID() {
+  async computeFingerprintAndKeyID() {
     await this.computeFingerprint();
     this.keyID = new KeyID();
 

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -219,7 +219,6 @@ class PublicKeyPacket {
 
   /**
    * Computes and set the fingerprint of the key
-   * @returns {Uint8Array} A Uint8Array containing the fingerprint
    */
   async computeFingerprint() {
     const toHash = this.writeForHash(this.version);

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -17,8 +17,6 @@
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["isDecrypted"] }] */
 
-import { Sha1 } from '@openpgp/asmcrypto.js/dist_es8/hash/sha1/sha1';
-import { Sha256 } from '@openpgp/asmcrypto.js/dist_es8/hash/sha256/sha256';
 import KeyID from '../type/keyid';
 import defaultConfig from '../config';
 import crypto from '../crypto';
@@ -72,8 +70,8 @@ class PublicKeyPacket {
      */
     this.expirationTimeV3 = 0;
     /**
-     * Fingerprint in lowercase hex
-     * @type {String}
+     * Fingerprint bytes
+     * @type {Uint8Array}
      */
     this.fingerprint = null;
     /**
@@ -84,12 +82,30 @@ class PublicKeyPacket {
   }
 
   /**
-   * Internal Parser for public keys as specified in {@link https://tools.ietf.org/html/rfc4880#section-5.5.2|RFC 4880 section 5.5.2 Public-Key Packet Formats}
-   * called by read_tag&lt;num&gt;
-   * @param {Uint8Array} bytes - Input array to read the packet from
-   * @returns {Object} This object with attributes set by the parser.
+   * Create a PublicKeyPacket from a SecretKeyPacket
+   * @param {SecretKeyPacket} secretKeyPacket - key packet to convert
+   * @returns {PublicKeyPacket} public key packet
+   * @static
    */
-  read(bytes) {
+  static fromSecretKeyPacket(secretKeyPacket) {
+    const keyPacket = new PublicKeyPacket();
+    const { version, created, algorithm, publicParams, keyID, fingerprint } = secretKeyPacket;
+    keyPacket.version = version;
+    keyPacket.created = created;
+    keyPacket.algorithm = algorithm;
+    keyPacket.publicParams = publicParams;
+    keyPacket.keyID = keyID;
+    keyPacket.fingerprint = fingerprint;
+    return keyPacket;
+  }
+
+  /**
+   * Internal Parser for public keys as specified in {@link https://tools.ietf.org/html/rfc4880#section-5.5.2|RFC 4880 section 5.5.2 Public-Key Packet Formats}
+   * @param {Uint8Array} bytes - Input array to read the packet from
+   * @returns {Object} This object with attributes set by the parser
+   * @async
+   */
+  async read(bytes) {
     let pos = 0;
     // A one-octet version number (3, 4 or 5).
     this.version = bytes[pos++];
@@ -117,6 +133,8 @@ class PublicKeyPacket {
         throw new Error('Error reading MPIs');
       }
 
+      // we set the fingerprint and keyID already to make it possible to put together the key packets directly in the Key constructor
+      await this.computeKeyFingerprintAndID();
       return pos;
     }
     throw new Error('Version ' + this.version + ' of the key packet is unsupported.');
@@ -146,7 +164,8 @@ class PublicKeyPacket {
   }
 
   /**
-   * Write packet in order to be hashed; either for a signature or a fingerprint.
+   * Write packet in order to be hashed; either for a signature or a fingerprint
+   * @param {Integer} version - target version of signature or key
    */
   writeForHash(version) {
     const bytes = this.writePublicKey();
@@ -174,42 +193,57 @@ class PublicKeyPacket {
   }
 
   /**
-   * Calculates the key id of the key
-   * @returns {module:type/keyid~KeyID} A 8 byte key id.
+   * Return the key ID of the key
+   * @returns {module:type/keyid~KeyID} The 8-byte key ID
    */
   getKeyID() {
-    if (this.keyID) {
-      return this.keyID;
-    }
-    this.keyID = new KeyID();
-    if (this.version === 5) {
-      this.keyID.read(util.hexToUint8Array(this.getFingerprint()).subarray(0, 8));
-    } else if (this.version === 4) {
-      this.keyID.read(util.hexToUint8Array(this.getFingerprint()).subarray(12, 20));
-    }
     return this.keyID;
   }
 
   /**
-   * Calculates the fingerprint of the key
-   * @returns {Uint8Array} A Uint8Array containing the fingerprint.
+   * Computes and set the key ID and fingerprint of the key
+   * @async
+   */
+  async computeKeyFingerprintAndID() {
+    await this.computeFingerprint();
+    this.keyID = new KeyID();
+
+    if (this.version === 5) {
+      this.keyID.read(this.fingerprint.subarray(0, 8));
+    } else if (this.version === 4) {
+      this.keyID.read(this.fingerprint.subarray(12, 20));
+    } else {
+      throw new Error('Unsupported key version');
+    }
+  }
+
+  /**
+   * Computes and set the fingerprint of the key
+   * @returns {Uint8Array} A Uint8Array containing the fingerprint
+   */
+  async computeFingerprint() {
+    const toHash = this.writeForHash(this.version);
+
+    if (this.version === 5) {
+      this.fingerprint = await crypto.hash.sha256(toHash);
+    } else if (this.version === 4) {
+      this.fingerprint = await crypto.hash.sha1(toHash);
+    } else {
+      throw new Error('Unsupported key version');
+    }
+  }
+
+  /**
+   * Returns the fingerprint of the key, as an array of bytes
+   * @returns {Uint8Array} A Uint8Array containing the fingerprint
    */
   getFingerprintBytes() {
-    if (this.fingerprint) {
-      return this.fingerprint;
-    }
-    const toHash = this.writeForHash(this.version);
-    if (this.version === 5) {
-      this.fingerprint = Sha256.bytes(toHash);
-    } else if (this.version === 4) {
-      this.fingerprint = Sha1.bytes(toHash);
-    }
     return this.fingerprint;
   }
 
   /**
-   * Calculates the fingerprint of the key
-   * @returns {String} A string containing the fingerprint in lowercase hex.
+   * Calculates and returns the fingerprint of the key, as a string
+   * @returns {String} A string containing the fingerprint in lowercase hex
    */
   getFingerprint() {
     return util.uint8ArrayToHex(this.getFingerprintBytes());

--- a/src/packet/public_subkey.js
+++ b/src/packet/public_subkey.js
@@ -39,6 +39,24 @@ class PublicSubkeyPacket extends PublicKeyPacket {
   constructor(date, config) {
     super(date, config);
   }
+
+  /**
+   * Create a PublicSubkeyPacket from a SecretSubkeyPacket
+   * @param {SecretSubkeyPacket} secretSubkeyPacket - subkey packet to convert
+   * @returns {SecretSubkeyPacket} public key packet
+   * @static
+   */
+  static fromSecretSubkeyPacket(secretSubkeyPacket) {
+    const keyPacket = new PublicSubkeyPacket();
+    const { version, created, algorithm, publicParams, keyID, fingerprint } = secretSubkeyPacket;
+    keyPacket.version = version;
+    keyPacket.created = created;
+    keyPacket.algorithm = algorithm;
+    keyPacket.publicParams = publicParams;
+    keyPacket.keyID = keyID;
+    keyPacket.fingerprint = fingerprint;
+    return keyPacket;
+  }
 }
 
 export default PublicSubkeyPacket;

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -80,10 +80,11 @@ class SecretKeyPacket extends PublicKeyPacket {
    * Internal parser for private keys as specified in
    * {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.5.3|RFC4880bis-04 section 5.5.3}
    * @param {String} bytes - Input string to read the packet from
+   * @async
    */
-  read(bytes) {
+  async read(bytes) {
     // - A Public-Key or Public-Subkey packet, as described above.
-    let i = this.readPublicKey(bytes);
+    let i = await this.readPublicKey(bytes);
 
     // - One octet indicating string-to-key usage conventions.  Zero
     //   indicates that the secret-key data is not encrypted.  255 or 254

--- a/test/crypto/validate.js
+++ b/test/crypto/validate.js
@@ -74,9 +74,9 @@ vqBGKJzmO5q3cECw
 =X9kJ
 -----END PGP PRIVATE KEY BLOCK-----`;
 
-function cloneKeyPacket(key) {
+async function cloneKeyPacket(key) {
   const keyPacket = new openpgp.SecretKeyPacket();
-  keyPacket.read(key.keyPacket.write());
+  await keyPacket.read(key.keyPacket.write());
   return keyPacket;
 }
 
@@ -93,7 +93,7 @@ module.exports = () => {
     });
 
     it('detect invalid edDSA Q', async function() {
-      const eddsaKeyPacket = cloneKeyPacket(eddsaKey);
+      const eddsaKeyPacket = await cloneKeyPacket(eddsaKey);
       const Q = eddsaKeyPacket.publicParams.Q;
       Q[0]++;
       await expect(eddsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -118,7 +118,7 @@ module.exports = () => {
       const { oid, Q } = eddsaKey.keyPacket.publicParams;
       const { seed } = eddsaKey.keyPacket.privateParams;
 
-      const ecdhKeyPacket = cloneKeyPacket(ecdhKey);
+      const ecdhKeyPacket = await cloneKeyPacket(ecdhKey);
       const ecdhOID = ecdhKeyPacket.publicParams.oid;
 
       ecdhKeyPacket.publicParams.oid = oid;
@@ -130,11 +130,11 @@ module.exports = () => {
       await expect(ecdhKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
-    it('EdDSA params are not valid for EcDSA', async function() {
+    it('EdDSA params are not valid for ECDSA', async function() {
       const { oid, Q } = eddsaKey.keyPacket.publicParams;
       const { seed } = eddsaKey.keyPacket.privateParams;
 
-      const ecdsaKeyPacket = cloneKeyPacket(ecdsaKey);
+      const ecdsaKeyPacket = await cloneKeyPacket(ecdsaKey);
       const ecdsaOID = ecdsaKeyPacket.publicParams.oid;
       ecdsaKeyPacket.publicParams.oid = oid;
       await expect(ecdsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -145,22 +145,22 @@ module.exports = () => {
       await expect(ecdsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
-    it('ECDH x25519 params are not valid for EcDSA', async function() {
+    it('ECDH x25519 params are not valid for ECDSA', async function() {
       const { oid, Q } = ecdhKey.keyPacket.publicParams;
       const { d } = ecdhKey.keyPacket.privateParams;
 
-      const ecdsaKeyPacket = cloneKeyPacket(ecdsaKey);
+      const ecdsaKeyPacket = await cloneKeyPacket(ecdsaKey);
       ecdsaKeyPacket.publicParams.oid = oid;
       ecdsaKeyPacket.publicParams.Q = Q;
       ecdsaKeyPacket.privateParams.d = d;
       await expect(ecdsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
-    it('EcDSA params are not valid for EdDSA', async function() {
+    it('ECDSA params are not valid for EdDSA', async function() {
       const { oid, Q } = ecdsaKey.keyPacket.publicParams;
       const { d } = ecdsaKey.keyPacket.privateParams;
 
-      const eddsaKeyPacket = cloneKeyPacket(eddsaKey);
+      const eddsaKeyPacket = await cloneKeyPacket(eddsaKey);
       const eddsaOID = eddsaKeyPacket.publicParams.oid;
       eddsaKeyPacket.publicParams.oid = oid;
       await expect(eddsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -175,7 +175,7 @@ module.exports = () => {
       const { oid, Q } = ecdhKey.keyPacket.publicParams;
       const { d } = ecdhKey.keyPacket.privateParams;
 
-      const eddsaKeyPacket = cloneKeyPacket(eddsaKey);
+      const eddsaKeyPacket = await cloneKeyPacket(eddsaKey);
       const eddsaOID = eddsaKeyPacket.publicParams.oid;
       eddsaKeyPacket.publicParams.oid = oid;
       await expect(eddsaKeyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -202,7 +202,7 @@ module.exports = () => {
         }
       });
 
-      it(`EcDSA ${curve} params should be valid`, async function() {
+      it(`ECDSA ${curve} params should be valid`, async function() {
         if (!ecdsaKey) {
           this.skip();
         }
@@ -213,7 +213,7 @@ module.exports = () => {
         if (!ecdsaKey) {
           this.skip();
         }
-        const keyPacket = cloneKeyPacket(ecdsaKey);
+        const keyPacket = await cloneKeyPacket(ecdsaKey);
         const Q = keyPacket.publicParams.Q;
         Q[16]++;
         await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -228,7 +228,7 @@ module.exports = () => {
       });
 
       it(`ECDH ${curve} - detect invalid Q`, async function() {
-        const keyPacket = cloneKeyPacket(ecdhKey);
+        const keyPacket = await cloneKeyPacket(ecdhKey);
         const Q = keyPacket.publicParams.Q;
         Q[16]++;
         await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -252,14 +252,14 @@ module.exports = () => {
     });
 
     it('detect invalid RSA n', async function() {
-      const keyPacket = cloneKeyPacket(rsaKey);
+      const keyPacket = await cloneKeyPacket(rsaKey);
       const n = keyPacket.publicParams.n;
       n[0]++;
       await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
     it('detect invalid RSA e', async function() {
-      const keyPacket = cloneKeyPacket(rsaKey);
+      const keyPacket = await cloneKeyPacket(rsaKey);
       const e = keyPacket.publicParams.e;
       e[0]++;
       await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
@@ -277,14 +277,14 @@ module.exports = () => {
     });
 
     it('detect invalid DSA p', async function() {
-      const keyPacket = cloneKeyPacket(dsaKey);
+      const keyPacket = await cloneKeyPacket(dsaKey);
       const p = keyPacket.publicParams.p;
       p[0]++;
       await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
     it('detect invalid DSA y', async function() {
-      const keyPacket = cloneKeyPacket(dsaKey);
+      const keyPacket = await cloneKeyPacket(dsaKey);
       const y = keyPacket.publicParams.y;
 
       y[0]++;
@@ -292,7 +292,7 @@ module.exports = () => {
     });
 
     it('detect invalid DSA g', async function() {
-      const keyPacket = cloneKeyPacket(dsaKey);
+      const keyPacket = await cloneKeyPacket(dsaKey);
       const g = keyPacket.publicParams.g;
 
       g[0]++;
@@ -314,21 +314,21 @@ module.exports = () => {
     });
 
     it('detect invalid p', async function() {
-      const keyPacket = cloneKeyPacket(egKey);
+      const keyPacket = await cloneKeyPacket(egKey);
       const p = keyPacket.publicParams.p;
       p[0]++;
       await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
     it('detect invalid y', async function() {
-      const keyPacket = cloneKeyPacket(egKey);
+      const keyPacket = await cloneKeyPacket(egKey);
       const y = keyPacket.publicParams.y;
       y[0]++;
       await expect(keyPacket.validate()).to.be.rejectedWith('Key is invalid');
     });
 
     it('detect invalid g', async function() {
-      const keyPacket = cloneKeyPacket(egKey);
+      const keyPacket = await cloneKeyPacket(egKey);
       const g = keyPacket.publicParams.g;
 
       g[0]++;
@@ -339,7 +339,7 @@ module.exports = () => {
     });
 
     it('detect g with small order', async function() {
-      const keyPacket = cloneKeyPacket(egKey);
+      const keyPacket = await cloneKeyPacket(egKey);
       const p = keyPacket.publicParams.p;
       const g = keyPacket.publicParams.g;
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -822,7 +822,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       return openpgp.decryptKey({
         privateKey: privateKey,
         passphrase: passphrase
-      }).then(function(unlocked){
+      }).then(unlocked => {
         expect(unlocked.getKeyID().toHex()).to.equal(privateKey.getKeyID().toHex());
         expect(unlocked.subKeys[0].getKeyID().toHex()).to.equal(privateKey.subKeys[0].getKeyID().toHex());
         expect(unlocked.isDecrypted()).to.be.true;
@@ -830,7 +830,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         // original key should be unchanged
         expect(privateKey.isDecrypted()).to.be.false;
         expect(privateKey.keyPacket.privateParams).to.be.null;
-        originalKey.subKeys[0].getKeyID(); // fill in keyID
         expect(privateKey).to.deep.equal(originalKey);
       });
     });
@@ -841,7 +840,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       return openpgp.decryptKey({
         privateKey: privateKey,
         passphrase: ['rubbish', passphrase]
-      }).then(function(unlocked){
+      }).then(unlocked => {
         expect(unlocked.getKeyID().toHex()).to.equal(privateKey.getKeyID().toHex());
         expect(unlocked.subKeys[0].getKeyID().toHex()).to.equal(privateKey.subKeys[0].getKeyID().toHex());
         expect(unlocked.isDecrypted()).to.be.true;
@@ -849,7 +848,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         // original key should be unchanged
         expect(privateKey.isDecrypted()).to.be.false;
         expect(privateKey.keyPacket.privateParams).to.be.null;
-        originalKey.subKeys[0].getKeyID(); // fill in keyID
         expect(privateKey).to.deep.equal(originalKey);
       });
     });
@@ -897,7 +895,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       return openpgp.encryptKey({
         privateKey: key,
         passphrase: passphrase
-      }).then(function(locked){
+      }).then(locked => {
         expect(locked.getKeyID().toHex()).to.equal(key.getKeyID().toHex());
         expect(locked.subKeys[0].getKeyID().toHex()).to.equal(key.subKeys[0].getKeyID().toHex());
         expect(locked.isDecrypted()).to.be.false;
@@ -905,7 +903,6 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         // original key should be unchanged
         expect(key.isDecrypted()).to.be.true;
         expect(key.keyPacket.privateParams).to.not.be.null;
-        originalKey.subKeys[0].getKeyID(); // fill in keyID
         expect(key).to.deep.equal(originalKey);
       });
     });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -927,12 +927,13 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
     const rsa = openpgp.enums.publicKey.rsaEncryptSign;
     const key = new openpgp.SecretKeyPacket();
 
-    return crypto.generateParams(rsa, 1024, 65537).then(function({ privateParams, publicParams }) {
+    return crypto.generateParams(rsa, 1024, 65537).then(async ({ privateParams, publicParams }) => {
       const testText = input.createSomeMessage();
 
       key.publicParams = publicParams;
       key.privateParams = privateParams;
       key.algorithm = "rsaSign";
+      await key.computeKeyFingerprintAndID();
 
       const signed = new openpgp.PacketList();
       const literal = new openpgp.LiteralDataPacket();

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -933,7 +933,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
       key.publicParams = publicParams;
       key.privateParams = privateParams;
       key.algorithm = "rsaSign";
-      await key.computeKeyFingerprintAndID();
+      await key.computeFingerprintAndKeyID();
 
       const signed = new openpgp.PacketList();
       const literal = new openpgp.LiteralDataPacket();


### PR DESCRIPTION
Close #961, changes : 
- make fingerprint and keyID computation async, and rely on webCrypto for hashing if available
- always set fingerprint and keyID on key parsing/generation
- introduce `*KeyPacket.computeFingerprint()` and `KeyPacket.computeFingerprintAndID()` 
- change `getKeyID` and `getFingerprint*` functions to only return data
- `PublicKeyPacket.read` is now async

