### PR TITLE
Ignore Trust and Marker packets on parsing and always throw on unexpected packets

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -85,17 +85,15 @@ export class Message {
    * @returns {Array<module:type/keyid~KeyID>} Array of keyID objects.
    */
   getSigningKeyIDs() {
-    let keyIDs = [];
     const msg = this.unwrapCompressed();
     // search for one pass signatures
     const onePassSigList = msg.packets.filterByTag(enums.packet.onePassSignature);
-    keyIDs = onePassSigList.map(packet => packet.issuerKeyID);
-    // if nothing found look for signature packets
-    if (!keyIDs.length) {
-      const signatureList = msg.packets.filterByTag(enums.packet.signature);
-      keyIDs = signatureList.map(packet => packet.issuerKeyID);
+    if (onePassSigList.length > 0) {
+      return onePassSigList.map(packet => packet.issuerKeyID);
     }
-    return keyIDs;
+    // if nothing found look for signature packets
+    const signatureList = msg.packets.filterByTag(enums.packet.signature);
+    return signatureList.map(packet => packet.issuerKeyID);
   }
 
   /**

--- a/src/message.js
+++ b/src/message.js
@@ -85,19 +85,15 @@ export class Message {
    * @returns {Array<module:type/keyid~KeyID>} Array of keyID objects.
    */
   getSigningKeyIDs() {
-    const keyIDs = [];
+    let keyIDs = [];
     const msg = this.unwrapCompressed();
     // search for one pass signatures
     const onePassSigList = msg.packets.filterByTag(enums.packet.onePassSignature);
-    onePassSigList.forEach(function(packet) {
-      keyIDs.push(packet.issuerKeyID);
-    });
+    keyIDs = onePassSigList.map(packet => packet.issuerKeyID);
     // if nothing found look for signature packets
     if (!keyIDs.length) {
       const signatureList = msg.packets.filterByTag(enums.packet.signature);
-      signatureList.forEach(function(packet) {
-        keyIDs.push(packet.issuerKeyID);
-      });
+      keyIDs = signatureList.map(packet => packet.issuerKeyID);
     }
     return keyIDs;
   }

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -109,7 +109,7 @@ class OnePassSignaturePacket {
    * @returns {Uint8Array} A Uint8Array representation of a one-pass signature packet.
    */
   write() {
-    const start = new Uint8Array([3, enums.write(enums.signature, this.signatureType),
+    const start = new Uint8Array([VERSION, enums.write(enums.signature, this.signatureType),
       enums.write(enums.hash, this.hashAlgorithm),
       enums.write(enums.publicKey, this.publicKeyAlgorithm)]);
 

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -5,8 +5,6 @@ import {
   writePartialLength, writeSimpleLength,
   UnsupportedError
 } from './packet';
-import TrustPacket from './trust';
-import MarkerPacket from './marker';
 import util from '../util';
 import enums from '../enums';
 import defaultConfig from '../config';
@@ -72,7 +70,7 @@ class PacketList extends Array {
           await writer.ready;
           const done = await readPackets(readable, async parsed => {
             try {
-              if (parsed.tag === MarkerPacket.tag || parsed.tag === TrustPacket.tag) {
+              if (parsed.tag === enums.packet.marker || parsed.tag === enums.packet.trust) {
                 // According to the spec, these packet types should be ignored and not cause parsing errors, even if not esplicitly allowed:
                 // - Marker packets MUST be ignored when received: https://github.com/openpgpjs/openpgpjs/issues/1145
                 // - Trust packets SHOULD be ignored outside of keyrings (unsupported): https://datatracker.ietf.org/doc/html/rfc4880#section-5.10

--- a/src/signature.js
+++ b/src/signature.js
@@ -57,12 +57,7 @@ export class Signature {
    * @returns {Array<KeyID>} The Key IDs of the signing keys
    */
   getSigningKeyIDs() {
-    const keyIDs = [];
-    const signatureList = this.packets.filterByTag(enums.packet.signature);
-    signatureList.forEach(function(packet) {
-      keyIDs.push(packet.issuerKeyID);
-    });
-    return keyIDs;
+    return this.packets.map(packet => packet.issuerKeyID);
   }
 }
 

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -631,6 +631,49 @@ hW1Hj9AO8lzggBQ=
 =Nt+N
 -----END PGP PUBLIC KEY BLOCK-----`;
 
+  const sequoiaBobPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Bob's OpenPGP certificate
+
+mQGNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv
+/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz
+/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/
+5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3
+X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv
+9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0
+qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb
+SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb
+vLIwa3T4CyshfT0AEQEAAbQhQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w
+bGU+iQHOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx
+gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz
+XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO
+ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g
+9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF
+DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c
+ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1
+6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ
+ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo
+zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGuQGNBF2lnPIBDADW
+ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI
+DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+
+Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO
+baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT
+86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh
+827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6
+vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U
+qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A
+EQEAAYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ
+EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS
+KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx
+cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i
+tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV
+dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w
+qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy
+jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj
+zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV
+NEJd3XZRzaXZE2aAMQ==
+=NXei
+-----END PGP PUBLIC KEY BLOCK-----`;
+
   const signature_with_critical_notation = `-----BEGIN PGP MESSAGE-----
 
 owGbwMvMwMH4oOW7S46CznTG09xJDDE3Wl1KUotLuDousDAwcjBYiSmyXL+48d6x
@@ -691,6 +734,30 @@ kCNcH9WI6idSzFjuYegECf+ZA1xOCjS9oLTGbSeT7jNfC8dH5+E92qlBLq4Ctt7k
 
     await expect(openpgp.readSignature({ armoredSignature })).to.be.rejectedWith(/Missing signature creation time/);
   });
+
+  it('Ignores marker packets when verifying signatures', async function () {
+    const signatureWithMarkerPacket = `-----BEGIN PGP SIGNATURE-----
+
+ygNQR1DCwPMEAAEKAAYFgl8831AAIQkQ+/zIKgFeczAWIQTRpm4aI7GCyZgPeIz7
+/MgqAV5zMLckDACWiDbasKMTX/+czxHXyVcFJ/+ZeYqKEjYq6LueHy11XjJ0NZAM
+LG9TqsXpWOsHrwE6wUQ7RvKQYtfIAeMUZtD87/XomIj6B/rQC5dHuQTb0b8lrRJb
+OuW1sz6AYwceqkSvN3T5+KKNMXkaFw/DzWGPfqQQJDOqfgKxf5uO7GPVzaIU6aXn
+76iKHQ7wowT2qHoFhd+t4S11iGr6XJef6QqIW2kTetZMf2Dp/rr7228VJJ1S0RdD
+xxKJEbNrmdMNgE8/U+pkWjMQyVOOxWyPKlG3kv2Cu/naj4Lg2io3RhOAuNW5xEJF
+gAId3WUNl3/PCu/PcTS1yS/Nj0ptwjKHwG0Zg8Dk5Jey8lUVyVhjxrV5tb6NLoAG
+RlyTajZ3Sjhsg4mXHopjSF2w30saN64L5VAfGF1afFu7yzNYC+Fn6GL5yTJfKs4j
+PNo4zCwOCumsVP0jWp09yUNflE6MTd21miBgbmPxyLyuwP2YrvT4+rCl+meNZ98a
+cJRRGJPL16wINuk=
+=VNoM
+-----END PGP SIGNATURE-----`;
+
+    const key = await openpgp.readKey({ armoredKey: sequoiaBobPublicKey });
+    const message = await openpgp.createMessage({ text: 'Marker + Detached signature' });
+    const signature = await openpgp.readSignature({ armoredSignature: signatureWithMarkerPacket });
+    const { signatures: [sigInfo] } = await openpgp.verify({ message, signature, verificationKeys: key });
+    expect(sigInfo.valid).to.be.true;
+  });
+
 
   it('Testing signature checking on CAST5-enciphered message', async function() {
     const publicKey = await openpgp.readKey({ armoredKey: pub_key_arm1 });


### PR DESCRIPTION
- Parsing changes:
  - throw on unexpected packets even if `config.tolerant = true` (e.g. if a Public Key packet is found when reading a signature).
  - ignore Trust and Marker packets (based on https://datatracker.ietf.org/doc/html/rfc4880#section-5.10, https://datatracker.ietf.org/doc/html/rfc4880#section-5.8)
- Fix #1145 even for `config.tolerant = false` 
