### PR TITLE
Do not consider `config.tolerant` for parsing errors

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -366,10 +366,10 @@ export class AEADEncryptedDataPacket extends BasePacket {
   private crypt(fn: Function, sessionKey: Uint8Array, data: MaybeStream<Uint8Array>): MaybeStream<Uint8Array>
 }
 
-export class PublicKeyEncryptedSessionKeyPaclet extends BasePacket {
+export class PublicKeyEncryptedSessionKeyPacket extends BasePacket {
   static readonly tag: enums.packet.publicKeyEncryptedSessionKey;
-  private decrypt(keyPacket: SecretKeyPacket): Promise<true>; // throws on error
-  private encrypt(keyPacket: PublicKeyPacket): Promise<true>; // throws on error
+  private decrypt(keyPacket: SecretKeyPacket): void; // throws on error
+  private encrypt(keyPacket: PublicKeyPacket): void; // throws on error
 }
 
 export class SymEncryptedSessionKey extends BasePacket {

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -20,6 +20,7 @@ import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
 import defaultConfig from '../config';
+import { UnsupportedPacketError } from './packet';
 
 import LiteralDataPacket from './literal_data';
 import CompressedDataPacket from './compressed_data';
@@ -66,8 +67,9 @@ class AEADEncryptedDataPacket {
    */
   async read(bytes) {
     await stream.parse(bytes, async reader => {
-      if (await reader.readByte() !== VERSION) { // The only currently defined value is 1.
-        throw new Error('Invalid packet version.');
+      const version = await reader.readByte();
+      if (version !== VERSION) { // The only currently defined value is 1.
+        throw new UnsupportedPacketError(`Version ${version} of the AEAD-encrypted data packet is not supported.`);
       }
       this.cipherAlgo = await reader.readByte();
       this.aeadAlgo = await reader.readByte();

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -20,7 +20,7 @@ import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
 import defaultConfig from '../config';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 import LiteralDataPacket from './literal_data';
 import CompressedDataPacket from './compressed_data';
@@ -69,7 +69,7 @@ class AEADEncryptedDataPacket {
     await stream.parse(bytes, async reader => {
       const version = await reader.readByte();
       if (version !== VERSION) { // The only currently defined value is 1.
-        throw new UnsupportedPacketError(`Version ${version} of the AEAD-encrypted data packet is not supported.`);
+        throw new UnsupportedError(`Version ${version} of the AEAD-encrypted data packet is not supported.`);
       }
       this.cipherAlgo = await reader.readByte();
       this.aeadAlgo = await reader.readByte();

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -20,6 +20,9 @@ import SignaturePacket from './signature';
 import KeyID from '../type/keyid';
 import enums from '../enums';
 import util from '../util';
+import { UnsupportedPacketError } from './packet';
+
+const VERSION = 3;
 
 /**
  * Implementation of the One-Pass Signature Packets (Tag 4)
@@ -74,6 +77,9 @@ class OnePassSignaturePacket {
     let mypos = 0;
     // A one-octet version number.  The current version is 3.
     this.version = bytes[mypos++];
+    if (this.version !== VERSION) {
+      throw new UnsupportedPacketError(`Version ${this.version} of the one-pass signature packet is unsupported.`);
+    }
 
     // A one-octet signature type.  Signature types are described in
     //   Section 5.2.1.

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -20,7 +20,7 @@ import SignaturePacket from './signature';
 import KeyID from '../type/keyid';
 import enums from '../enums';
 import util from '../util';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 const VERSION = 3;
 
@@ -78,7 +78,7 @@ class OnePassSignaturePacket {
     // A one-octet version number.  The current version is 3.
     this.version = bytes[mypos++];
     if (this.version !== VERSION) {
-      throw new UnsupportedPacketError(`Version ${this.version} of the one-pass signature packet is unsupported.`);
+      throw new UnsupportedError(`Version ${this.version} of the one-pass signature packet is unsupported.`);
     }
 
     // A one-octet signature type.  Signature types are described in

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -297,17 +297,15 @@ export async function readPackets(input, callback) {
   }
 }
 
-export class UnsupportedPacketError extends Error {
+export class UnsupportedError extends Error {
   constructor(...params) {
     super(...params);
-    this.name = 'UnsupportedPacketError';
-  }
-}
 
-export class UnknownPacketError extends Error {
-  constructor(...params) {
-    super(...params);
-    this.name = 'UnknownPacketError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnsupportedError);
+    }
+
+    this.name = 'UnsupportedError';
   }
 }
 

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -97,17 +97,17 @@ export function writeHeader(tag_type, length) {
 
 /**
  * Whether the packet type supports partial lengths per RFC4880
- * @param {Integer} tag_type - Tag type
+ * @param {Integer} tag - Tag type
  * @returns {Boolean} String of the header.
  */
-export function supportsStreaming(tag_type) {
+export function supportsStreaming(tag) {
   return [
     enums.packet.literalData,
     enums.packet.compressedData,
     enums.packet.symmetricallyEncryptedData,
     enums.packet.symEncryptedIntegrityProtectedData,
     enums.packet.aeadEncryptedData
-  ].includes(tag_type);
+  ].includes(tag);
 }
 
 /**
@@ -296,3 +296,18 @@ export async function readPackets(input, callback) {
     reader.releaseLock();
   }
 }
+
+export class UnsupportedPacketError extends Error {
+  constructor(...params) {
+    super(...params);
+    this.name = 'UnsupportedPacketError';
+  }
+}
+
+export class UnknownPacketError extends Error {
+  constructor(...params) {
+    super(...params);
+    this.name = 'UnknownPacketError';
+  }
+}
+

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -3,7 +3,7 @@ import {
   readPackets, supportsStreaming,
   writeTag, writeHeader,
   writePartialLength, writeSimpleLength,
-  UnsupportedPacketError, UnknownPacketError
+  UnsupportedError
 } from './packet';
 import util from '../util';
 import enums from '../enums';
@@ -23,9 +23,9 @@ export function newPacketFromTag(tag, allowedPackets) {
     try {
       packetType = enums.read(enums.packet, tag);
     } catch (e) {
-      throw new UnknownPacketError(`Unknown packet type with tag: ${tag}`);
+      throw new UnsupportedError(`Unknown packet type with tag: ${tag}`);
     }
-    throw new UnsupportedPacketError(`Packet not allowed in this context: ${packetType}`);
+    throw new UnsupportedError(`Packet not allowed in this context: ${packetType}`);
   }
   return new allowedPackets[tag]();
 }
@@ -75,7 +75,7 @@ class PacketList extends Array {
               await packet.read(parsed.packet, config);
               await writer.write(packet);
             } catch (e) {
-              const isTolerableError = config.tolerant && (e instanceof UnknownPacketError || e instanceof UnsupportedPacketError);
+              const isTolerableError = config.tolerant && e instanceof UnsupportedError;
               if (!isTolerableError || supportsStreaming(parsed.tag)) {
                 // The packets that support streaming are the ones that contain message data.
                 // Those are also the ones we want to be more strict about and throw on parse errors

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -21,7 +21,7 @@ export function newPacketFromTag(tag, allowedPackets) {
     // distinguish between disallowed packets and unknown ones
     let packetType;
     try {
-      packetType = enums.read(enums.packets, tag);
+      packetType = enums.read(enums.packet, tag);
     } catch (e) {
       throw new UnknownPacketError(`Unknown packet type with tag: ${tag}`);
     }

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -22,6 +22,7 @@ import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
+import { UnsupportedPacketError } from './packet';
 
 /**
  * Implementation of the Key Material Packet (Tag 5,6,7,14)
@@ -137,7 +138,7 @@ class PublicKeyPacket {
       await this.computeFingerprintAndKeyID();
       return pos;
     }
-    throw new Error('Version ' + this.version + ' of the key packet is unsupported.');
+    throw new UnsupportedPacketError(`Version ${this.version} of the key packet is unsupported.`);
   }
 
   /**

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -22,7 +22,7 @@ import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 /**
  * Implementation of the Key Material Packet (Tag 5,6,7,14)
@@ -138,7 +138,7 @@ class PublicKeyPacket {
       await this.computeFingerprintAndKeyID();
       return pos;
     }
-    throw new UnsupportedPacketError(`Version ${this.version} of the key packet is unsupported.`);
+    throw new UnsupportedError(`Version ${this.version} of the key packet is unsupported.`);
   }
 
   /**

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -19,6 +19,9 @@ import KeyID from '../type/keyid';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
+import { UnsupportedPacketError } from './packet';
+
+const VERSION = 3;
 
 /**
  * Public-Key Encrypted Session Key Packets (Tag 1)
@@ -61,6 +64,9 @@ class PublicKeyEncryptedSessionKeyPacket {
    */
   read(bytes) {
     this.version = bytes[0];
+    if (this.version !== VERSION) {
+      throw new UnsupportedPacketError(`Version ${this.version} of the PKESK packet is unsupported.`);
+    }
     this.publicKeyID.read(bytes.subarray(1, bytes.length));
     this.publicKeyAlgorithm = enums.read(enums.publicKey, bytes[9]);
 

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -89,7 +89,7 @@ class PublicKeyEncryptedSessionKeyPacket {
   /**
    * Encrypt session key packet
    * @param {PublicKeyPacket} key - Public key
-   * @returns {Promise<Boolean>}
+   * @throws {Error} if encryption failed
    * @async
    */
   async encrypt(key) {
@@ -101,16 +101,13 @@ class PublicKeyEncryptedSessionKeyPacket {
     const algo = enums.write(enums.publicKey, this.publicKeyAlgorithm);
     this.encrypted = await crypto.publicKeyEncrypt(
       algo, key.publicParams, data, key.getFingerprintBytes());
-    return true;
   }
 
   /**
    * Decrypts the session key (only for public key encrypted session key
    * packets (tag 1)
-   *
-   * @param {SecretKeyPacket} key
-   *            Private key with secret params unlocked
-   * @returns {Promise<Boolean>}
+   * @param {SecretKeyPacket} key - decrypted private key
+   * @throws {Error} if decryption failed
    * @async
    */
   async decrypt(key) {
@@ -129,7 +126,6 @@ class PublicKeyEncryptedSessionKeyPacket {
       this.sessionKey = sessionKey;
       this.sessionKeyAlgorithm = enums.read(enums.symmetric, decoded[0]);
     }
-    return true;
   }
 }
 

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -19,7 +19,7 @@ import KeyID from '../type/keyid';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 const VERSION = 3;
 
@@ -65,7 +65,7 @@ class PublicKeyEncryptedSessionKeyPacket {
   read(bytes) {
     this.version = bytes[0];
     if (this.version !== VERSION) {
-      throw new UnsupportedPacketError(`Version ${this.version} of the PKESK packet is unsupported.`);
+      throw new UnsupportedError(`Version ${this.version} of the PKESK packet is unsupported.`);
     }
     this.publicKeyID.read(bytes.subarray(1, bytes.length));
     this.publicKeyAlgorithm = enums.read(enums.publicKey, bytes[9]);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -16,7 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import * as stream from '@openpgp/web-stream-tools';
-import { readSimpleLength, writeSimpleLength } from './packet';
+import { readSimpleLength, UnsupportedPacketError, writeSimpleLength } from './packet';
 import KeyID from '../type/keyid.js';
 import crypto from '../crypto';
 import enums from '../enums';
@@ -99,7 +99,7 @@ class SignaturePacket {
     this.version = bytes[i++];
 
     if (this.version !== 4 && this.version !== 5) {
-      throw new Error('Version ' + this.version + ' of the signature is unsupported.');
+      throw new UnsupportedPacketError(`Version ${this.version} of the signature packet is unsupported.`);
     }
 
     this.signatureType = bytes[i++];

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -16,7 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import * as stream from '@openpgp/web-stream-tools';
-import { readSimpleLength, UnsupportedPacketError, writeSimpleLength } from './packet';
+import { readSimpleLength, UnsupportedError, writeSimpleLength } from './packet';
 import KeyID from '../type/keyid.js';
 import crypto from '../crypto';
 import enums from '../enums';
@@ -99,7 +99,7 @@ class SignaturePacket {
     this.version = bytes[i++];
 
     if (this.version !== 4 && this.version !== 5) {
-      throw new UnsupportedPacketError(`Version ${this.version} of the signature packet is unsupported.`);
+      throw new UnsupportedError(`Version ${this.version} of the signature packet is unsupported.`);
     }
 
     this.signatureType = bytes[i++];

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -26,7 +26,7 @@ import CompressedDataPacket from './compressed_data';
 import OnePassSignaturePacket from './one_pass_signature';
 import SignaturePacket from './signature';
 import PacketList from './packetlist';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 // A SEIP packet can contain the following packet types
 const allowedPackets = /*#__PURE__*/ util.constructAllowedPackets([
@@ -64,7 +64,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
       const version = await reader.readByte();
       // - A one-octet version number. The only currently defined value is 1.
       if (version !== VERSION) {
-        throw new UnsupportedPacketError(`Version ${version} of the SEIP packet is unsupported.`);
+        throw new UnsupportedError(`Version ${version} of the SEIP packet is unsupported.`);
       }
 
       // - Encrypted data, the output of the selected symmetric-key cipher

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -26,6 +26,7 @@ import CompressedDataPacket from './compressed_data';
 import OnePassSignaturePacket from './one_pass_signature';
 import SignaturePacket from './signature';
 import PacketList from './packetlist';
+import { UnsupportedPacketError } from './packet';
 
 // A SEIP packet can contain the following packet types
 const allowedPackets = /*#__PURE__*/ util.constructAllowedPackets([
@@ -60,10 +61,10 @@ class SymEncryptedIntegrityProtectedDataPacket {
 
   async read(bytes) {
     await stream.parse(bytes, async reader => {
-
+      const version = await reader.readByte();
       // - A one-octet version number. The only currently defined value is 1.
-      if (await reader.readByte() !== VERSION) {
-        throw new Error('Invalid packet version.');
+      if (version !== VERSION) {
+        throw new UnsupportedPacketError(`Version ${version} of the SEIP packet is unsupported.`);
       }
 
       // - Encrypted data, the output of the selected symmetric-key cipher

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -20,7 +20,7 @@ import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 /**
  * Symmetric-Key Encrypted Session Key Packets (Tag 3)
@@ -65,7 +65,7 @@ class SymEncryptedSessionKeyPacket {
     // A one-octet version number. The only currently defined version is 4.
     this.version = bytes[offset++];
     if (this.version !== 4 && this.version !== 5) {
-      throw new UnsupportedPacketError(`Version ${this.version} of the SKESK packet is unsupported.`);
+      throw new UnsupportedError(`Version ${this.version} of the SKESK packet is unsupported.`);
     }
 
     // A one-octet number describing the symmetric algorithm used.

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -20,6 +20,7 @@ import defaultConfig from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
+import { UnsupportedPacketError } from './packet';
 
 /**
  * Symmetric-Key Encrypted Session Key Packets (Tag 3)
@@ -63,6 +64,9 @@ class SymEncryptedSessionKeyPacket {
 
     // A one-octet version number. The only currently defined version is 4.
     this.version = bytes[offset++];
+    if (this.version !== 4 && this.version !== 5) {
+      throw new UnsupportedPacketError(`Version ${this.version} of the SKESK packet is unsupported.`);
+    }
 
     // A one-octet number describing the symmetric algorithm used.
     const algo = enums.read(enums.symmetric, bytes[offset++]);

--- a/src/packet/trust.js
+++ b/src/packet/trust.js
@@ -1,6 +1,7 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["read"] }] */
 
 import enums from '../enums';
+import { UnsupportedPacketError } from './packet';
 
 /**
  * Implementation of the Trust Packet (Tag 12)
@@ -25,13 +26,14 @@ class TrustPacket {
   /**
    * Parsing function for a trust packet (tag 12).
    * Currently not implemented as we ignore trust packets
-   * @param {String} byptes - Payload of a tag 12 packet
    */
-  read() {} // TODO
+  read() {
+    throw new UnsupportedPacketError('Trust packets are not supported');
+  }
 
   // eslint-disable-next-line class-methods-use-this
   write() {
-    throw new Error('Trust packets are not supported');
+    throw new UnsupportedPacketError('Trust packets are not supported');
   }
 }
 

--- a/src/packet/trust.js
+++ b/src/packet/trust.js
@@ -1,7 +1,7 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["read"] }] */
 
 import enums from '../enums';
-import { UnsupportedPacketError } from './packet';
+import { UnsupportedError } from './packet';
 
 /**
  * Implementation of the Trust Packet (Tag 12)
@@ -28,12 +28,12 @@ class TrustPacket {
    * Currently not implemented as we ignore trust packets
    */
   read() {
-    throw new UnsupportedPacketError('Trust packets are not supported');
+    throw new UnsupportedError('Trust packets are not supported');
   }
 
   // eslint-disable-next-line class-methods-use-this
   write() {
-    throw new UnsupportedPacketError('Trust packets are not supported');
+    throw new UnsupportedError('Trust packets are not supported');
   }
 }
 

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -359,11 +359,4 @@ qDEdLyNWF30o6wD/fZYCV8aS4dAu2U3fpN5y5+PbuXFRYljA5gQ/1zrGN/UA
     await expect(sig4.valid).to.be.false;
     await expect(sig4.error).to.match(/eddsa keys are considered too weak/);
   });
-
-  it('tolerant mode still throws on parsing errors', async function () {
-    const { privateKeyArmored: armoredKey } = await openpgp.generateKey({ userIDs:[{ name:'test', email:'test@a.it' }] });
-    await expect(
-      openpgp.readKey({ armoredKey, config: { tolerant: true, maxUserIDLength: 2 } })
-    ).to.be.rejectedWith(/User ID string is too long/);
-  });
 });

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -360,4 +360,10 @@ qDEdLyNWF30o6wD/fZYCV8aS4dAu2U3fpN5y5+PbuXFRYljA5gQ/1zrGN/UA
     await expect(sig4.error).to.match(/eddsa keys are considered too weak/);
   });
 
+  it('tolerant mode still throws on parsing errors', async function () {
+    const { privateKeyArmored: armoredKey } = await openpgp.generateKey({ userIDs:[{ name:'test', email:'test@a.it' }] });
+    await expect(
+      openpgp.readKey({ armoredKey, config: { tolerant: true, maxUserIDLength: 2 } })
+    ).to.be.rejectedWith(/User ID string is too long/);
+  });
 });


### PR DESCRIPTION
Changes:
- if `config.tolerant` is enabled, unsupported and unknown packets are ignored, but parsing errors of known packets will still be thrown. This is helpful for debugging.
- (unrelated) make `PKESK.encrypt/decrypt` void, as a follow-up to #1191 

- [x] merge after #1294 