### PR TITLE
Remove `primaryKey` argument from `User` methods, rename `User.sign` to `User.certify`

### DIFF
--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -247,7 +247,7 @@ export async function mergeSignatures(source, dest, attr, date = new Date(), che
  * @param  {PublicSubkeyPacket|
  *          SecretSubkeyPacket|
  *          PublicKeyPacket|
- *          SecretKeyPacket} key, optional The key packet to check the signature
+ *          SecretKeyPacket} key, optional The key packet to verify the signature, instead of the primary key
  * @param {Date} date - Use the given date instead of the current time
  * @param {Object} config - Full configuration
  * @returns {Promise<Boolean>} True if the signature revokes the data.

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -507,10 +507,12 @@ class Key {
       ));
       if (usersToUpdate.length > 0) {
         await Promise.all(
-          usersToUpdate.map(userToUpdate => userToUpdate.update(srcUser, updatedKey.keyPacket, date, config))
+          usersToUpdate.map(userToUpdate => userToUpdate.update(srcUser, date, config))
         );
       } else {
-        updatedKey.users.push(srcUser);
+        const newUser = srcUser.clone();
+        newUser.mainKey = updatedKey;
+        updatedKey.users.push(newUser);
       }
     }));
     // update subkeys
@@ -524,7 +526,9 @@ class Key {
           subkeysToUpdate.map(subkeyToUpdate => subkeyToUpdate.update(srcSubkey, date, config))
         );
       } else {
-        updatedKey.subkeys.push(srcSubkey);
+        const newSubkey = srcSubkey.clone();
+        newSubkey.mainKey = updatedKey;
+        updatedKey.subkeys.push(newSubkey);
       }
     }));
 

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -70,7 +70,7 @@ class Key {
           break;
         case enums.packet.userID:
         case enums.packet.userAttribute:
-          user = new User(packet);
+          user = new User(packet, this);
           this.users.push(user);
           break;
         case enums.packet.publicSubkey:

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -588,7 +588,7 @@ class Key {
    */
   async signPrimaryUser(privateKeys, date, userID, config = defaultConfig) {
     const { index, user } = await this.getPrimaryUser(date, userID, config);
-    const userSign = await user.sign(this.keyPacket, privateKeys, date, config);
+    const userSign = await user.sign(privateKeys, date, config);
     const key = this.clone();
     key.users[index] = userSign;
     return key;
@@ -603,10 +603,9 @@ class Key {
    * @async
    */
   async signAllUsers(privateKeys, date = new Date(), config = defaultConfig) {
-    const that = this;
     const key = this.clone();
     key.users = await Promise.all(this.users.map(function(user) {
-      return user.sign(that.keyPacket, privateKeys, date, config);
+      return user.sign(privateKeys, date, config);
     }));
     return key;
   }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -620,8 +620,9 @@ class Key {
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Array<{
    *   keyID: module:type/keyid~KeyID,
-   *   valid: Boolean
-   * }>>} List of signer's keyID and validity of signature
+   *   valid: Boolean|null
+   * }>>} List of signer's keyID and validity of signature.
+   *      Signature validity is null if the verification keys do not correspond to the certificate.
    * @async
    */
   async verifyPrimaryUser(verificationKeys, date = new Date(), userID, config = defaultConfig) {
@@ -629,7 +630,7 @@ class Key {
     const { user } = await this.getPrimaryUser(date, userID, config);
     const results = verificationKeys ?
       await user.verifyAllCertifications(verificationKeys, date, config) :
-      [{ keyID: primaryKey.getKeyID(), valid: await user.verify(primaryKey, date, config).catch(() => false) }];
+      [{ keyID: primaryKey.getKeyID(), valid: await user.verify(date, config).catch(() => false) }];
     return results;
   }
 
@@ -644,7 +645,8 @@ class Key {
    *   userID: String,
    *   keyID: module:type/keyid~KeyID,
    *   valid: Boolean|null
-   * }>>} List of userID, signer's keyID and validity of signature
+   * }>>} List of userID, signer's keyID and validity of signature.
+   *      Signature validity is null if the verification keys do not correspond to the certificate.
    * @async
    */
   async verifyAllUsers(verificationKeys, date = new Date(), config = defaultConfig) {
@@ -653,7 +655,7 @@ class Key {
     await Promise.all(this.users.map(async user => {
       const signatures = verificationKeys ?
         await user.verifyAllCertifications(verificationKeys, date, config) :
-        [{ keyID: primaryKey.getKeyID(), valid: await user.verify(primaryKey, date, config).catch(() => false) }];
+        [{ keyID: primaryKey.getKeyID(), valid: await user.verify(date, config).catch(() => false) }];
 
       results.push(...signatures.map(
         signature => ({

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -592,7 +592,7 @@ class Key {
    */
   async signPrimaryUser(privateKeys, date, userID, config = defaultConfig) {
     const { index, user } = await this.getPrimaryUser(date, userID, config);
-    const userSign = await user.sign(privateKeys, date, config);
+    const userSign = await user.certify(privateKeys, date, config);
     const key = this.clone();
     key.users[index] = userSign;
     return key;
@@ -609,7 +609,7 @@ class Key {
   async signAllUsers(privateKeys, date = new Date(), config = defaultConfig) {
     const key = this.clone();
     key.users = await Promise.all(this.users.map(function(user) {
-      return user.sign(privateKeys, date, config);
+      return user.certify(privateKeys, date, config);
     }));
     return key;
   }

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -440,7 +440,7 @@ class Key {
       throw exception || new Error('Could not find primary user');
     }
     await Promise.all(users.map(async function (a) {
-      return a.user.revoked || a.user.isRevoked(primaryKey, a.selfCertification, null, date, config);
+      return a.user.revoked || a.user.isRevoked(a.selfCertification, null, date, config);
     }));
     // sort by primary user flag and signature creation time
     const primaryUser = users.sort(function(a, b) {
@@ -449,7 +449,7 @@ class Key {
       return B.revoked - A.revoked || A.isPrimaryUserID - B.isPrimaryUserID || A.created - B.created;
     }).pop();
     const { user, selfCertification: cert } = primaryUser;
-    if (cert.revoked || await user.isRevoked(primaryKey, cert, null, date, config)) {
+    if (cert.revoked || await user.isRevoked(cert, null, date, config)) {
       throw new Error('Primary user is revoked');
     }
     return primaryUser;

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -42,6 +42,17 @@ class Subkey {
   }
 
   /**
+   * Shallow clone
+   * @return {Subkey}
+   */
+  clone() {
+    const subkey = new Subkey(this.keyPacket, this.mainKey);
+    subkey.bindingSignatures = [...this.bindingSignatures];
+    subkey.revocationSignatures = [...this.revocationSignatures];
+    return subkey;
+  }
+
+  /**
    * Checks if a binding signature of a subkey is revoked
    * @param {SignaturePacket} signature - The binding signature to verify
    * @param  {PublicSubkeyPacket|

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -69,7 +69,7 @@ class User {
         throw new Error('Need private key for signing');
       }
       if (privateKey.hasSameFingerprintAs(primaryKey)) {
-        throw new Error(`The user's own key can only be used for self-certifications`);
+        throw new Error("The user's own key can only be used for self-certifications");
       }
       const signingKey = await privateKey.getSigningKey(undefined, date, undefined, config);
       return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -38,15 +38,14 @@ class User {
 
   /**
    * Signs user
-   * @param  {SecretKeyPacket|
-   *          PublicKeyPacket}          primaryKey  The primary key packet
-   * @param {Array<Key>} privateKeys - Decrypted private keys for signing
+   * @param {Array<PrivateKey>} privateKeys - Decrypted private keys for signing
    * @param {Date} date - Date to overwrite creation date of the signature
    * @param {Object} config - Full configuration
-   * @returns {Promise<Key>} New user with new certificate signatures.
+   * @returns {Promise<User>} New user with new certificate signatures.
    * @async
    */
-  async sign(primaryKey, privateKeys, date, config) {
+  async sign(privateKeys, date, config) {
+    const primaryKey = this.mainKey.keyPacket;
     const dataToSign = {
       userID: this.userID,
       userAttribute: this.userAttribute,

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -10,14 +10,17 @@ import { mergeSignatures, isDataRevoked, createSignaturePacket } from './helper'
 
 /**
  * Class that represents an user ID or attribute packet and the relevant signatures.
+  * @param {UserIDPacket|UserAttributePacket} userPacket - packet containing the user info
+  * @param {Key} mainKey - reference to main Key object containing the primary key and subkeys that the user is associated with
  */
 class User {
-  constructor(userPacket) {
+  constructor(userPacket, mainKey) {
     this.userID = userPacket.constructor.tag === enums.packet.userID ? userPacket : null;
     this.userAttribute = userPacket.constructor.tag === enums.packet.userAttribute ? userPacket : null;
     this.selfCertifications = [];
     this.otherCertifications = [];
     this.revocationSignatures = [];
+    this.mainKey = mainKey;
   }
 
   /**
@@ -49,7 +52,7 @@ class User {
       userAttribute: this.userAttribute,
       key: primaryKey
     };
-    const user = new User(dataToSign.userID || dataToSign.userAttribute);
+    const user = new User(dataToSign.userID || dataToSign.userAttribute, this.mainKey);
     user.otherCertifications = await Promise.all(privateKeys.map(async function(privateKey) {
       if (privateKey.isPublic()) {
         throw new Error('Need private key for signing');

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2840,7 +2840,7 @@ module.exports = () => describe('Key', function() {
       expect(signatures[1].valid).to.be.false;
 
       const { user } = await pubKey.getPrimaryUser();
-      await expect(user.verifyCertificate(pubKey.keyPacket, user.otherCertifications[0], [certifyingKey], undefined, openpgp.config)).to.be.rejectedWith('User certificate is revoked');
+      await expect(user.verifyCertificate(user.otherCertifications[0], [certifyingKey], undefined, openpgp.config)).to.be.rejectedWith('User certificate is revoked');
     } finally {
       openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
     }
@@ -2854,8 +2854,8 @@ module.exports = () => describe('Key', function() {
   it('Verify certificate of key with future creation date', async function() {
     const pubKey = await openpgp.readKey({ armoredKey: key_created_2030 });
     const user = pubKey.users[0];
-    await user.verifyCertificate(pubKey.keyPacket, user.selfCertifications[0], [pubKey], pubKey.keyPacket.created, openpgp.config);
-    const verifyAllResult = await user.verifyAllCertifications(pubKey.keyPacket, [pubKey], pubKey.keyPacket.created);
+    await user.verifyCertificate(user.selfCertifications[0], [pubKey], pubKey.keyPacket.created, openpgp.config);
+    const verifyAllResult = await user.verifyAllCertifications([pubKey], pubKey.keyPacket.created, openpgp.config);
     expect(verifyAllResult[0].valid).to.be.true;
     await user.verify(pubKey.keyPacket, pubKey.keyPacket.created);
   });

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2857,7 +2857,7 @@ module.exports = () => describe('Key', function() {
     await user.verifyCertificate(user.selfCertifications[0], [pubKey], pubKey.keyPacket.created, openpgp.config);
     const verifyAllResult = await user.verifyAllCertifications([pubKey], pubKey.keyPacket.created, openpgp.config);
     expect(verifyAllResult[0].valid).to.be.true;
-    await user.verify(pubKey.keyPacket, pubKey.keyPacket.created);
+    await user.verify(pubKey.keyPacket.created, openpgp.config);
   });
 
   it('Evaluate key flags to find valid encryption key packet', async function() {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1623,7 +1623,7 @@ iTuGu4fEU1UligAXSrZmCdE=
 
     const key = await openpgp.readKey({ armoredKey: armoredKeyWithPhoto });
     await Promise.all(key.users.map(async user => {
-      await user.verify(key.keyPacket);
+      await user.verify(undefined, openpgp.config);
     }));
   });
 

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -407,9 +407,7 @@ function omnibus() {
       await certificate.verify(
         primaryKey, openpgp.enums.signature.certGeneric, { userID: user.userID, key: primaryKey }
       );
-      await user.verifyCertificate(
-        primaryKey, certificate, [hi.toPublic()], undefined, openpgp.config
-      );
+      await user.verifyCertificate(certificate, [hi.toPublic()], undefined, openpgp.config);
 
       const options = {
         userIDs: { name: "Bye", email: "bye@good.bye" },
@@ -428,9 +426,7 @@ function omnibus() {
         await certificate.verify(
           bye.keyPacket, openpgp.enums.signature.certGeneric, { userID: user.userID, key: bye.keyPacket }
         );
-        await user.verifyCertificate(
-          bye.keyPacket, user.selfCertifications[0], [bye.toPublic()], undefined, openpgp.config
-        );
+        await user.verifyCertificate(user.selfCertifications[0], [bye.toPublic()], undefined, openpgp.config);
 
         return Promise.all([
           // Hi trusts Bye!


### PR DESCRIPTION
Changes:
- add `User.mainKey` field to store a reference to the corresponding `Key`, allowing to simplify calling some `User` methods. This is a follow-up to #1302 , which introduced `Subkey.mainKey` for the same reason.
- rename `User.sign` to `User.certify`, since it's used for third-party certifications and not as a counterpart of `User.verify`, which deals with self-signatures.
- change `Key.update` to store a copy of newly added users and subkeys (pointing to the same instance could give issues since the lists of certifications and signatures could be altered by both the source key and the updated one).

Breaking changes in `User` methods:
- `User.constructor(userPacket)` -> `constructor(userPacket, mainKey)`
- `User.sign(primaryKey, signingKeys, date, config)` -> `.certify(signingKeys, date, config)`
- `User.verify(primaryKey, date = new Date(), config)` -> `.verify(date = new Date(), config)`
- `User.verifyCertificate(primaryKey, certificate, verificationKeys, date = new Date(), config)` -> `.verifyCertificate(certificate, verificationKeys, date = new Date(), config)`
- `User.verifyAllCertifications(primaryKey, verificationKeys, date = new Date(), config)` -> `.verifyAllCertifications(verificationKeys, date = new Date(), config)`
- `User.isRevoked(primaryKey, certificate, keyPacket, date = new Date(), config)` -> `.isRevoked(certificate, keyPacket, date = new Date(), config)`
- `User.update(sourceUser, primaryKey, date, config)` -> `.update(sourceUser, date, config)`
