### PR TITLE
Throw errors when privateKeys/publicKeys are passed to top-level methods

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -249,12 +249,14 @@ export async function encryptKey({ privateKey, passphrase, config }) {
  * @async
  * @static
  */
-export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, detached = false, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config }) {
+export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, detached = false, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, privateKeys, publicKeys }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (detached) {
     throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
   }
+  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.encrypt, pass `encryptionKeys` instead");
+  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.encrypt, pass `signingKeys` instead");
 
   return Promise.resolve().then(async function() {
     const streaming = message.fromStream;
@@ -305,9 +307,11 @@ export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessi
  * @async
  * @static
  */
-export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
+export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, privateKeys, publicKeys }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); verificationKeys = toArray(verificationKeys); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
+  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.decrypt, pass `decryptionKeys` instead");
+  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.decrypt, pass `verificationKeys` instead");
 
   return message.decrypt(decryptionKeys, passwords, sessionKeys, config).then(async function(decrypted) {
     if (!verificationKeys) {
@@ -362,11 +366,13 @@ export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verif
  * @async
  * @static
  */
-export function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config }) {
+export function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, privateKeys }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && !armor) throw new Error("Can't sign non-armored cleartext message");
   if (message instanceof CleartextMessage && detached) throw new Error("Can't detach-sign a cleartext message");
+  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead");
+
   signingKeys = toArray(signingKeys); signingUserIDs = toArray(signingUserIDs);
 
   return Promise.resolve().then(async function() {
@@ -415,11 +421,13 @@ export function sign({ message, signingKeys, armor = true, detached = false, sig
  * @async
  * @static
  */
-export function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config }) {
+export function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, publicKeys }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
   if (message instanceof CleartextMessage && format === 'binary') throw new Error("Can't return cleartext message data as binary");
   if (message instanceof CleartextMessage && signature) throw new Error("Can't verify detached cleartext signature");
+  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.verify, pass `verificationKeys` instead");
+
   verificationKeys = toArray(verificationKeys);
 
   return Promise.resolve().then(async function() {

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -257,7 +257,7 @@ export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessi
   config = { ...defaultConfig, ...config };
   checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.detached) {
-    throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
+    throw new Error("The `detached` option has been removed from openpgp.encrypt, separately call openpgp.sign instead. Don't forget to remove the `privateKeys` option as well.");
   }
   if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.encrypt, pass `encryptionKeys` instead");
   if (rest.privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.encrypt, pass `signingKeys` instead");

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -249,14 +249,14 @@ export async function encryptKey({ privateKey, passphrase, config }) {
  * @async
  * @static
  */
-export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, detached = false, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, privateKeys, publicKeys }) {
+export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
-  if (detached) {
+  if (rest.detached) {
     throw new Error("detached option has been removed from openpgp.encrypt. Separately call openpgp.sign instead. Don't forget to remove privateKeys option as well.");
   }
-  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.encrypt, pass `encryptionKeys` instead");
-  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.encrypt, pass `signingKeys` instead");
+  if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.encrypt, pass `encryptionKeys` instead");
+  if (rest.privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.encrypt, pass `signingKeys` instead");
 
   return Promise.resolve().then(async function() {
     const streaming = message.fromStream;
@@ -307,11 +307,11 @@ export function encrypt({ message, encryptionKeys, signingKeys, passwords, sessi
  * @async
  * @static
  */
-export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, privateKeys, publicKeys }) {
+export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); verificationKeys = toArray(verificationKeys); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
-  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.decrypt, pass `decryptionKeys` instead");
-  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.decrypt, pass `verificationKeys` instead");
+  if (rest.privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.decrypt, pass `decryptionKeys` instead");
+  if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.decrypt, pass `verificationKeys` instead");
 
   return message.decrypt(decryptionKeys, passwords, sessionKeys, config).then(async function(decrypted) {
     if (!verificationKeys) {
@@ -366,12 +366,12 @@ export function decrypt({ message, decryptionKeys, passwords, sessionKeys, verif
  * @async
  * @static
  */
-export function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, privateKeys }) {
+export function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
+  if (rest.privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead");
   if (message instanceof CleartextMessage && !armor) throw new Error("Can't sign non-armored cleartext message");
   if (message instanceof CleartextMessage && detached) throw new Error("Can't detach-sign a cleartext message");
-  if (privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead");
 
   signingKeys = toArray(signingKeys); signingUserIDs = toArray(signingUserIDs);
 
@@ -421,12 +421,12 @@ export function sign({ message, signingKeys, armor = true, detached = false, sig
  * @async
  * @static
  */
-export function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, publicKeys }) {
+export function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message);
+  if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.verify, pass `verificationKeys` instead");
   if (message instanceof CleartextMessage && format === 'binary') throw new Error("Can't return cleartext message data as binary");
   if (message instanceof CleartextMessage && signature) throw new Error("Can't verify detached cleartext signature");
-  if (publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.verify, pass `verificationKeys` instead");
 
   verificationKeys = toArray(verificationKeys);
 
@@ -474,9 +474,10 @@ export function verify({ message, verificationKeys, expectSigned = false, format
  * @async
  * @static
  */
-export function generateSessionKey({ encryptionKeys, date = new Date(), encryptionUserIDs = [], config }) {
+export function generateSessionKey({ encryptionKeys, date = new Date(), encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   encryptionKeys = toArray(encryptionKeys); encryptionUserIDs = toArray(encryptionUserIDs);
+  if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.generateSessionKey, pass `encryptionKeys` instead");
 
   return Promise.resolve().then(async function() {
 
@@ -504,9 +505,10 @@ export function generateSessionKey({ encryptionKeys, date = new Date(), encrypti
  * @async
  * @static
  */
-export function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, armor = true, wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config }) {
+export function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, armor = true, wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkBinary(data); checkString(algorithm, 'algorithm'); encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionUserIDs = toArray(encryptionUserIDs);
+  if (rest.publicKeys) throw new Error("The `publicKeys` option has been removed from openpgp.encryptSessionKey, pass `encryptionKeys` instead");
 
   return Promise.resolve().then(async function() {
 
@@ -530,9 +532,10 @@ export function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKe
  * @async
  * @static
  */
-export function decryptSessionKeys({ message, decryptionKeys, passwords, config }) {
+export function decryptSessionKeys({ message, decryptionKeys, passwords, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords);
+  if (rest.privateKeys) throw new Error("The `privateKeys` option has been removed from openpgp.decryptSessionKeys, pass `decryptionKeys` instead");
 
   return Promise.resolve().then(async function() {
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1509,7 +1509,7 @@ aOU=
   describe('sign - unit tests', function() {
     it('Supports signing with GnuPG dummy key', async function() {
       const dummyKey = await openpgp.readKey({ armoredKey: gnuDummyKeySigningSubkey });
-      const sig = await openpgp.sign({ message: await openpgp.createMessage({ text: 'test' }), privateKeys: dummyKey, date: new Date('2018-12-17T03:24:00') });
+      const sig = await openpgp.sign({ message: await openpgp.createMessage({ text: 'test' }), signingKeys: dummyKey, date: new Date('2018-12-17T03:24:00') });
       expect(sig).to.match(/-----END PGP MESSAGE-----\n$/);
     });
   });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1509,7 +1509,12 @@ aOU=
   describe('sign - unit tests', function() {
     it('Supports signing with GnuPG dummy key', async function() {
       const dummyKey = await openpgp.readKey({ armoredKey: gnuDummyKeySigningSubkey });
-      const sig = await openpgp.sign({ message: await openpgp.createMessage({ text: 'test' }), signingKeys: dummyKey, date: new Date('2018-12-17T03:24:00') });
+      const sig = await openpgp.sign({
+        message: await openpgp.createMessage({ text: 'test' }),
+        signingKeys: dummyKey,
+        date: new Date('2018-12-17T03:24:00'),
+        config: { minRSABits: 1024 }
+      });
       expect(sig).to.match(/-----END PGP MESSAGE-----\n$/);
     });
   });


### PR DESCRIPTION
With the v5 parameter changes, it Is helpful to warn the user about this change as indicated by @larabr  in https://github.com/openpgpjs/openpgpjs/pull/1323#issuecomment-855210378

This PR does that :)