### PR TITLE
Replace publicKeys/privateKeys with encryptionKeys, decryptionKeys, signingKeys, and verificationKeys

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -249,9 +249,9 @@ export class Message<T extends MaybeStream<Data>> {
   public unwrapCompressed(): Message<T>;
 
   /** Verify message signatures
-      @param signingKeys array of public keys to verify signatures
+      @param verificationKeys array of public keys to verify signatures
   */
-  public verify(signingKeys: Key[], date?: Date, config?: Config): Promise<VerificationResult[]>;
+  public verify(verificationKeys: Key[], date?: Date, config?: Config): Promise<VerificationResult[]>;
 
   /**
    * Append signature to unencrypted message object

--- a/src/message.js
+++ b/src/message.js
@@ -359,7 +359,7 @@ export class Message {
    * @param {Uint8Array} sessionKey - session key for encryption
    * @param {String} algorithm - session key algorithm
    * @param {String} [aeadAlgorithm] - AEAD algorithm, e.g. 'eax' or 'ocb'
-   * @param {Array<Key>} [encryptionKeys] - Encryption key(s) for message encryption
+   * @param {Array<Key>} [encryptionKeys] - Public key(s) for message encryption
    * @param {Array<String>} [passwords] - For message encryption
    * @param {Boolean} [wildcard] - Use a key ID of 0 instead of the public key IDs
    * @param {Array<module:type/keyid~KeyID>} [encryptionKeyIDs] - Array of key IDs to use for encryption. Each encryptionKeyIDs[i] corresponds to encryptionKeys[i]

--- a/src/message.js
+++ b/src/message.js
@@ -533,7 +533,7 @@ export class Message {
 
   /**
    * Verify message signatures
-   * @param {Array<Key>} encryptionKeys - Array of public keys to verify signatures
+   * @param {Array<Key>} signingKeys - Array of public keys to verify signatures
    * @param {Date} [date] - Verify the signature against the given date, i.e. check signature creation time < date < expiration time
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{
@@ -543,7 +543,7 @@ export class Message {
    * }>>} List of signer's keyID and validity of signatures.
    * @async
    */
-  async verify(encryptionKeys, date = new Date(), config = defaultConfig) {
+  async verify(signingKeys, date = new Date(), config = defaultConfig) {
     const msg = this.unwrapCompressed();
     const literalDataList = msg.packets.filterByTag(enums.packet.literalData);
     if (literalDataList.length !== 1) {
@@ -582,14 +582,14 @@ export class Message {
           await writer.abort(e);
         }
       });
-      return createVerificationObjects(onePassSigList, literalDataList, encryptionKeys, date, false, config);
+      return createVerificationObjects(onePassSigList, literalDataList, signingKeys, date, false, config);
     }
-    return createVerificationObjects(signatureList, literalDataList, encryptionKeys, date, false, config);
+    return createVerificationObjects(signatureList, literalDataList, signingKeys, date, false, config);
   }
 
   /**
    * Verify detached message signature
-   * @param {Array<Key>} encryptionKeys - Array of public keys to verify signatures
+   * @param {Array<Key>} signingKeys - Array of public keys to verify signatures
    * @param {Signature} signature
    * @param {Date} date - Verify the signature against the given date, i.e. check signature creation time < date < expiration time
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
@@ -600,14 +600,14 @@ export class Message {
    * }>>} List of signer's keyID and validity of signature.
    * @async
    */
-  verifyDetached(signature, encryptionKeys, date = new Date(), config = defaultConfig) {
+  verifyDetached(signature, signingKeys, date = new Date(), config = defaultConfig) {
     const msg = this.unwrapCompressed();
     const literalDataList = msg.packets.filterByTag(enums.packet.literalData);
     if (literalDataList.length !== 1) {
       throw new Error('Can only verify message with one literal data packet.');
     }
     const signatureList = signature.packets;
-    return createVerificationObjects(signatureList, literalDataList, encryptionKeys, date, true, config);
+    return createVerificationObjects(signatureList, literalDataList, signingKeys, date, true, config);
   }
 
   /**
@@ -696,7 +696,7 @@ export async function createSignaturePackets(literalDataPacket, signingKeys, sig
  * Create object containing signer's keyID and validity of signature
  * @param {SignaturePacket} signature - Signature packet
  * @param {Array<LiteralDataPacket>} literalDataList - Array of literal data packets
- * @param {Array<Key>} encryptionKeys - Array of public keys to verify signatures
+ * @param {Array<Key>} signingKeys - Array of public keys to verify signatures
  * @param {Date} date - Verify the signature against the given date,
  *                    i.e. check signature creation time < date < expiration time
  * @param {Boolean} [detached] - Whether to verify detached signature packets
@@ -709,12 +709,12 @@ export async function createSignaturePackets(literalDataPacket, signingKeys, sig
  * @async
  * @private
  */
-async function createVerificationObject(signature, literalDataList, encryptionKeys, date = new Date(), detached = false, config = defaultConfig) {
+async function createVerificationObject(signature, literalDataList, signingKeys, date = new Date(), detached = false, config = defaultConfig) {
   let primaryKey;
   let signingKey;
   let keyError;
 
-  for (const key of encryptionKeys) {
+  for (const key of signingKeys) {
     const issuerKeys = key.getKeys(signature.issuerKeyID);
     if (issuerKeys.length > 0) {
       primaryKey = key;
@@ -772,7 +772,7 @@ async function createVerificationObject(signature, literalDataList, encryptionKe
  * Create list of objects containing signer's keyID and validity of signature
  * @param {Array<SignaturePacket>} signatureList - Array of signature packets
  * @param {Array<LiteralDataPacket>} literalDataList - Array of literal data packets
- * @param {Array<Key>} encryptionKeys - Array of public keys to verify signatures
+ * @param {Array<Key>} signingKeys - Array of public keys to verify signatures
  * @param {Date} date - Verify the signature against the given date,
  *                    i.e. check signature creation time < date < expiration time
  * @param {Boolean} [detached] - Whether to verify detached signature packets
@@ -785,11 +785,11 @@ async function createVerificationObject(signature, literalDataList, encryptionKe
  * @async
  * @private
  */
-export async function createVerificationObjects(signatureList, literalDataList, encryptionKeys, date = new Date(), detached = false, config = defaultConfig) {
+export async function createVerificationObjects(signatureList, literalDataList, signingKeys, date = new Date(), detached = false, config = defaultConfig) {
   return Promise.all(signatureList.filter(function(signature) {
     return ['text', 'binary'].includes(enums.read(enums.signature, signature.signatureType));
   }).map(async function(signature) {
-    return createVerificationObject(signature, literalDataList, encryptionKeys, date, detached, config);
+    return createVerificationObject(signature, literalDataList, signingKeys, date, detached, config);
   }));
 }
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -253,7 +253,7 @@ export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessi
   config = { ...defaultConfig, ...config };
   checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (detached) {
-    throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove signingKeys option as well.");
+    throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
   }
 
   return Promise.resolve().then(async function() {

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -228,47 +228,47 @@ export async function encryptKey({ privateKey, passphrase, config }) {
 
 
 /**
- * Encrypts message text/data with public keys, passwords or both at once. At least either public keys or passwords
- *   must be specified. If private keys are specified, those will be used to sign the message.
+ * Encrypts message text/data with public keys, passwords or both at once. At least either encryption keys or passwords
+ *   must be specified. If signing keys are specified, those will be used to sign the message.
  * @param {Object} options
  * @param {Message} options.message - Message to be encrypted as created by {@link createMessage}
- * @param {Key|Array<Key>} [options.publicKeys] - Array of keys or single key, used to encrypt the message
- * @param {Key|Array<Key>} [options.privateKeys] - Private keys for signing. If omitted message will not be signed
+ * @param {Key|Array<Key>} [options.encryptionKeys] - Array of keys or single key, used to encrypt the message
+ * @param {Key|Array<Key>} [options.signingKeys] - Private keys for signing. If omitted message will not be signed
  * @param {String|Array<String>} [options.passwords] - Array of passwords or a single password to encrypt the message
  * @param {Object} [options.sessionKey] - Session key in the form: `{ data:Uint8Array, algorithm:String }`
  * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
  * @param {Signature} [options.signature] - A detached signature to add to the encrypted message
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
- * @param {Array<module:type/keyid~KeyID>} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each `signingKeyIDs[i]` corresponds to `privateKeys[i]`
- * @param {Array<module:type/keyid~KeyID>} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each `encryptionKeyIDs[i]` corresponds to `publicKeys[i]`
+ * @param {Array<module:type/keyid~KeyID>} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each `signingKeyIDs[i]` corresponds to `signingKeys[i]`
+ * @param {Array<module:type/keyid~KeyID>} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each `encryptionKeyIDs[i]` corresponds to `encryptionKeys[i]`
  * @param {Date} [options.date=current date] - Override the creation date of the message signature
- * @param {Array<Object>} [options.fromUserIDs=primary user IDs] - Array of user IDs to sign with, one per key in `privateKeys`, e.g. `[{ name: 'Steve Sender', email: 'steve@openpgp.org' }]`
- * @param {Array<Object>} [options.toUserIDs=primary user IDs] - Array of user IDs to encrypt for, one per key in `publicKeys`, e.g. `[{ name: 'Robert Receiver', email: 'robert@openpgp.org' }]`
+ * @param {Array<Object>} [options.signingUserIDs=primary user IDs] - Array of user IDs to sign with, one per key in `signingKeys`, e.g. `[{ name: 'Steve Sender', email: 'steve@openpgp.org' }]`
+ * @param {Array<Object>} [options.encryptionUserIDs=primary user IDs] - Array of user IDs to encrypt for, one per key in `encryptionKeys`, e.g. `[{ name: 'Robert Receiver', email: 'robert@openpgp.org' }]`
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<String|ReadableStream<String>|NodeStream<String>|Uint8Array|ReadableStream<Uint8Array>|NodeStream<Uint8Array>>} Encrypted message (string if `armor` was true, the default; Uint8Array if `armor` was false).
  * @async
  * @static
  */
-export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKey, armor = true, detached = false, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), fromUserIDs = [], toUserIDs = [], config }) {
+export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, detached = false, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config }) {
   config = { ...defaultConfig, ...config };
-  checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); fromUserIDs = toArray(fromUserIDs); toUserIDs = toArray(toUserIDs);
+  checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (detached) {
-    throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
+    throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove signingKeys option as well.");
   }
 
   return Promise.resolve().then(async function() {
     const streaming = message.fromStream;
-    if (!privateKeys) {
-      privateKeys = [];
+    if (!signingKeys) {
+      signingKeys = [];
     }
-    if (privateKeys.length || signature) { // sign the message only if private keys or signature is specified
-      message = await message.sign(privateKeys, signature, signingKeyIDs, date, fromUserIDs, config);
+    if (signingKeys.length || signature) { // sign the message only if signing keys or signature is specified
+      message = await message.sign(signingKeys, signature, signingKeyIDs, date, signingUserIDs, config);
     }
     message = message.compress(
-      await getPreferredAlgo('compression', publicKeys, date, toUserIDs, config),
+      await getPreferredAlgo('compression', encryptionKeys, date, encryptionUserIDs, config),
       config
     );
-    message = await message.encrypt(publicKeys, passwords, sessionKey, wildcard, encryptionKeyIDs, date, toUserIDs, config);
+    message = await message.encrypt(encryptionKeys, passwords, sessionKey, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);
     const data = armor ? message.armor(config) : message.write();
     return convertStream(data, streaming, armor ? 'utf8' : 'binary');
   }).catch(onError.bind(null, 'Error encrypting message'));
@@ -279,10 +279,10 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  *   a session key or a password must be specified.
  * @param {Object} options
  * @param {Message} options.message - The message object with the encrypted data
- * @param {Key|Array<Key>} [options.privateKeys] - Private keys with decrypted secret key data or session key
+ * @param {Key|Array<Key>} [options.decryptionKeys] - Private keys with decrypted secret key data or session key
  * @param {String|Array<String>} [options.passwords] - Passwords to decrypt the message
  * @param {Object|Array<Object>} [options.sessionKeys] - Session keys in the form: { data:Uint8Array, algorithm:String }
- * @param {Key|Array<Key>} [options.publicKeys] - Array of public keys or single key, to verify signatures
+ * @param {Key|Array<Key>} [options.verificationKeys] - Array of public keys or single key, to verify signatures
  * @param {Boolean} [options.expectSigned=false] - If true, data decryption fails if the message is not signed with the provided publicKeys
  * @param {'utf8'|'binary'} [options.format='utf8'] - Whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines.
  * @param {Signature} [options.signature] - Detached signature for verification
@@ -305,23 +305,23 @@ export function encrypt({ message, publicKeys, privateKeys, passwords, sessionKe
  * @async
  * @static
  */
-export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
+export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
   config = { ...defaultConfig, ...config };
-  checkMessage(message); publicKeys = toArray(publicKeys); privateKeys = toArray(privateKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
+  checkMessage(message); verificationKeys = toArray(verificationKeys); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
 
-  return message.decrypt(privateKeys, passwords, sessionKeys, config).then(async function(decrypted) {
-    if (!publicKeys) {
-      publicKeys = [];
+  return message.decrypt(decryptionKeys, passwords, sessionKeys, config).then(async function(decrypted) {
+    if (!verificationKeys) {
+      verificationKeys = [];
     }
 
     const result = {};
-    result.signatures = signature ? await decrypted.verifyDetached(signature, publicKeys, date, config) : await decrypted.verify(publicKeys, date, config);
+    result.signatures = signature ? await decrypted.verifyDetached(signature, verificationKeys, date, config) : await decrypted.verify(verificationKeys, date, config);
     result.data = format === 'binary' ? decrypted.getLiteralData() : decrypted.getText();
     result.filename = decrypted.getFilename();
     linkStreams(result, message);
     if (expectSigned) {
-      if (publicKeys.length === 0) {
-        throw new Error('Public keys are required to verify message signatures');
+      if (verificationKeys.length === 0) {
+        throw new Error('Verification keys are required to verify message signatures');
       }
       if (result.signatures.length === 0) {
         throw new Error('Message is not signed');
@@ -351,30 +351,30 @@ export function decrypt({ message, privateKeys, passwords, sessionKeys, publicKe
  * Signs a message.
  * @param {Object} options
  * @param {CleartextMessage|Message} options.message - (cleartext) message to be signed
- * @param {Key|Array<Key>} options.privateKeys - Array of keys or single key with decrypted secret key data to sign cleartext
+ * @param {Key|Array<Key>} options.signingKeys - Array of keys or single key with decrypted secret key data to sign cleartext
  * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
  * @param {Boolean} [options.detached=false] - If the return value should contain a detached signature
- * @param {Array<module:type/keyid~KeyID>} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to privateKeys[i]
+ * @param {Array<module:type/keyid~KeyID>} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
  * @param {Date} [options.date=current date] - Override the creation date of the signature
- * @param {Array<Object>} [options.fromUserIDs=primary user IDs] - Array of user IDs to sign with, one per key in `privateKeys`, e.g. `[{ name: 'Steve Sender', email: 'steve@openpgp.org' }]`
+ * @param {Array<Object>} [options.signingUserIDs=primary user IDs] - Array of user IDs to sign with, one per key in `signingKeys`, e.g. `[{ name: 'Steve Sender', email: 'steve@openpgp.org' }]`
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<String|ReadableStream<String>|NodeStream<String>|Uint8Array|ReadableStream<Uint8Array>|NodeStream<Uint8Array>>} Signed message (string if `armor` was true, the default; Uint8Array if `armor` was false).
  * @async
  * @static
  */
-export function sign({ message, privateKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), fromUserIDs = [], config }) {
+export function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && !armor) throw new Error("Can't sign non-armored cleartext message");
   if (message instanceof CleartextMessage && detached) throw new Error("Can't detach-sign a cleartext message");
-  privateKeys = toArray(privateKeys); fromUserIDs = toArray(fromUserIDs);
+  signingKeys = toArray(signingKeys); signingUserIDs = toArray(signingUserIDs);
 
   return Promise.resolve().then(async function() {
     let signature;
     if (detached) {
-      signature = await message.signDetached(privateKeys, undefined, signingKeyIDs, date, fromUserIDs, config);
+      signature = await message.signDetached(signingKeys, undefined, signingKeyIDs, date, signingUserIDs, config);
     } else {
-      signature = await message.sign(privateKeys, undefined, signingKeyIDs, date, fromUserIDs, config);
+      signature = await message.sign(signingKeys, undefined, signingKeyIDs, date, signingUserIDs, config);
     }
     signature = armor ? signature.armor(config) : signature.write();
     if (detached) {
@@ -393,7 +393,7 @@ export function sign({ message, privateKeys, armor = true, detached = false, sig
  * Verifies signatures of cleartext signed message
  * @param {Object} options
  * @param {CleartextMessage|Message} options.message - (cleartext) message object with signatures
- * @param {Key|Array<Key>} options.publicKeys - Array of publicKeys or single key, to verify signatures
+ * @param {Key|Array<Key>} options.verificationKeys - Array of publicKeys or single key, to verify signatures
  * @param {Boolean} [options.expectSigned=false] - If true, verification throws if the message is not signed with the provided publicKeys
  * @param {'utf8'|'binary'} [options.format='utf8'] - Whether to return data as a string(Stream) or Uint8Array(Stream). If 'utf8' (the default), also normalize newlines.
  * @param {Signature} [options.signature] - Detached signature for verification
@@ -415,19 +415,19 @@ export function sign({ message, privateKeys, armor = true, detached = false, sig
  * @async
  * @static
  */
-export function verify({ message, publicKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
+export function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && format === 'binary') throw new Error("Can't return cleartext message data as binary");
   if (message instanceof CleartextMessage && signature) throw new Error("Can't verify detached cleartext signature");
-  publicKeys = toArray(publicKeys);
+  verificationKeys = toArray(verificationKeys);
 
   return Promise.resolve().then(async function() {
     const result = {};
     if (signature) {
-      result.signatures = await message.verifyDetached(signature, publicKeys, date, config);
+      result.signatures = await message.verifyDetached(signature, verificationKeys, date, config);
     } else {
-      result.signatures = await message.verify(publicKeys, date, config);
+      result.signatures = await message.verify(verificationKeys, date, config);
     }
     result.data = format === 'binary' ? message.getLiteralData() : message.getText();
     if (message.fromStream) linkStreams(result, message);
@@ -458,21 +458,21 @@ export function verify({ message, publicKeys, expectSigned = false, format = 'ut
 /**
  * Generate a new session key object, taking the algorithm preferences of the passed public keys into account.
  * @param {Object} options
- * @param {Key|Array<Key>} options.publicKeys - Array of public keys or single key used to select algorithm preferences for
+ * @param {Key|Array<Key>} options.encryptionKeys - Array of public keys or single key used to select algorithm preferences for
  * @param {Date} [options.date=current date] - Date to select algorithm preferences at
- * @param {Array} [options.toUserIDs=primary user IDs] - User IDs to select algorithm preferences for
+ * @param {Array} [options.encryptionUserIDs=primary user IDs] - User IDs to select algorithm preferences for
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<{ data: Uint8Array, algorithm: String }>} Object with session key data and algorithm.
  * @async
  * @static
  */
-export function generateSessionKey({ publicKeys, date = new Date(), toUserIDs = [], config }) {
+export function generateSessionKey({ encryptionKeys, date = new Date(), encryptionUserIDs = [], config }) {
   config = { ...defaultConfig, ...config };
-  publicKeys = toArray(publicKeys); toUserIDs = toArray(toUserIDs);
+  encryptionKeys = toArray(encryptionKeys); encryptionUserIDs = toArray(encryptionUserIDs);
 
   return Promise.resolve().then(async function() {
 
-    return Message.generateSessionKey(publicKeys, date, toUserIDs, config);
+    return Message.generateSessionKey(encryptionKeys, date, encryptionUserIDs, config);
 
   }).catch(onError.bind(null, 'Error generating session key'));
 }
@@ -484,25 +484,25 @@ export function generateSessionKey({ publicKeys, date = new Date(), toUserIDs = 
  * @param {Uint8Array} options.data - The session key to be encrypted e.g. 16 random bytes (for aes128)
  * @param {String} options.algorithm - Algorithm of the symmetric session key e.g. 'aes128' or 'aes256'
  * @param {String} [options.aeadAlgorithm] - AEAD algorithm, e.g. 'eax' or 'ocb'
- * @param {Key|Array<Key>} [options.publicKeys] - Array of public keys or single key, used to encrypt the key
+ * @param {Key|Array<Key>} [options.encryptionKeys] - Array of public keys or single key, used to encrypt the key
  * @param {String|Array<String>} [options.passwords] - Passwords for the message
  * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
- * @param {Array<module:type/keyid~KeyID>} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each encryptionKeyIDs[i] corresponds to publicKeys[i]
+ * @param {Array<module:type/keyid~KeyID>} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each encryptionKeyIDs[i] corresponds to encryptionKeys[i]
  * @param {Date} [options.date=current date] - Override the date
- * @param {Array} [options.toUserIDs=primary user IDs] - Array of user IDs to encrypt for, one per key in `publicKeys`, e.g. `[{ name: 'Phil Zimmermann', email: 'phil@openpgp.org' }]`
+ * @param {Array} [options.encryptionUserIDs=primary user IDs] - Array of user IDs to encrypt for, one per key in `encryptionKeys`, e.g. `[{ name: 'Phil Zimmermann', email: 'phil@openpgp.org' }]`
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<String|Uint8Array>} Encrypted session keys (string if `armor` was true, the default; Uint8Array if `armor` was false).
  * @async
  * @static
  */
-export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, armor = true, wildcard = false, encryptionKeyIDs = [], date = new Date(), toUserIDs = [], config }) {
+export function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, armor = true, wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config }) {
   config = { ...defaultConfig, ...config };
-  checkBinary(data); checkString(algorithm, 'algorithm'); publicKeys = toArray(publicKeys); passwords = toArray(passwords); toUserIDs = toArray(toUserIDs);
+  checkBinary(data); checkString(algorithm, 'algorithm'); encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionUserIDs = toArray(encryptionUserIDs);
 
   return Promise.resolve().then(async function() {
 
-    const message = await Message.encryptSessionKey(data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard, encryptionKeyIDs, date, toUserIDs, config);
+    const message = await Message.encryptSessionKey(data, algorithm, aeadAlgorithm, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);
     return armor ? message.armor(config) : message.write();
 
   }).catch(onError.bind(null, 'Error encrypting session key'));
@@ -513,7 +513,7 @@ export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, 
  *   a password must be specified.
  * @param {Object} options
  * @param {Message} options.message - A message object containing the encrypted session key packets
- * @param {Key|Array<Key>} [options.privateKeys] - Private keys with decrypted secret key data
+ * @param {Key|Array<Key>} [options.decryptionKeys] - Private keys with decrypted secret key data
  * @param {String|Array<String>} [options.passwords] - Passwords to decrypt the session key
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object|undefined>} Array of decrypted session key, algorithm pairs in the form:
@@ -522,13 +522,13 @@ export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, 
  * @async
  * @static
  */
-export function decryptSessionKeys({ message, privateKeys, passwords, config }) {
+export function decryptSessionKeys({ message, decryptionKeys, passwords, config }) {
   config = { ...defaultConfig, ...config };
-  checkMessage(message); privateKeys = toArray(privateKeys); passwords = toArray(passwords);
+  checkMessage(message); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords);
 
   return Promise.resolve().then(async function() {
 
-    return message.decryptSessionKeys(privateKeys, passwords, config);
+    return message.decryptSessionKeys(decryptionKeys, passwords, config);
 
   }).catch(onError.bind(null, 'Error decrypting session keys'));
 }

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -177,7 +177,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   it('Verify clear signed message', async function () {
     const pub = await load_pub_key('juliet');
     const msg = await openpgp.readCleartextMessage({ cleartextMessage: data.juliet.message_signed });
-    return openpgp.verify({ publicKeys: [pub], message: msg }).then(function(result) {
+    return openpgp.verify({ verificationKeys: [pub], message: msg }).then(function(result) {
       expect(result).to.exist;
       expect(result.data).to.equal(data.juliet.message);
       expect(result.signatures).to.have.length(1);
@@ -186,10 +186,10 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   });
   it('Sign message', async function () {
     const romeoPrivate = await load_priv_key('romeo');
-    const signed = await openpgp.sign({ privateKeys: [romeoPrivate], message: await openpgp.createCleartextMessage({ text: data.romeo.message }) });
+    const signed = await openpgp.sign({ signingKeys: [romeoPrivate], message: await openpgp.createCleartextMessage({ text: data.romeo.message }) });
     const romeoPublic = await load_pub_key('romeo');
     const msg = await openpgp.readCleartextMessage({ cleartextMessage: signed });
-    const result = await openpgp.verify({ publicKeys: [romeoPublic], message: msg });
+    const result = await openpgp.verify({ verificationKeys: [romeoPublic], message: msg });
 
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message);
@@ -200,7 +200,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     const juliet = await load_pub_key('juliet');
     const romeo = await load_priv_key('romeo');
     const msg = await openpgp.readMessage({ armoredMessage: data.juliet.message_encrypted });
-    const result = await openpgp.decrypt({ privateKeys: romeo, publicKeys: [juliet], message: msg });
+    const result = await openpgp.decrypt({ decryptionKeys: romeo, verificationKeys: [juliet], message: msg });
 
     expect(result).to.exist;
     expect(result.data).to.equal(data.juliet.message);
@@ -210,12 +210,12 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   it('Encrypt and sign message', async function () {
     const romeoPrivate = await load_priv_key('romeo');
     const julietPublic = await load_pub_key('juliet');
-    const encrypted = await openpgp.encrypt({ publicKeys: [julietPublic], privateKeys: [romeoPrivate], message: await openpgp.createMessage({ text: data.romeo.message }) });
+    const encrypted = await openpgp.encrypt({ encryptionKeys: [julietPublic], signingKeys: [romeoPrivate], message: await openpgp.createMessage({ text: data.romeo.message }) });
 
     const message = await openpgp.readMessage({ armoredMessage: encrypted });
     const romeoPublic = await load_pub_key('romeo');
     const julietPrivate = await load_priv_key('juliet');
-    const result = await openpgp.decrypt({ privateKeys: julietPrivate, publicKeys: [romeoPublic], message: message });
+    const result = await openpgp.decrypt({ decryptionKeys: julietPrivate, verificationKeys: [romeoPublic], message: message });
 
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -980,13 +980,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        privateKeys: privateKey,
-        publicKeys: publicKey
+        signingKeys: privateKey,
+        encryptionKeys: publicKey
       });
       const { data, signatures } = await openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
-        privateKeys: privateKey,
-        publicKeys: publicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: publicKey,
         expectSigned: true
       });
       expect(data).to.equal(plaintext);
@@ -1002,12 +1002,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey,
-        privateKeys: privateKey
+        encryptionKeys: publicKey,
+        signingKeys: privateKey
       });
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
-        privateKeys: privateKey,
+        decryptionKeys: privateKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Public keys are required/);
     });
@@ -1021,12 +1021,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey
+        encryptionKeys: publicKey
       });
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
-        privateKeys: privateKey,
-        publicKeys: publicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: publicKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Message is not signed/);
     });
@@ -1041,13 +1041,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey,
-        privateKeys: privateKey
+        encryptionKeys: publicKey,
+        signingKeys: privateKey
       });
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
-        privateKeys: privateKey,
-        publicKeys: wrongPublicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: wrongPublicKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Could not find signing key/);
     });
@@ -1061,13 +1061,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        privateKeys: privateKey,
-        publicKeys: publicKey
+        signingKeys: privateKey,
+        encryptionKeys: publicKey
       });
       const { data: streamedData, signatures } = await openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
-        privateKeys: privateKey,
-        publicKeys: publicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: publicKey,
         expectSigned: true
       });
       const data = await openpgp.stream.readToEnd(streamedData);
@@ -1084,12 +1084,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey,
-        privateKeys: privateKey
+        encryptionKeys: publicKey,
+        signingKeys: privateKey
       });
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
-        privateKeys: privateKey,
+        decryptionKeys: privateKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Public keys are required/);
     });
@@ -1103,12 +1103,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey
+        encryptionKeys: publicKey
       });
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
-        privateKeys: privateKey,
-        publicKeys: publicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: publicKey,
         expectSigned: true
       })).to.be.eventually.rejectedWith(/Message is not signed/);
     });
@@ -1123,13 +1123,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey,
-        privateKeys: privateKey
+        encryptionKeys: publicKey,
+        signingKeys: privateKey
       });
       const { data: streamedData } = await openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
-        privateKeys: privateKey,
-        publicKeys: wrongPublicKey,
+        decryptionKeys: privateKey,
+        verificationKeys: wrongPublicKey,
         expectSigned: true
       });
       await expect(
@@ -1176,11 +1176,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
-          privateKeys: privateKey
+          signingKeys: privateKey
         });
         const { data, signatures } = await openpgp.verify({
           message: await readMessage({ armoredMessage: signed }),
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           expectSigned: true
         });
         expect(data).to.equal(text);
@@ -1192,7 +1192,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         await expect(openpgp.verify({
           message: await createMessage({ text }),
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           expectSigned: true
         })).to.be.eventually.rejectedWith(/Message is not signed/);
       });
@@ -1206,11 +1206,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
-          privateKeys: privateKey
+          signingKeys: privateKey
         });
         await expect(openpgp.verify({
           message: await readMessage({ armoredMessage: signed }),
-          publicKeys: wrongPublicKey,
+          verificationKeys: wrongPublicKey,
           expectSigned: true
         })).to.be.eventually.rejectedWith(/Could not find signing key/);
       });
@@ -1226,11 +1226,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
-          privateKeys: privateKey
+          signingKeys: privateKey
         });
         const { data: streamedData, signatures } = await openpgp.verify({
           message: await readMessage({ armoredMessage: openpgp.stream.toStream(signed) }),
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           expectSigned: true
         });
         const data = await openpgp.stream.readToEnd(streamedData);
@@ -1245,7 +1245,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         await expect(openpgp.verify({
           message: await createMessage({ text: openpgp.stream.toStream(text) }),
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           expectSigned: true
         })).to.be.eventually.rejectedWith(/Message is not signed/);
       });
@@ -1261,11 +1261,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         const signed = await openpgp.sign({
           message: await createMessage({ text }),
-          privateKeys: privateKey
+          signingKeys: privateKey
         });
         const { data: streamedData } = await openpgp.verify({
           message: await readMessage({ armoredMessage: openpgp.stream.toStream(signed) }),
-          publicKeys: wrongPublicKey,
+          verificationKeys: wrongPublicKey,
           expectSigned: true
         });
         await expect(
@@ -1326,14 +1326,14 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       const commentStringVal = openpgp.config.commentString;
 
       try {
-        const encryptedDefault = await openpgp.encrypt({ publicKeys:publicKey, message:await openpgp.createMessage({ text: plaintext }) });
+        const encryptedDefault = await openpgp.encrypt({ encryptionKeys:publicKey, message:await openpgp.createMessage({ text: plaintext }) });
         expect(encryptedDefault).to.exist;
         expect(encryptedDefault).not.to.match(/^Version:/);
         expect(encryptedDefault).not.to.match(/^Comment:/);
 
         openpgp.config.showComment = true;
         openpgp.config.commentString = 'different';
-        const encryptedWithComment = await openpgp.encrypt({ publicKeys:publicKey, message:await openpgp.createMessage({ text: plaintext }) });
+        const encryptedWithComment = await openpgp.encrypt({ encryptionKeys:publicKey, message:await openpgp.createMessage({ text: plaintext }) });
         expect(encryptedWithComment).to.exist;
         expect(encryptedWithComment).not.to.match(/^Version:/);
         expect(encryptedWithComment).to.match(/Comment: different/);
@@ -1360,10 +1360,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     it('Calling decrypt with not decrypted key leads to exception', async function() {
       const encOpt = {
         message: await openpgp.createMessage({ text: plaintext }),
-        publicKeys: publicKey
+        encryptionKeys: publicKey
       };
       const decOpt = {
-        privateKeys: privateKey
+        decryptionKeys: privateKey
       };
       const encrypted = await openpgp.encrypt(encOpt);
       decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1433,13 +1433,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           return openpgp.encryptSessionKey({
             data: sk,
             algorithm: 'aes128',
-            publicKeys: publicKey,
+            encryptionKeys: publicKey,
             armor: false
           }).then(async function(encrypted) {
             const message = await openpgp.readMessage({ binaryMessage: encrypted });
             return openpgp.decryptSessionKeys({
               message,
-              privateKeys: privateKey
+              decryptionKeys: privateKey
             });
           }).then(function(decrypted) {
             expect(decrypted[0].data).to.deep.equal(sk);
@@ -1467,7 +1467,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           return openpgp.encryptSessionKey({
             data: sk,
             algorithm: 'aes128',
-            publicKeys: publicKey,
+            encryptionKeys: publicKey,
             armor: false
           }).then(async function(encrypted) {
             const message = await openpgp.readMessage({ binaryMessage: encrypted });
@@ -1475,7 +1475,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
             invalidPrivateKey.subKeys[0].bindingSignatures = [];
             return openpgp.decryptSessionKeys({
               message,
-              privateKeys: invalidPrivateKey
+              decryptionKeys: invalidPrivateKey
             }).then(() => {
               throw new Error('Should not decrypt with invalid key');
             }).catch(error => {
@@ -1487,11 +1487,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('roundtrip workflow: encrypt, decryptSessionKeys, decrypt with pgp key pair', async function () {
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           });
           const decryptedSessionKeys = await openpgp.decryptSessionKeys({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           });
           const decrypted = await openpgp.decrypt({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
@@ -1504,11 +1504,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           });
           const decryptedSessionKeys = await openpgp.decryptSessionKeys({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           });
           const decrypted = await openpgp.decrypt({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
@@ -1591,10 +1591,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt then decrypt', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           };
           const decOpt = {
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
@@ -1615,10 +1615,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           };
           const decOpt = {
-            privateKeys: [privKeyDE, privateKey]
+            decryptionKeys: [privKeyDE, privateKey]
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
@@ -1634,11 +1634,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt then decrypt with wildcard', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
+            encryptionKeys: publicKey,
             wildcard: true
           };
           const decOpt = {
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
@@ -1659,11 +1659,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
+            encryptionKeys: publicKey,
             wildcard: true
           };
           const decOpt = {
-            privateKeys: [privKeyDE, privateKey]
+            decryptionKeys: [privKeyDE, privateKey]
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
@@ -1678,7 +1678,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         it('should encrypt then decrypt using returned session key', async function () {
           const sessionKey = await openpgp.generateSessionKey({
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           });
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
@@ -1702,7 +1702,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
             sessionKey: sessionKey,
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           };
           const decOpt = {
             sessionKeys: sessionKey
@@ -1725,10 +1725,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
             sessionKey: sessionKey,
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           };
           const decOpt = {
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
@@ -1743,12 +1743,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt/sign and decrypt/verify', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: publicKey
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1766,12 +1766,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt/sign and decrypt/verify (expectSigned=true)', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: publicKey,
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey,
             expectSigned: true
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
@@ -1790,12 +1790,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt/sign and decrypt/verify (no AEAD support)', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKeyNoAEAD,
-            privateKeys: privateKey
+            encryptionKeys: publicKeyNoAEAD,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: publicKeyNoAEAD
+            decryptionKeys: privateKey,
+            verificationKeys: publicKeyNoAEAD
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1821,12 +1821,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
             const encOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
-              publicKeys: newPublicKey,
-              privateKeys: newPrivateKey
+              encryptionKeys: newPublicKey,
+              signingKeys: newPrivateKey
             };
             const decOpt = {
-              privateKeys: newPrivateKey,
-              publicKeys: newPublicKey
+              decryptionKeys: newPrivateKey,
+              verificationKeys: newPublicKey
             };
             return openpgp.encrypt(encOpt).then(async function (encrypted) {
               decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1851,11 +1851,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: newPublicKey
+            encryptionKeys: newPublicKey
           });
           const signed = await openpgp.sign({
             message: await openpgp.createMessage({ text: plaintext }),
-            privateKeys: newPrivateKey,
+            signingKeys: newPrivateKey,
             detached: true
           });
           const message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1863,8 +1863,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const decrypted = await openpgp.decrypt({
             message,
             signature: await openpgp.readSignature({ armoredSignature: signed }),
-            privateKeys: newPrivateKey,
-            publicKeys: newPublicKey
+            decryptionKeys: newPrivateKey,
+            verificationKeys: newPublicKey
           });
           expect(decrypted.data).to.equal(plaintext);
           expect(decrypted.signatures[0].valid).to.be.true;
@@ -1876,12 +1876,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt/sign and decrypt/verify with null string input', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: '' }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: publicKey
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -1898,18 +1898,18 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should encrypt/sign and decrypt/verify with detached signatures', async function () {
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           });
           const signed = await openpgp.sign({
             message: await openpgp.createMessage({ text: plaintext }),
-            privateKeys: privateKey,
+            verificationKeys: privateKey,
             detached: true
           });
           const decrypted = await openpgp.decrypt({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
             signature: await openpgp.readSignature({ armoredSignature: signed }),
-            privateKeys: privateKey,
-            publicKeys: publicKey
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey
           });
           expect(decrypted.data).to.equal(plaintext);
           expect(decrypted.signatures[0].valid).to.be.true;
@@ -1934,19 +1934,19 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
             const signOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
-              privateKeys: privKeyDE,
+              signingKeys: privKeyDE,
               detached: true
             };
 
             const encOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
-              publicKeys: publicKey,
-              privateKeys: privateKey
+              encryptionKeys: publicKey,
+              signingKeys: privateKey
             };
 
             const decOpt = {
-              privateKeys: privateKey,
-              publicKeys: [publicKey, pubKeyDE]
+              decryptionKeys: privateKey,
+              verificationKeys: [publicKey, pubKeyDE]
             };
 
             await openpgp.sign(signOpt).then(async function (armoredSignature) {
@@ -1975,18 +1975,18 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should fail to encrypt and decrypt/verify with detached signature as input for encryption with wrong public key', async function () {
           const signOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            privateKeys: privateKey,
+            signingKeys: privateKey,
             detached: true
           };
 
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           };
 
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+            decryptionKeys: privateKey,
+            verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
           };
 
           return openpgp.sign(signOpt).then(async function (armoredSignature) {
@@ -2008,12 +2008,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should fail to verify decrypted data with wrong public pgp key', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+            decryptionKeys: privateKey,
+            verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -2031,12 +2031,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should fail to verify decrypted null string with wrong public pgp key', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: '' }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey,
-            publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+            decryptionKeys: privateKey,
+            verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -2054,11 +2054,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should successfully decrypt signed message without public keys to verify', async function () {
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey,
-            privateKeys: privateKey
+            encryptionKeys: publicKey,
+            signingKeys: privateKey
           };
           const decOpt = {
-            privateKeys: privateKey
+            decryptionKeys: privateKey
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
@@ -2076,18 +2076,18 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should fail to verify decrypted data with wrong public pgp key with detached signatures', async function () {
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: publicKey
+            encryptionKeys: publicKey
           });
           const signed = await openpgp.sign({
             message: await openpgp.createMessage({ text: plaintext }),
-            privateKeys: privateKey,
+            signingKeys: privateKey,
             detached: true
           });
           const { signatures, data } = await openpgp.decrypt({
             message: await openpgp.readMessage({ armoredMessage: encrypted }),
             signature: await openpgp.readSignature({ armoredSignature: signed }),
-            privateKeys: privateKey,
-            publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+            decryptionKeys: privateKey,
+            verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
           });
           expect(data).to.equal(plaintext);
           expect(signatures[0].valid).to.be.false;
@@ -2111,13 +2111,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
             const encOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
-              publicKeys: publicKey,
-              privateKeys: [privateKey, privKeyDE]
+              publencryptionKeysicKeys: publicKey,
+              signingKeys: [privateKey, privKeyDE]
             };
 
             const decOpt = {
-              privateKeys: privateKey,
-              publicKeys: [publicKey, pubKeyDE]
+              decryptionKeys: privateKey,
+              verificationKeys: [publicKey, pubKeyDE]
             };
 
             await openpgp.encrypt(encOpt).then(async function (encrypted) {
@@ -2143,7 +2143,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         it('should fail to decrypt modified message', async function() {
           const { privateKeyArmored } = await openpgp.generateKey({ curve: 'curve25519', userIDs: [{ email: 'test@email.com' }] });
           const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
-          const data = await openpgp.encrypt({ message: await openpgp.createMessage({ binary: new Uint8Array(500) }), publicKeys: [key.toPublic()] });
+          const data = await openpgp.encrypt({ message: await openpgp.createMessage({ binary: new Uint8Array(500) }), encryptionKeys: [key.toPublic()] });
           let badSumEncrypted = data.replace(/\n=[a-zA-Z0-9/+]{4}/, '\n=aaaa');
           if (badSumEncrypted === data) { // checksum was already =aaaa
             badSumEncrypted = data.replace(/\n=[a-zA-Z0-9/+]{4}/, '\n=bbbb');
@@ -2176,7 +2176,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
                 try {
                   const message = await openpgp.readMessage({ armoredMessage: encrypted });
                   stepReached = 1;
-                  const { data: decrypted } = await openpgp.decrypt({ message: message, privateKeys: [key] });
+                  const { data: decrypted } = await openpgp.decrypt({ message: message, decryptionKeys: [key] });
                   stepReached = 2;
                   await openpgp.stream.readToEnd(decrypted);
                 } catch (e) {
@@ -2196,10 +2196,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
         it('should fail to decrypt unarmored message with garbage data appended', async function() {
           const { key } = await openpgp.generateKey({ userIDs: {} });
-          const message = await openpgp.encrypt({ message: await openpgp.createMessage({ text: 'test' }), publicKeys: key, privateKeys: key, armor: false });
+          const message = await openpgp.encrypt({ message: await openpgp.createMessage({ text: 'test' }), encryptionKeys: key, signingKeys: key, armor: false });
           const encrypted = util.concat([message, new Uint8Array([11])]);
           await expect((async () => {
-            await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), privateKeys: key, publicKeys: key });
+            await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), decryptionKeys: key, verificationKeys: key });
           })()).to.be.rejectedWith('Error during parsing. This message / key probably does not conform to a valid OpenPGP format.');
         });
       });
@@ -2218,13 +2218,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
             });
             pubKeyDE.users[0].selfCertifications[0].features = [7]; // Monkey-patch AEAD feature flag
             await openpgp.encrypt({
-              publicKeys: pubKeyDE,
-              privateKeys: privKeyDE,
+              encryptionKeys: pubKeyDE,
+              signingKeys: privKeyDE,
               message: await openpgp.createMessage({ text: plaintext })
             }).then(async function (encrypted) {
               return openpgp.decrypt({
-                privateKeys: privKeyDE,
-                publicKeys: pubKeyDE,
+                decryptionKeys: privKeyDE,
+                verificationKeys: pubKeyDE,
                 message: await openpgp.readMessage({ armoredMessage: encrypted })
               });
             }).then(async function (decrypted) {
@@ -2302,7 +2302,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           });
           const message = await openpgp.readMessage({ armoredMessage: pgp_msg });
 
-          return openpgp.decrypt({ privateKeys:privKey, message:message }).then(function(decrypted) {
+          return openpgp.decrypt({ decryptionKeys:privKey, message:message }).then(function(decrypted) {
             expect(decrypted.data).to.equal('hello 3des\n');
             expect(decrypted.signatures.length).to.equal(0);
           });
@@ -2464,10 +2464,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createCleartextMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey
+          signingKeys: privateKey
         };
         const verifyOpt = {
-          publicKeys: publicKey
+          verificationKeys: publicKey
         };
         return openpgp.sign(signOpt).then(async function (signed) {
           expect(signed).to.match(/-----BEGIN PGP SIGNED MESSAGE-----/);
@@ -2495,10 +2495,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           const message = await openpgp.createCleartextMessage({ text: plaintext });
           const signOpt = {
             message,
-            privateKeys: [privateKey, privKeyDE]
+            signingKeys: [privateKey, privKeyDE]
           };
           const verifyOpt = {
-            publicKeys: [publicKey, privKeyDE.toPublic()]
+            verificationKeys: [publicKey, privKeyDE.toPublic()]
           };
           await openpgp.sign(signOpt).then(async function (signed) {
             expect(signed).to.match(/-----BEGIN PGP SIGNED MESSAGE-----/);
@@ -2525,12 +2525,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           detached: true
         };
         const verifyOpt = {
           message,
-          publicKeys: publicKey
+          verificationKeys: publicKey
         };
         return openpgp.sign(signOpt).then(async function (armoredSignature) {
           verifyOpt.signature = await openpgp.readSignature({ armoredSignature });
@@ -2548,10 +2548,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createCleartextMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey
+          signingKeys: privateKey
         };
         const verifyOpt = {
-          publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+          verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
         };
         return openpgp.sign(signOpt).then(async function (signed) {
           verifyOpt.message = await openpgp.readCleartextMessage({ cleartextMessage: signed });
@@ -2570,12 +2570,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           detached: true
         };
         const verifyOpt = {
           message,
-          publicKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
+          verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
         };
         return openpgp.sign(signOpt).then(async function (armoredSignature) {
           verifyOpt.signature = await openpgp.readSignature({ armoredSignature });
@@ -2594,11 +2594,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           armor: false
         };
         const verifyOpt = {
-          publicKeys: publicKey
+          verificationKeys: publicKey
         };
         return openpgp.sign(signOpt).then(async function (signed) {
           verifyOpt.message = await openpgp.readMessage({ binaryMessage: signed });
@@ -2617,13 +2617,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const message = await openpgp.createMessage({ text: plaintext });
         const signOpt = {
           message,
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           detached: true,
           armor: false
         };
         const verifyOpt = {
           message,
-          publicKeys: publicKey
+          verificationKeys: publicKey
         };
         return openpgp.sign(signOpt).then(async function (signed) {
           verifyOpt.signature = await openpgp.readSignature({ binarySignature: signed });
@@ -2644,14 +2644,14 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const past = new Date(2000);
         const signOpt = {
           message,
-          privateKeys: privateKey_1337,
+          signingKeys: privateKey_1337,
           detached: true,
           date: past,
           armor: false
         };
         const verifyOpt = {
           message,
-          publicKeys: publicKey_1337,
+          verificationKeys: publicKey_1337,
           date: past
         };
         return openpgp.sign(signOpt).then(async function (signed) {
@@ -2682,13 +2682,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
         const signOpt = {
           message: await openpgp.createMessage({ binary: data }),
-          privateKeys: privateKey_2038_2045,
+          signingKeys: privateKey_2038_2045,
           detached: true,
           date: future,
           armor: false
         };
         const verifyOpt = {
-          publicKeys: publicKey_2038_2045,
+          verificationKeys: publicKey_2038_2045,
           date: future,
           format: 'binary'
         };
@@ -2710,11 +2710,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
         const signOpt = {
           message: await openpgp.createMessage({ binary: data }),
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           armor: false
         };
         const verifyOpt = {
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           format: 'binary'
         };
         return openpgp.sign(signOpt).then(async function (signed) {
@@ -2749,11 +2749,11 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
         const signOpt = {
           message: await openpgp.createMessage({ binary: dataStream }),
-          privateKeys: privateKey,
+          signingKeys: privateKey,
           armor: false
         };
         const verifyOpt = {
-          publicKeys: publicKey,
+          verificationKeys: publicKey,
           format: 'binary'
         };
         return openpgp.sign(signOpt).then(async function (signed) {
@@ -2783,7 +2783,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const future = new Date(2040, 5, 5, 5, 5, 5, 0);
         const encryptOpt = {
           message: await openpgp.createMessage({ text: plaintext, date: future }),
-          publicKeys: publicKey_2038_2045,
+          encryptionKeys: publicKey_2038_2045,
           date: future,
           armor: false
         };
@@ -2804,7 +2804,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
         const encryptOpt = {
           message: await openpgp.createMessage({ binary: data, date: past }),
-          publicKeys: publicKey_2000_2008,
+          encryptionKeys: publicKey_2000_2008,
           date: past,
           armor: false
         };
@@ -2824,8 +2824,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const past = new Date(2005, 5, 5, 5, 5, 5, 0);
         const encryptOpt = {
           message: await openpgp.createMessage({ text: plaintext, date: past }),
-          publicKeys: publicKey_2000_2008,
-          privateKeys: privateKey_2000_2008,
+          encryptionKeys: publicKey_2000_2008,
+          signingKeys: privateKey_2000_2008,
           date: past,
           armor: false
         };
@@ -2852,8 +2852,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
         const encryptOpt = {
           message: await openpgp.createMessage({ binary: data, date: future }),
-          publicKeys: publicKey_2038_2045,
-          privateKeys: privateKey_2038_2045,
+          encryptionKeys: publicKey_2038_2045,
+          signingKeys: privateKey_2038_2045,
           date: future,
           armor: false
         };
@@ -2881,8 +2881,8 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         const data = new Uint8Array([3, 14, 15, 92, 65, 35, 59]);
         const encryptOpt = {
           message: await openpgp.createMessage({ binary: data, date: future, format: 'mime' }),
-          publicKeys: publicKey_2038_2045,
-          privateKeys: privateKey_2038_2045,
+          encryptionKeys: publicKey_2038_2045,
+          signingKeys: privateKey_2038_2045,
           date: future,
           armor: false
         };
@@ -2911,7 +2911,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         }).then(async function(revKey) {
           return openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: revKey.publicKey
+            encryptionKeys: revKey.publicKey
           }).then(function() {
             throw new Error('Should not encrypt with revoked key');
           }).catch(function(error) {
@@ -2930,7 +2930,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           pubKeyDE.subKeys[0] = revSubKey;
           return openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            publicKeys: pubKeyDE,
+            encryptionKeys: pubKeyDE,
             config: { rejectPublicKeyAlgorithms: new Set() }
           }).then(function() {
             throw new Error('Should not encrypt with revoked subkey');
@@ -2948,13 +2948,13 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
         const encrypted = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: plaintext }),
-          publicKeys: pubKeyDE,
+          encryptionKeys: pubKeyDE,
           config: { rejectPublicKeyAlgorithms: new Set() }
         });
         privKeyDE.subKeys[0] = await privKeyDE.subKeys[0].revoke(privKeyDE.primaryKey);
         const decOpt = {
           message: await openpgp.readMessage({ armoredMessage: encrypted }),
-          privateKeys: privKeyDE,
+          decryptionKeys: privKeyDE,
           config: { rejectPublicKeyAlgorithms: new Set() }
         };
         const decrypted = await openpgp.decrypt(decOpt);
@@ -2973,12 +2973,12 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         });
         const encrypted = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: plaintext }),
-          publicKeys: pubKeyDE,
+          encryptionKeys: pubKeyDE,
           config: { rejectPublicKeyAlgorithms: new Set() }
         });
         const decOpt = {
           message: await openpgp.readMessage({ armoredMessage: encrypted }),
-          privateKeys: decryptedKeyDE
+          decryptionKeys: decryptedKeyDE
         };
         // binding signature is invalid
         await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith(/Session key decryption failed/);
@@ -3019,13 +3019,13 @@ J9I8AcH94nE77JUtCm7s1kOlo0EIshZsAqJwGveDGdAuabfViVwVxG4I24M6
 
         const decOpt02 = {
           message: await openpgp.readMessage({ armoredMessage: padding02 }),
-          privateKeys: key
+          decryptionKeys: key
         };
         await expect(openpgp.decrypt(decOpt02)).to.be.rejectedWith(/Decryption error/);
 
         const decOpt000002 = {
           message: await openpgp.readMessage({ armoredMessage: padding000002 }),
-          privateKeys: key
+          decryptionKeys: key
         };
         await expect(openpgp.decrypt(decOpt000002)).to.be.rejectedWith(/Decryption error/);
       });
@@ -3055,7 +3055,7 @@ J9I8AcH94nE77JUtCm7s1kOlo0EIshZsAqJwGveDGdAuabfViVwVxG4I24M6
           passphrase: '12345'
         });
         const message = await openpgp.readMessage({ armoredMessage: ecdh_msg_bad });
-        const decrypted = await openpgp.decrypt({ message, privateKeys: key });
+        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key });
         expect(decrypted.data).to.equal('\n');
       });
 
@@ -3065,7 +3065,7 @@ J9I8AcH94nE77JUtCm7s1kOlo0EIshZsAqJwGveDGdAuabfViVwVxG4I24M6
           passphrase: '12345'
         });
         const message = await openpgp.readMessage({ armoredMessage: ecdh_msg_bad_2 });
-        const decrypted = await openpgp.decrypt({ message, privateKeys: key });
+        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key });
         expect(decrypted.data).to.equal('Tesssst<br><br><br>Sent from ProtonMail mobile<br><br><br>');
       });
 
@@ -3108,8 +3108,8 @@ amnR6g==
         it(`sign/verify with ${curve}`, async function() {
           const plaintext = 'short message';
           const key = (await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' } })).key;
-          const signed = await openpgp.sign({ privateKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }) });
-          const verified = await openpgp.verify({ publicKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }) });
+          const signed = await openpgp.sign({ signingKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }) });
+          const verified = await openpgp.verify({ verificationKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }) });
           expect(verified.signatures[0].valid).to.be.true;
         });
       });
@@ -3145,7 +3145,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
 -----END PGP MESSAGE-----`
         });
         await expect(
-          openpgp.decrypt({ message, privateKeys: key, publicKeys: key })
+          openpgp.decrypt({ message, decryptionKeys: key, verificationKeys: key })
         ).to.be.rejectedWith('Error decrypting message: Message is not authenticated.');
       });
 
@@ -3179,7 +3179,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
 =T4iR
 -----END PGP MESSAGE-----`
         });
-        const decrypted = await openpgp.decrypt({ message, privateKeys: key, publicKeys: key, config: { allowUnauthenticatedMessages: true } });
+        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key, verificationKeys: key, config: { allowUnauthenticatedMessages: true } });
         expect(decrypted.data).to.equal('test');
       });
 
@@ -3213,7 +3213,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
 =T4iR
 -----END PGP MESSAGE-----`)
         });
-        const decrypted = await openpgp.decrypt({ message, privateKeys: key, publicKeys: key, config: { allowUnauthenticatedMessages: true } });
+        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key, decryptionKeys: key, config: { allowUnauthenticatedMessages: true } });
         const data = await openpgp.stream.readToEnd(decrypted.data);
         expect(data).to.equal('test');
       });
@@ -3257,7 +3257,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
           m = await openpgp.readMessage({
             armoredMessage: await openpgp.encrypt({
               message: await openpgp.createMessage({ text: "Hello World\n" }),
-              publicKeys: primaryKey,
+              encryptionKeys: primaryKey,
               encryptionKeyIDs: [encryptionKeyIDs[i]]
             })
           });
@@ -3275,7 +3275,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
           s = await openpgp.readSignature({
             armoredSignature: await openpgp.sign({
               message: await openpgp.createMessage({ text: "Hello World\n" }),
-              privateKeys: primaryKey,
+              signingKeys: primaryKey,
               signingKeyIDs: [signingKeyIDs[i]],
               detached: true
             })
@@ -3306,8 +3306,8 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
         const message = await openpgp.readMessage({
           armoredMessage: await openpgp.encrypt({
             message: plaintextMessage,
-            privateKeys: [primaryKey, primaryKey, primaryKey],
-            publicKeys: [primaryKey, primaryKey, primaryKey],
+            signingKeys: [primaryKey, primaryKey, primaryKey],
+            encryptionKeys: [primaryKey, primaryKey, primaryKey],
             encryptionKeyIDs: kIds,
             signingKeyIDs: sIds
           })
@@ -3317,7 +3317,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
         checkEncryptedPackets(kIds, pKESKList);
         const { signatures } = await openpgp.decrypt({
           message,
-          privateKeys: [primaryKey, primaryKey, primaryKey]
+          decryptionKeys: [primaryKey, primaryKey, primaryKey]
         });
         expect(signatures.length).equals(3);
         checkSignatures(sIds, signatures);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1009,7 +1009,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         decryptionKeys: privateKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/Public keys are required/);
+      })).to.be.eventually.rejectedWith(/Verification keys are required/);
     });
 
     it('decrypt/verify should throw on missing signature (expectSigned=true)', async function () {
@@ -1091,7 +1091,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         message: await openpgp.readMessage({ armoredMessage: openpgp.stream.toStream(encrypted) }),
         decryptionKeys: privateKey,
         expectSigned: true
-      })).to.be.eventually.rejectedWith(/Public keys are required/);
+      })).to.be.eventually.rejectedWith(/Verification keys are required/);
     });
 
     it('decrypt/verify should throw on missing signature (expectSigned=true, with streaming)', async function () {
@@ -1367,7 +1367,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       };
       const encrypted = await openpgp.encrypt(encOpt);
       decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-      await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith('Error decrypting message: Private key is not decrypted.');
+      await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith('Error decrypting message: Decryption key is not decrypted.');
     });
 
     tryTests('CFB mode (asm.js)', tests, {
@@ -1902,7 +1902,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
           });
           const signed = await openpgp.sign({
             message: await openpgp.createMessage({ text: plaintext }),
-            verificationKeys: privateKey,
+            signingKeys: privateKey,
             detached: true
           });
           const decrypted = await openpgp.decrypt({
@@ -2111,7 +2111,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
             const encOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
-              publencryptionKeysicKeys: publicKey,
+              encryptionKeys: publicKey,
               signingKeys: [privateKey, privKeyDE]
             };
 
@@ -3213,7 +3213,7 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
 =T4iR
 -----END PGP MESSAGE-----`)
         });
-        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key, decryptionKeys: key, config: { allowUnauthenticatedMessages: true } });
+        const decrypted = await openpgp.decrypt({ message, decryptionKeys: key, verificationKeys: key, config: { allowUnauthenticatedMessages: true } });
         const data = await openpgp.stream.readToEnd(decrypted.data);
         expect(data).to.equal('test');
       });

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -241,7 +241,7 @@ function tests() {
   it('Sign: Input stream should be canceled when canceling encrypted stream', async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       config: { minRSABits: 1024 }
     });
     const reader = openpgp.stream.getReader(signed);
@@ -315,8 +315,8 @@ function tests() {
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
-        publicKeys: pubKey,
-        privateKeys: privKey,
+        encryptionKeys: pubKey,
+        signingKeys: privKey,
         armor: false,
         config: { minRSABits: 1024 }
       });
@@ -324,8 +324,8 @@ function tests() {
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
-        publicKeys: pubKey,
-        privateKeys: privKey,
+        verificationKeys: pubKey,
+        decryptionKeys: privKey,
         message,
         format: 'binary'
       });
@@ -351,16 +351,16 @@ function tests() {
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
-        publicKeys: pub,
-        privateKeys: priv,
+        encryptionKeys: pub,
+        signingKeys: priv,
         armor: false
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
-        publicKeys: pub,
-        privateKeys: priv,
+        verificationKeys: pub,
+        decryptionKeys: priv,
         message,
         format: 'binary'
       });
@@ -386,16 +386,16 @@ function tests() {
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
-        publicKeys: pub,
-        privateKeys: priv,
+        encryptionKeys: pub,
+        signingKeys: priv,
         armor: false
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
 
       const message = await openpgp.readMessage({ binaryMessage: encrypted });
       const decrypted = await openpgp.decrypt({
-        publicKeys: pub,
-        privateKeys: priv,
+        verificationKeys: pub,
+        decryptionKeys: priv,
         message,
         format: 'binary'
       });
@@ -453,8 +453,8 @@ function tests() {
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
-        publicKeys: pubKey,
-        privateKeys: privKey,
+        encryptionKeys: pubKey,
+        signingKeys: privKey,
         config: { minRSABits: 1024 }
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
@@ -468,8 +468,8 @@ function tests() {
         }), { encoding: 'utf8' })
       });
       const decrypted = await openpgp.decrypt({
-        publicKeys: pubKey,
-        privateKeys: privKey,
+        verificationKeys: pubKey,
+        decryptionKeys: privKey,
         message,
         format: 'binary'
       });
@@ -490,8 +490,8 @@ function tests() {
     try {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
-        publicKeys: pubKey,
-        privateKeys: privKey,
+        encryptionKeys: pubKey,
+        signingKeys: privKey,
         config: { minRSABits: 1024 }
       });
       expect(openpgp.stream.isStream(encrypted)).to.equal(expectedType);
@@ -505,7 +505,7 @@ function tests() {
         }), { encoding: 'utf8' })
       });
       const decrypted = await openpgp.decrypt({
-        privateKeys: privKey,
+        decryptionKeys: privKey,
         message,
         format: 'binary'
       });
@@ -524,7 +524,7 @@ function tests() {
   it('Sign/verify: Detect armor checksum error', async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       config: { minRSABits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
@@ -538,7 +538,7 @@ function tests() {
       }), { encoding: 'utf8' })
     });
     const verified = await openpgp.verify({
-      publicKeys: pubKey,
+      verificationKeys: pubKey,
       message,
       format: 'binary',
       config: { minRSABits: 1024 }
@@ -579,14 +579,14 @@ function tests() {
   it('Sign/verify: Input stream should be canceled when canceling verified stream', async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       config: { minRSABits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
 
     const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
-      publicKeys: pubKey,
+      verificationKeys: pubKey,
       message,
       format: 'binary',
       config: { minRSABits: 1024 }
@@ -619,7 +619,7 @@ function tests() {
   it("Sign: Don't pull entire input stream when we're not pulling signed stream", async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       config: { minRSABits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
@@ -634,13 +634,13 @@ function tests() {
   it("Sign/verify: Don't pull entire input stream when we're not pulling verified stream", async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       config: { minRSABits: 1024 }
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
     const message = await openpgp.readMessage({ armoredMessage: signed });
     const verified = await openpgp.verify({
-      publicKeys: pubKey,
+      verificationKeys: pubKey,
       message,
       format: 'binary'
     });
@@ -669,7 +669,7 @@ function tests() {
     });
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       detached: true,
       config: { minRSABits: 1024 }
     });
@@ -678,7 +678,7 @@ function tests() {
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
-      publicKeys: pubKey,
+      verificationKeys: pubKey,
       message: await openpgp.createMessage({ text: 'hello world' }),
       config: { minRSABits: 1024 }
     });
@@ -710,7 +710,7 @@ function tests() {
 
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: priv,
+      signingKeys: priv,
       detached: true
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
@@ -718,7 +718,7 @@ function tests() {
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
-      publicKeys: pub,
+      verificationKeys: pub,
       message: await openpgp.createMessage({ text: 'hello world' })
     });
     expect(verified.data).to.equal('hello world');
@@ -749,7 +749,7 @@ function tests() {
 
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: priv,
+      signingKeys: priv,
       detached: true
     });
     expect(openpgp.stream.isStream(signed)).to.equal(expectedType);
@@ -757,7 +757,7 @@ function tests() {
     const signature = await openpgp.readSignature({ armoredSignature });
     const verified = await openpgp.verify({
       signature,
-      publicKeys: pub,
+      verificationKeys: pub,
       message: await openpgp.createMessage({ text: 'hello world' })
     });
     expect(verified.data).to.equal('hello world');
@@ -768,7 +768,7 @@ function tests() {
   it("Detached sign is expected to pull entire input stream when we're not pulling signed stream", async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       detached: true,
       config: { minRSABits: 1024 }
     });
@@ -783,7 +783,7 @@ function tests() {
   it('Detached sign: Input stream should be canceled when canceling signed stream', async function() {
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
-      privateKeys: privKey,
+      signingKeys: privKey,
       detached: true,
       config: { minRSABits: 1024 }
     });

--- a/test/security/message_signature_bypass.js
+++ b/test/security/message_signature_bypass.js
@@ -97,7 +97,7 @@ async function fakeSignature() {
   // faked message now verifies correctly
   const res = await openpgp.verify({
     message: fake,
-    publicKeys: await getOtherPubKey()
+    verificationKeys: await getOtherPubKey()
   });
   const { signatures } = res;
   expect(signatures).to.have.length(0);

--- a/test/security/preferred_algo_mismatch.js
+++ b/test/security/preferred_algo_mismatch.js
@@ -43,5 +43,5 @@ EnxUPL95HuMKoVkf4w==
 module.exports = () => it('Does not accept message encrypted with algo not mentioned in preferred algorithms', async function() {
   const message = await openpgp.readMessage({ armoredMessage });
   const privKey = await openpgp.readKey({ armoredKey: privateKeyArmor });
-  await expect(openpgp.decrypt({ message, privateKeys: [privKey] })).to.be.rejectedWith('A non-preferred symmetric algorithm was used.');
+  await expect(openpgp.decrypt({ message, decryptionKeys: [privKey] })).to.be.rejectedWith('A non-preferred symmetric algorithm was used.');
 });

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -28,7 +28,7 @@ async function generateTestData() {
   attackerPrivKey.revocationSignatures = [];
   const signed = await openpgp.sign({
     message: await createCleartextMessage({ text: 'I am batman' }),
-    privateKeys: victimPrivKey,
+    signingKeys: victimPrivKey,
     armor: true
   });
   return {
@@ -67,7 +67,7 @@ async function testSubkeyTrust() {
   fakeKey = await readKey({ armoredKey: await fakeKey.toPublic().armor() });
   const verifyAttackerIsBatman = await openpgp.verify({
     message: await readCleartextMessage({ cleartextMessage: signed }),
-    publicKeys: fakeKey
+    verificationKeys: fakeKey
   });
   expect(verifyAttackerIsBatman.signatures[0].keyID.equals(victimPubKey.subKeys[0].getKeyID())).to.be.true;
   expect(verifyAttackerIsBatman.signatures[0].valid).to.be.false;

--- a/test/security/unsigned_subpackets.js
+++ b/test/security/unsigned_subpackets.js
@@ -59,7 +59,7 @@ async function makeKeyValid() {
     try {
       await openpgp.encrypt({
         message: await createMessage({ text: 'Hello', filename: 'hello.txt' }),
-        publicKeys: k
+        encryptionKeys: k
       });
       return false;
     } catch (e) {

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -30,7 +30,7 @@ import {
   // Encrypt text message (armored)
   const text = 'hello';
   const textMessage = await createMessage({ text: 'hello' });
-  const encryptedArmor: string = await encrypt({ publicKeys, message: textMessage });
+  const encryptedArmor: string = await encrypt({ encryptionKeys: publicKeys, message: textMessage });
   expect(encryptedArmor).to.include('-----BEGIN PGP MESSAGE-----');
 
   // Encrypt binary message (unarmored)
@@ -38,18 +38,18 @@ import {
   binary[0] = 1;
   binary[1] = 2;
   const binaryMessage = await createMessage({ binary });
-  const encryptedBinary: Uint8Array = await encrypt({ publicKeys, message: binaryMessage, armor: false });
+  const encryptedBinary: Uint8Array = await encrypt({ encryptionKeys: publicKeys, message: binaryMessage, armor: false });
   expect(encryptedBinary).to.be.instanceOf(Uint8Array);
 
   // Decrypt text message (armored)
   const encryptedTextMessage = await readMessage({ armoredMessage: encryptedArmor });
-  const decryptedText = await decrypt({ privateKeys, message: encryptedTextMessage });
+  const decryptedText = await decrypt({ decryptionKeys: privateKeys, message: encryptedTextMessage });
   const decryptedTextData: string = decryptedText.data;
   expect(decryptedTextData).to.equal(text);
 
   // Decrypt binary message (unarmored)
   const encryptedBinaryMessage = await readMessage({ binaryMessage: encryptedBinary });
-  const decryptedBinary = await decrypt({ privateKeys, message: encryptedBinaryMessage, format: 'binary' });
+  const decryptedBinary = await decrypt({ decryptionKeys: privateKeys, message: encryptedBinaryMessage, format: 'binary' });
   const decryptedBinaryData: Uint8Array = decryptedBinary.data;
   expect(decryptedBinaryData).to.deep.equal(binary);
 
@@ -59,26 +59,26 @@ import {
 
   // Sign cleartext message (armored)
   const cleartextMessage = await createCleartextMessage({ text: 'hello' });
-  const clearSignedArmor = await sign({ privateKeys, message: cleartextMessage });
+  const clearSignedArmor = await sign({ signingKeys: privateKeys, message: cleartextMessage });
   expect(clearSignedArmor).to.include('-----BEGIN PGP SIGNED MESSAGE-----');
 
   // Sign text message (armored)
-  const textSignedArmor: string = await sign({ privateKeys, message: textMessage });
+  const textSignedArmor: string = await sign({ signingKeys: privateKeys, message: textMessage });
   expect(textSignedArmor).to.include('-----BEGIN PGP MESSAGE-----');
 
   // Sign text message (unarmored)
-  const textSignedBinary: Uint8Array = await sign({ privateKeys, message: binaryMessage, armor: false });
+  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, armor: false });
   expect(textSignedBinary).to.be.instanceOf(Uint8Array);
 
   // Verify signed text message (armored)
   const signedMessage = await readMessage({ armoredMessage: textSignedArmor });
-  const verifiedText = await verify({ publicKeys, message: signedMessage });
+  const verifiedText = await verify({ verificationKeys: publicKeys, message: signedMessage });
   const verifiedTextData: string = verifiedText.data;
   expect(verifiedTextData).to.equal(text);
 
   // Verify signed binary message (unarmored)
   const message = await readMessage({ binaryMessage: textSignedBinary });
-  const verifiedBinary = await verify({ publicKeys, message, format: 'binary' });
+  const verifiedBinary = await verify({ verificationKeys: publicKeys, message, format: 'binary' });
   const verifiedBinaryData: Uint8Array = verifiedBinary.data;
   expect(verifiedBinaryData).to.deep.equal(binary);
 

--- a/test/worker/worker_example.js
+++ b/test/worker/worker_example.js
@@ -51,8 +51,8 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
         });
         const data = await openpgp.encrypt({
           message: await openpgp.createMessage({ text: message }),
-          publicKeys: publicKey,
-          privateKeys: privateKey
+          encryptionKeys: publicKey,
+          signingKeys: privateKey
         });
         result = data;
         break;
@@ -65,8 +65,8 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
         });
         const { data, signatures } = await openpgp.decrypt({
           message: await openpgp.readMessage({ armoredMessage: message }),
-          publicKeys: publicKey,
-          privateKeys: privateKey
+          verificationKeys: publicKey,
+          decryptionKeys: privateKey
         });
         if (!signatures[0].valid) {
           throw new Error("Couldn't veriy signature");


### PR DESCRIPTION
This PR aims to fulfill https://github.com/openpgpjs/openpgpjs/pull/1205#issuecomment-772888464

Notes:

- Some error messages were modified:
  - `Private key is not decrypted.` --> `Decryption key is not decrypted.`
  -  ` detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.` --> `detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove signingKeys option as well.`
  -  `Public keys are required to verify message signatures` --> `Verification keys are required to verify message signatures`
- Should the `keys` parameters be renamed in `Message.prototype.createVerificationObjects?`
`Message.prototype.encrypt`, `Message.prototype.verify(Detached)?`,
and `Message.prototype.encryptSessionKeys` ?
- JSDoc for `message.js` might describe the `encryptionKeys` parameter as a list of **public** keys. Similarly for `decryptionKeys` and the like. Just to hint that the encryption key is often a public key. Should this be changed?

Checklist:

- [x] openpgp.encrypt
- [x] openpgp.decrypt
- [x] openpgp.sign
- [x] openpgp.verify
- [x] openpgp.generateSessionKey
- [x] openpgp.encryptSessionKey
- [x] openpgp.decryptSessionKey
- [x] openpgp.signDetached
- [x] Message.prototype.encrypt
- [x] Message.prototype.decrypt
- [x] Message.prototype.sign
- [x] Message.prototype.signDetached
- [x] Message.prototype.verify
- [x] Message.prototype.createSignaturePackets
- [x] Message.prototype.generateSessionKey
- [x] Message.prototype.encryptSessionKey
- [x] Message.prototype.decryptSessionKey
- [x] Fix test cases