### PR TITLE
CI: detect unhandled rejections in browser tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -102,7 +102,7 @@ module.exports = function(config) {
       bs_safari_14: {
         base: 'BrowserStack',
         browser: 'Safari',
-        browser_version: '14',
+        browser_version: '14.0',
         os: 'OS X',
         os_version: 'Big Sur'
       },

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -31,7 +31,7 @@ describe('Unit Tests', function () {
   openpgp.config.s2kIterationCountByte = 0;
 
   if (typeof window !== 'undefined') {
-    window.addEventListener("unhandledrejection", function (event) {
+    window.addEventListener('unhandledrejection', function (event) {
       throw event.reason;
     });
 

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -31,7 +31,7 @@ describe('Unit Tests', function () {
   openpgp.config.s2kIterationCountByte = 0;
 
   if (typeof window !== 'undefined') {
-    window.addEventListener("unhandledrejection", function (event){
+    window.addEventListener("unhandledrejection", function (event) {
       throw event.reason;
     });
 

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -31,6 +31,10 @@ describe('Unit Tests', function () {
   openpgp.config.s2kIterationCountByte = 0;
 
   if (typeof window !== 'undefined') {
+    window.addEventListener("unhandledrejection", function (event){
+      throw event.reason;
+    });
+
     window.location.search.substr(1).split('&').forEach(param => {
       const [key, value] = param.split('=');
       if (key && key !== 'grep') {


### PR DESCRIPTION
Follow up to https://github.com/openpgpjs/openpgpjs/pull/1251 , which added an unhandled rejection listener for Node tests. This PR does the same for browsers.

Also target the Safari release for macOS Big Sur in Browserstack.