### PR TITLE
Simplify return value of `generateKey`, `reformatKey` and `revokeKey` and add support for binary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,15 +435,15 @@ and a subkey for encryption using Curve25519.
 
 ```js
 (async () => {
-    const { privateKeyArmored, publicKeyArmored, revocationCertificate } = await openpgp.generateKey({
+    const { privateKey, publicKey, revocationCertificate } = await openpgp.generateKey({
         type: 'ecc', // Type of the key, defaults to ECC
         curve: 'curve25519', // ECC curve name, defaults to curve25519
         userIDs: [{ name: 'Jon Smith', email: 'jon@example.com' }], // you can pass multiple user IDs
-        passphrase: 'super long and hard to guess secret' // protects the private key
-    });
+        passphrase: 'super long and hard to guess secret', // protects the private key
+        format: 'armor' // output key format, defaults to 'armor' (other options: 'binary' or 'object')
 
-    console.log(privateKeyArmored);     // '-----BEGIN PGP PRIVATE KEY BLOCK ... '
-    console.log(publicKeyArmored);      // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
+    console.log(privateKey);     // '-----BEGIN PGP PRIVATE KEY BLOCK ... '
+    console.log(publicKey);      // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
     console.log(revocationCertificate); // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 })();
 ```
@@ -452,7 +452,7 @@ RSA keys (increased compatibility):
 
 ```js
 (async () => {
-    const key = await openpgp.generateKey({
+    const { privateKey, publicKey } = await openpgp.generateKey({
         type: 'rsa', // Type of the key
         rsaBits: 4096, // RSA key size (defaults to 4096 bits)
         userIDs: [{ name: 'Jon Smith', email: 'jon@example.com' }], // you can pass multiple user IDs
@@ -466,9 +466,10 @@ RSA keys (increased compatibility):
 Using a revocation certificate:
 ```js
 (async () => {
-    const { publicKeyArmored: revokedKeyArmored } = await openpgp.revokeKey({
+    const { publicKey: revokedKeyArmored } = await openpgp.revokeKey({
         key: await openpgp.readKey({ armoredKey: publicKeyArmored }),
-        revocationCertificate
+        revocationCertificate,
+        format: 'armor' // output armored keys
     });
     console.log(revokedKeyArmored); // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 })();
@@ -477,9 +478,11 @@ Using a revocation certificate:
 Using the private key:
 ```js
 (async () => {
-    const { publicKeyArmored, publicKey } = await openpgp.revokeKey({
-        key: await openpgp.readKey({ armoredKey: privateKeyArmored })
+    const { publicKey: revokedKeyArmored } = await openpgp.revokeKey({
+        key: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        format: 'armor' // output armored keys
     });
+    console.log(revokedKeyArmored); // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 })();
 ```
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -27,6 +27,12 @@ export function encryptKey(options: { privateKey: PrivateKey; passphrase?: strin
 export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
 export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
 export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<string>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'binary', config?: PartialConfig }): Promise<Uint8Array>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'object', config?: PartialConfig }): Promise<PrivateKey>;
+export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<string>;
+export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<Uint8Array>;
+export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<T>;
 
 export abstract class Key {
   public readonly keyPacket: PublicKeyPacket | SecretKeyPacket;
@@ -68,7 +74,7 @@ export class PublicKey extends Key {
 
 export class PrivateKey extends PublicKey {
   constructor(packetlist: PacketList<AnyKeyPacket>);
-  public revoke(reason: { flag?: enums.reasonForRevocation; string?: string; }, date?: Date, config?: Config): Promise<PrivateKey>;
+  public revoke(reason?: ReasonForRevocation, date?: Date, config?: Config): Promise<PrivateKey>;
   public isDecrypted(): boolean;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
   public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<PrivateKey | Subkey>
@@ -542,6 +548,7 @@ export namespace stream {
 export interface UserID { name?: string; email?: string; comment?: string; }
 export interface SessionKey { data: Uint8Array; algorithm: string; }
 
+export interface ReasonForRevocation { flag?: enums.reasonForRevocation, string?: string }
 
 interface EncryptOptions {
   /** message to be encrypted as created by createMessage */

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -17,22 +17,25 @@ export function readPrivateKey(options: { armoredKey: string, config?: PartialCo
 export function readPrivateKey(options: { binaryKey: Uint8Array, config?: PartialConfig }): Promise<PrivateKey>;
 export function readPrivateKeys(options: { armoredKeys: string, config?: PartialConfig }): Promise<PrivateKey[]>;
 export function readPrivateKeys(options: { binaryKeys: Uint8Array, config?: PartialConfig }): Promise<PrivateKey[]>;
-export function generateKey(options: KeyOptions & { format?: 'armor' }): Promise<SerializedKeyPair<string>>;
-export function generateKey(options: KeyOptions & { format: 'object' }): Promise<KeyPair>;
-export function generateKey(options: KeyOptions & { format: 'binary' }): Promise<SerializedKeyPair<Uint8Array>>;
+export function generateKey(options: KeyOptions & { format?: 'armor' }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
+export function generateKey(options: KeyOptions & { format: 'binary' }): Promise<SerializedKeyPair<Uint8Array> & { revocationCertificate: string }>;
+export function generateKey(options: KeyOptions & { format: 'object' }): Promise<KeyPair & { revocationCertificate: string }>;
 
 export function generateSessionKey(options: { encryptionKeys: PublicKey[], date?: Date, encryptionUserIDs?: UserID[], config?: PartialConfig }): Promise<SessionKey>;
 export function decryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
 export function encryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
-export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
-export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
-export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
-export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<string>;
-export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'binary', config?: PartialConfig }): Promise<Uint8Array>;
-export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'object', config?: PartialConfig }): Promise<PrivateKey>;
-export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<string>;
-export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<Uint8Array>;
-export function revokeKey<T extends PublicKey>(options: { key: T, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<T>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array> & { revocationCertificate: string }>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair & { revocationCertificate: string }>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
+export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
+export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
+export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
+export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<{ publicKey: string, privateKey: null }>;
+export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<{ publicKey: Uint8Array, privateKey: null }>;
+export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<{ publicKey: PublicKey, privateKey: null }>;
 
 export abstract class Key {
   public readonly keyPacket: PublicKeyPacket | SecretKeyPacket;
@@ -634,12 +637,10 @@ interface VerifyOptions {
 interface SerializedKeyPair<T extends string|Uint8Array> {
   privateKey: T;
   publicKey: T;
-  revocationCertificate: string;
 }
 interface KeyPair {
   privateKey: PrivateKey;
   publicKey: PublicKey;
-  revocationCertificate: string;
 }
 
 export type EllipticCurveName = 'ed25519' | 'curve25519' | 'p256' | 'p384' | 'p521' | 'secp256k1' | 'brainpoolP256r1' | 'brainpoolP384r1' | 'brainpoolP512r1';

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -643,10 +643,10 @@ interface KeyOptions {
   type?: 'ecc' | 'rsa';
   curve?: EllipticCurveName;
   rsaBits?: number;
-  format?: 'armor' | 'object' | 'binary';
   keyExpirationTime?: number;
   date?: Date;
   subkeys?: SubkeyOptions[];
+  format?: 'armor' | 'object' | 'binary';
   config?: PartialConfig;
 }
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -24,7 +24,9 @@ export function generateKey(options: KeyOptions & { format: 'binary' }): Promise
 export function generateSessionKey(options: { encryptionKeys: PublicKey[], date?: Date, encryptionUserIDs?: UserID[], config?: PartialConfig }): Promise<SessionKey>;
 export function decryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
 export function encryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
-export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; config?: PartialConfig }): Promise<KeyPair>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: UserID|UserID[]; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
 
 export abstract class Key {
   public readonly keyPacket: PublicKeyPacket | SecretKeyPacket;

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -17,7 +17,10 @@ export function readPrivateKey(options: { armoredKey: string, config?: PartialCo
 export function readPrivateKey(options: { binaryKey: Uint8Array, config?: PartialConfig }): Promise<PrivateKey>;
 export function readPrivateKeys(options: { armoredKeys: string, config?: PartialConfig }): Promise<PrivateKey[]>;
 export function readPrivateKeys(options: { binaryKeys: Uint8Array, config?: PartialConfig }): Promise<PrivateKey[]>;
-export function generateKey(options: KeyOptions): Promise<KeyPair>;
+export function generateKey(options: KeyOptions & { format?: 'armor' }): Promise<SerializedKeyPair<string>>;
+export function generateKey(options: KeyOptions & { format: 'object' }): Promise<KeyPair>;
+export function generateKey(options: KeyOptions & { format: 'binary' }): Promise<SerializedKeyPair<Uint8Array>>;
+
 export function generateSessionKey(options: { encryptionKeys: PublicKey[], date?: Date, encryptionUserIDs?: UserID[], config?: PartialConfig }): Promise<SessionKey>;
 export function decryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
 export function encryptKey(options: { privateKey: PrivateKey; passphrase?: string | string[]; config?: PartialConfig }): Promise<PrivateKey>;
@@ -618,10 +621,15 @@ interface VerifyOptions {
   config?: PartialConfig;
 }
 
+
+interface SerializedKeyPair<T extends string|Uint8Array> {
+  privateKey: T;
+  publicKey: T;
+  revocationCertificate: string;
+}
 interface KeyPair {
-  key: PrivateKey;
-  privateKeyArmored: string;
-  publicKeyArmored: string;
+  privateKey: PrivateKey;
+  publicKey: PublicKey;
   revocationCertificate: string;
 }
 
@@ -633,6 +641,7 @@ interface KeyOptions {
   type?: 'ecc' | 'rsa';
   curve?: EllipticCurveName;
   rsaBits?: number;
+  format?: 'armor' | 'object' | 'binary';
   keyExpirationTime?: number;
   date?: Date;
   subkeys?: SubkeyOptions[];

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -130,7 +130,10 @@ export async function reformat(options, config) {
 
   options.subkeys = options.subkeys.map(subkeyOptions => sanitize(subkeyOptions, options));
 
-  return wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, config);
+  const key = await wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, config);
+  const revocationCertificate = await key.getRevocationCertificate(options.date, config);
+  key.revocationSignatures = [];
+  return { key, revocationCertificate };
 
   function sanitize(options, subkeyDefaults = {}) {
     options.keyExpirationTime = options.keyExpirationTime || subkeyDefaults.keyExpirationTime;

--- a/test/crypto/validate.js
+++ b/test/crypto/validate.js
@@ -80,12 +80,17 @@ async function cloneKeyPacket(key) {
   return keyPacket;
 }
 
+async function generatePrivateKeyObject(options) {
+  const { privateKey } = await openpgp.generateKey({ ...options, userIDs: [{ name: 'Test', email: 'test@test.com' }], format: 'object' });
+  return privateKey;
+}
+
 /* eslint-disable no-invalid-this */
 module.exports = () => {
   describe('EdDSA parameter validation', function() {
     let eddsaKey;
     before(async () => {
-      eddsaKey = (await openpgp.generateKey({ curve: 'ed25519', userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+      eddsaKey = await generatePrivateKeyObject({ curve: 'ed25519' });
     });
 
     it('EdDSA params should be valid', async function() {
@@ -109,9 +114,9 @@ module.exports = () => {
     let ecdhKey;
     let ecdsaKey;
     before(async () => {
-      eddsaKey = (await openpgp.generateKey({ curve: 'ed25519', userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+      eddsaKey = await generatePrivateKeyObject({ curve: 'ed25519' });
       ecdhKey = eddsaKey.subkeys[0];
-      ecdsaKey = (await openpgp.generateKey({ curve: 'p256', userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+      ecdsaKey = await generatePrivateKeyObject({ curve: 'p256' });
     });
 
     it('EdDSA params are not valid for ECDH', async function() {
@@ -194,10 +199,10 @@ module.exports = () => {
       let ecdhKey;
       before(async () => {
         if (curve !== 'curve25519') {
-          ecdsaKey = (await openpgp.generateKey({ curve, userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+          ecdsaKey = await generatePrivateKeyObject({ curve });
           ecdhKey = ecdsaKey.subkeys[0];
         } else {
-          const eddsaKey = (await openpgp.generateKey({ curve: 'ed25519', userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+          const eddsaKey = await generatePrivateKeyObject({ curve: 'ed25519' });
           ecdhKey = eddsaKey.subkeys[0];
         }
       });
@@ -244,7 +249,7 @@ module.exports = () => {
   describe('RSA parameter validation', function() {
     let rsaKey;
     before(async () => {
-      rsaKey = (await openpgp.generateKey({ type: 'rsa', rsaBits: 2048, userIDs: [{ name: 'Test', email: 'test@test.com' }] })).key;
+      rsaKey = await generatePrivateKeyObject({ type: 'rsa', rsaBits: 2048 });
     });
 
     it('generated RSA params are valid', async function() {

--- a/test/general/brainpool.js
+++ b/test/general/brainpool.js
@@ -285,12 +285,8 @@ function omnibus() {
     const testData = input.createSomeMessage();
     const testData2 = input.createSomeMessage();
 
-    const firstKey = await openpgp.generateKey({ userIDs: { name: "Hi", email: "hi@hel.lo" }, curve: "brainpoolP256r1" });
-    const hi = firstKey.key;
-    const pubHi = hi.toPublic();
-    const secondKey = await openpgp.generateKey({ userIDs: { name: "Bye", email: "bye@good.bye" }, curve: "brainpoolP256r1" });
-    const bye = secondKey.key;
-    const pubBye = bye.toPublic();
+    const { privateKey: hi, publicKey: pubHi } = await openpgp.generateKey({ userIDs: { name: "Hi", email: "hi@hel.lo" }, curve: "brainpoolP256r1", format: 'object' });
+    const { privateKey: bye, publicKey: pubBye } = await openpgp.generateKey({ userIDs: { name: "Bye", email: "bye@good.bye" }, curve: "brainpoolP256r1", format: 'object' });
 
     const cleartextMessage = await openpgp.sign({ message: await openpgp.createCleartextMessage({ text: testData }), signingKeys: hi });
     await openpgp.verify({

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -41,7 +41,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
   });
 
   it('openpgp.readKey', async function() {
-    const { privateKeyArmored: armoredKey } = await openpgp.generateKey({ userIDs:[{ name:'test', email:'test@a.it' }] });
+    const { privateKey: armoredKey } = await openpgp.generateKey({ userIDs:[{ name:'test', email:'test@a.it' }] });
     await expect(
       openpgp.readKey({ armoredKey, config: { tolerant: false, maxUserIDLength: 2 } })
     ).to.be.rejectedWith(/User ID string is too long/);

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -61,9 +61,10 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
     try {
       const opt = {
-        userIDs: { name: 'Test User', email: 'text@example.com' }
+        userIDs: { name: 'Test User', email: 'text@example.com' },
       };
-      const { key, privateKeyArmored } = await openpgp.generateKey(opt);
+      const { privateKey: privateKeyArmored } = await openpgp.generateKey(opt);
+      const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
       expect(key.keyPacket.version).to.equal(4);
       expect(privateKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
       expect(key.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(openpgp.config.preferredHashAlgorithm);
@@ -77,7 +78,8 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
         userIDs: { name: 'Test User', email: 'text@example.com' },
         config
       };
-      const { key: key2, privateKeyArmored: privateKeyArmored2 } = await openpgp.generateKey(opt2);
+      const { privateKey: privateKeyArmored2 } = await openpgp.generateKey(opt2);
+      const key2 = await openpgp.readKey({ armoredKey: privateKeyArmored2 });
       expect(key2.keyPacket.version).to.equal(5);
       expect(privateKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
       expect(key2.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(config.preferredHashAlgorithm);
@@ -98,7 +100,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
     try {
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
-      const { key: origKey } = await openpgp.generateKey({ userIDs });
+      const { privateKey: origKey } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const opt = { privateKey: origKey, userIDs };
       const { key: refKey, privateKeyArmored: refKeyArmored } = await openpgp.reformatKey(opt);
@@ -133,7 +135,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
     try {
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
-      const { key, revocationCertificate } = await openpgp.generateKey({ userIDs });
+      const { privateKey: key, revocationCertificate } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const opt = { key };
       const { privateKeyArmored: revKeyArmored } = await openpgp.revokeKey(opt);
@@ -158,7 +160,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
     const userIDs = { name: 'Test User', email: 'text2@example.com' };
     const passphrase = '12345678';
 
-    const { key } = await openpgp.generateKey({ userIDs, passphrase });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs, passphrase, format: 'object' });
     key.keyPacket.makeDummy();
 
     const opt = {
@@ -176,7 +178,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
     try {
       const passphrase = '12345678';
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
-      const { key: privateKey } = await openpgp.generateKey({ userIDs });
+      const { privateKey } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const encKey = await openpgp.encryptKey({ privateKey, userIDs, passphrase });
       expect(encKey.keyPacket.s2k.c).to.equal(openpgp.config.s2kIterationCountByte);
@@ -222,7 +224,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       expect(compressed.algorithm).to.equal("zip");
 
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
-      const { key } = await openpgp.generateKey({ userIDs });
+      const { privateKey: key } = await openpgp.generateKey({ userIDs, format: 'object' });
       await expect(openpgp.encrypt({
         message, encryptionKeys: [key], config: { rejectPublicKeyAlgorithms: new Set([openpgp.enums.publicKey.ecdh]) }
       })).to.be.eventually.rejectedWith(/ecdh keys are considered too weak/);
@@ -236,7 +238,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
     const plaintext = 'test';
     const message = await openpgp.createMessage({ text: plaintext });
     const userIDs = { name: 'Test User', email: 'text2@example.com' };
-    const { key } = await openpgp.generateKey({ userIDs, type: 'rsa', rsaBits: 2048 });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs, type: 'rsa', rsaBits: 2048, format: 'object' });
 
     const armoredMessage = await openpgp.encrypt({ message, encryptionKeys:[key], signingKeys: [key] });
     const { data, signatures } = await openpgp.decrypt({
@@ -270,8 +272,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
   it('openpgp.sign', async function() {
     const userIDs = { name: 'Test User', email: 'text2@example.com' };
-    const { privateKeyArmored } = await openpgp.generateKey({ userIDs });
-    const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs, format: 'object' });
 
     const message = await openpgp.createMessage({ text: "test" });
     const opt = {
@@ -298,8 +299,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
   it('openpgp.verify', async function() {
     const userIDs = { name: 'Test User', email: 'text2@example.com' };
-    const { privateKeyArmored } = await openpgp.generateKey({ userIDs });
-    const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs, format: 'object' });
     const config = { rejectMessageHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) };
 
 

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -103,11 +103,12 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       const { privateKey: origKey } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const opt = { privateKey: origKey, userIDs };
-      const { key: refKey, privateKeyArmored: refKeyArmored } = await openpgp.reformatKey(opt);
+      const { privateKey: refKeyArmored } = await openpgp.reformatKey(opt);
+      expect(refKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
+      const refKey = await openpgp.readKey({ armoredKey: refKeyArmored });
       const prefs = refKey.users[0].selfCertifications[0];
       expect(prefs.preferredCompressionAlgorithms[0]).to.equal(openpgp.config.preferredCompressionAlgorithm);
       expect(prefs.preferredHashAlgorithms[0]).to.equal(openpgp.config.preferredHashAlgorithm);
-      expect(refKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
 
       const config = {
         showComment: true,
@@ -116,11 +117,12 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
         rejectPublicKeyAlgorithms: new Set([openpgp.enums.publicKey.eddsa]) // should not matter in this context
       };
       const opt2 = { privateKey: origKey, userIDs, config };
-      const { key: refKey2, privateKeyArmored: refKeyArmored2 } = await openpgp.reformatKey(opt2);
+      const { privateKey: refKeyArmored2 } = await openpgp.reformatKey(opt2);
+      expect(refKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
+      const refKey2 = await openpgp.readKey({ armoredKey: refKeyArmored2 });
       const prefs2 = refKey2.users[0].selfCertifications[0];
       expect(prefs2.preferredCompressionAlgorithms[0]).to.equal(config.preferredCompressionAlgorithm);
       expect(prefs2.preferredHashAlgorithms[0]).to.equal(config.preferredHashAlgorithm);
-      expect(refKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
     } finally {
       openpgp.config.preferredCompressionAlgorithm = preferredCompressionAlgorithmVal;
       openpgp.config.preferredHashAlgorithm = preferredHashAlgorithmVal;

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -140,11 +140,11 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       const { privateKey: key, revocationCertificate } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const opt = { key };
-      const revKeyArmored = await openpgp.revokeKey(opt);
+      const { privateKey: revKeyArmored } = await openpgp.revokeKey(opt);
       expect(revKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
 
       const opt2 = { key, config: { showComment: true } };
-      const revKeyArmored2 = await openpgp.revokeKey(opt2);
+      const { privateKey: revKeyArmored2 } = await openpgp.revokeKey(opt2);
       expect(revKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
 
       const opt3 = {

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -61,7 +61,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
 
     try {
       const opt = {
-        userIDs: { name: 'Test User', email: 'text@example.com' },
+        userIDs: { name: 'Test User', email: 'text@example.com' }
       };
       const { privateKey: privateKeyArmored } = await openpgp.generateKey(opt);
       const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
@@ -140,11 +140,11 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       const { privateKey: key, revocationCertificate } = await openpgp.generateKey({ userIDs, format: 'object' });
 
       const opt = { key };
-      const { privateKeyArmored: revKeyArmored } = await openpgp.revokeKey(opt);
+      const revKeyArmored = await openpgp.revokeKey(opt);
       expect(revKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
 
       const opt2 = { key, config: { showComment: true } };
-      const { privateKeyArmored: revKeyArmored2 } = await openpgp.revokeKey(opt2);
+      const revKeyArmored2 = await openpgp.revokeKey(opt2);
       expect(revKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
 
       const opt3 = {

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -226,14 +226,12 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     const options = {
       userIDs: { name: "Hamlet (secp256k1)", email: "hamlet@example.net" },
       curve: "secp256k1",
-      passphrase: "ophelia"
+      passphrase: "ophelia",
+      format: 'object'
     };
-    return openpgp.generateKey(options).then(function (key) {
-      expect(key).to.exist;
-      expect(key.key).to.exist;
-      expect(key.key.keyPacket).to.exist;
-      expect(key.privateKeyArmored).to.exist;
-      expect(key.publicKeyArmored).to.exist;
+    return openpgp.generateKey(options).then(function ({ privateKey, publicKey }) {
+      expect(privateKey.getAlgorithmInfo().curve).to.equal('secp256k1');
+      expect(publicKey.getAlgorithmInfo().curve).to.equal('secp256k1');
     });
   });
 });

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2650,7 +2650,7 @@ function versionSpecificTests() {
   it('Revoke generated key with revocation certificate', async function() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234', format: 'object' };
     const { publicKey, revocationCertificate } = await openpgp.generateKey(opt);
-    return openpgp.revokeKey({ key: publicKey, revocationCertificate, format: 'object' }).then(async function(revKey) {
+    return openpgp.revokeKey({ key: publicKey, revocationCertificate, format: 'object' }).then(async function({ publicKey: revKey }) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
@@ -2660,7 +2660,7 @@ function versionSpecificTests() {
   it('Revoke generated key with private key', async function() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' }, format: 'object' };
     const { privateKey: key } = await openpgp.generateKey(opt);
-    return openpgp.revokeKey({ key, reasonForRevocation: { string: 'Testing key revocation' }, format: 'object' }).then(async function(revKey) {
+    return openpgp.revokeKey({ key, reasonForRevocation: { string: 'Testing key revocation' }, format: 'object' }).then(async function({ publicKey: revKey }) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('Testing key revocation');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
@@ -2673,7 +2673,7 @@ function versionSpecificTests() {
 
     const opt = { privateKey, userIDs: { name: 'test', email: 'a@b.com' }, format: 'object' };
     const { publicKey: refKey, revocationCertificate } = await openpgp.reformatKey(opt);
-    return openpgp.revokeKey({ key: refKey, revocationCertificate, format: 'object' }).then(async function(revKey) {
+    return openpgp.revokeKey({ key: refKey, revocationCertificate, format: 'object' }).then(async function({ publicKey: revKey }) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2650,8 +2650,7 @@ function versionSpecificTests() {
   it('Revoke generated key with revocation certificate', async function() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234', format: 'object' };
     const { publicKey, revocationCertificate } = await openpgp.generateKey(opt);
-    return openpgp.revokeKey({ key: publicKey, revocationCertificate }).then(async function(revKey) {
-      revKey = revKey.publicKey;
+    return openpgp.revokeKey({ key: publicKey, revocationCertificate, format: 'object' }).then(async function(revKey) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
@@ -2661,8 +2660,7 @@ function versionSpecificTests() {
   it('Revoke generated key with private key', async function() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' }, format: 'object' };
     const { privateKey: key } = await openpgp.generateKey(opt);
-    return openpgp.revokeKey({ key, reasonForRevocation: { string: 'Testing key revocation' } }).then(async function(revKey) {
-      revKey = revKey.publicKey;
+    return openpgp.revokeKey({ key, reasonForRevocation: { string: 'Testing key revocation' }, format: 'object' }).then(async function(revKey) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('Testing key revocation');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
@@ -2675,8 +2673,7 @@ function versionSpecificTests() {
 
     const opt = { privateKey, userIDs: { name: 'test', email: 'a@b.com' }, format: 'object' };
     const { publicKey: refKey, revocationCertificate } = await openpgp.reformatKey(opt);
-    return openpgp.revokeKey({ key: refKey, revocationCertificate }).then(async function(revKey) {
-      revKey = revKey.publicKey;
+    return openpgp.revokeKey({ key: refKey, revocationCertificate, format: 'object' }).then(async function(revKey) {
       expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
       expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
       await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2155,10 +2155,10 @@ function versionSpecificTests() {
       }
       expect(key.users[0].selfCertifications[0].features).to.eql(expectedFeatures);
     };
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: 'hello' };
-    return openpgp.generateKey(opt).then(async function(key) {
-      testPref(key.key);
-      testPref(await openpgp.readKey({ armoredKey: key.publicKeyArmored }));
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: 'hello', format: 'object' };
+    return openpgp.generateKey(opt).then(async function({ privateKey, publicKey }) {
+      testPref(privateKey);
+      testPref(publicKey);
     });
   });
 
@@ -2200,11 +2200,11 @@ function versionSpecificTests() {
       }
       expect(key.users[0].selfCertifications[0].features).to.eql(expectedFeatures);
     };
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: 'hello' };
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: 'hello', format: 'object' };
     try {
-      const key = await openpgp.generateKey(opt);
-      testPref(key.key);
-      testPref(await openpgp.readKey({ armoredKey: key.publicKeyArmored }));
+      const { privateKey, publicKey } = await openpgp.generateKey(opt);
+      testPref(privateKey);
+      testPref(publicKey);
     } finally {
       openpgp.config.preferredSymmetricAlgorithm = preferredSymmetricAlgorithmVal;
       openpgp.config.preferredHashAlgorithm = preferredHashAlgorithmVal;
@@ -2214,8 +2214,8 @@ function versionSpecificTests() {
   });
 
   it('Generated key is not unlocked by default', async function() {
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '123' };
-    const { key } = await openpgp.generateKey(opt);
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '123', format: 'object' };
+    const { privateKey: key } = await openpgp.generateKey(opt);
     return openpgp.encrypt({
       message: await openpgp.createMessage({ text: 'hello' }),
       encryptionKeys: key
@@ -2229,9 +2229,8 @@ function versionSpecificTests() {
 
   it('Generate key - single userID', function() {
     const userID = { name: 'test', email: 'a@b.com', comment: 'test comment' };
-    const opt = { userIDs: userID, passphrase: '123' };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: userID, passphrase: '123', format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test (test comment) <a@b.com>');
       expect(key.users[0].userID.name).to.equal(userID.name);
@@ -2240,11 +2239,10 @@ function versionSpecificTests() {
     });
   });
 
-  it('Generate key - single userID (all missing)', function() {
+  it('Generate key - single userID (all empty)', function() {
     const userID = { name: '', email: '', comment: '' };
-    const opt = { userIDs: userID, passphrase: '123' };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: userID, passphrase: '123', format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('');
       expect(key.users[0].userID.name).to.equal(userID.name);
@@ -2253,11 +2251,10 @@ function versionSpecificTests() {
     });
   });
 
-  it('Generate key - single userID (missing email)', function() {
+  it('Generate key - single userID (empty email)', function() {
     const userID = { name: 'test', email: '', comment: 'test comment' };
-    const opt = { userIDs: userID, passphrase: '123' };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: userID, passphrase: '123', format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test (test comment)');
       expect(key.users[0].userID.name).to.equal(userID.name);
@@ -2266,11 +2263,10 @@ function versionSpecificTests() {
     });
   });
 
-  it('Generate key - single userID (missing comment)', function() {
+  it('Generate key - single userID (empty comment)', function() {
     const userID = { name: 'test', email: 'a@b.com', comment: '' };
-    const opt = { userIDs: userID, passphrase: '123' };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: userID, passphrase: '123', format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].userID.name).to.equal(userID.name);
@@ -2284,14 +2280,15 @@ function versionSpecificTests() {
     const opt = {
       userIDs: { name: 'Test User', email: 'text@example.com' },
       passphrase: 'secret',
-      date: past
+      date: past,
+      format: 'object'
     };
 
-    return openpgp.generateKey(opt).then(function(newKey) {
-      expect(newKey.key).to.exist;
-      expect(+newKey.key.getCreationTime()).to.equal(+past);
-      expect(+newKey.key.subkeys[0].getCreationTime()).to.equal(+past);
-      expect(+newKey.key.subkeys[0].bindingSignatures[0].created).to.equal(+past);
+    return openpgp.generateKey(opt).then(function({ privateKey }) {
+      expect(privateKey).to.exist;
+      expect(+privateKey.getCreationTime()).to.equal(+past);
+      expect(+privateKey.subkeys[0].getCreationTime()).to.equal(+past);
+      expect(+privateKey.subkeys[0].bindingSignatures[0].created).to.equal(+past);
     });
   });
 
@@ -2300,23 +2297,23 @@ function versionSpecificTests() {
     const opt = {
       userIDs: { name: 'Test User', email: 'text@example.com' },
       passphrase: 'secret',
-      date: future
+      date: future,
+      format: 'object'
     };
 
-    return openpgp.generateKey(opt).then(function(newKey) {
-      expect(newKey.key).to.exist;
-      expect(+newKey.key.getCreationTime()).to.equal(+future);
-      expect(+newKey.key.subkeys[0].getCreationTime()).to.equal(+future);
-      expect(+newKey.key.subkeys[0].bindingSignatures[0].created).to.equal(+future);
+    return openpgp.generateKey(opt).then(function({ privateKey }) {
+      expect(privateKey).to.exist;
+      expect(+privateKey.getCreationTime()).to.equal(+future);
+      expect(+privateKey.subkeys[0].getCreationTime()).to.equal(+future);
+      expect(+privateKey.subkeys[0].bindingSignatures[0].created).to.equal(+future);
     });
   });
 
   it('Generate key - multi userID', function() {
     const userID1 = { name: 'test', email: 'a@b.com' };
     const userID2 = { name: 'test', email: 'b@c.com' };
-    const opt = { userIDs: [userID1, userID2], passphrase: '123' };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: [userID1, userID2], passphrase: '123', format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(2);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2327,8 +2324,8 @@ function versionSpecificTests() {
 
   it('Generate key - default values', function() {
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: [userID] };
-    return openpgp.generateKey(opt).then(function({ key }) {
+    const opt = { userIDs: [userID], format: 'object' };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.isDecrypted()).to.be.true;
       expect(key.getAlgorithmInfo().algorithm).to.equal('eddsa');
       expect(key.users.length).to.equal(1);
@@ -2341,9 +2338,8 @@ function versionSpecificTests() {
 
   it('Generate key - two subkeys with default values', function() {
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: [userID], passphrase: '123', subkeys:[{},{}] };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
+    const opt = { userIDs: [userID], passphrase: '123', format: 'object', subkeys:[{},{}] };
+    return openpgp.generateKey(opt).then(function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2359,9 +2355,9 @@ function versionSpecificTests() {
     openpgp.config.minRSABits = rsaBits;
 
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { type: 'rsa', rsaBits, userIDs: [userID], passphrase: '123', subkeys:[{},{}] };
+    const opt = { type: 'rsa', rsaBits, userIDs: [userID], passphrase: '123', format: 'object', subkeys:[{},{}] };
     try {
-      const { key } = await openpgp.generateKey(opt);
+      const { privateKey: key } = await openpgp.generateKey(opt);
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2375,9 +2371,8 @@ function versionSpecificTests() {
 
   it('Generate key - one signing subkey', function() {
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: [userID], passphrase: '123', subkeys:[{}, { sign: true }] };
-    return openpgp.generateKey(opt).then(async function({ privateKeyArmored }) {
-      const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    const opt = { userIDs: [userID], passphrase: '123', format: 'object', subkeys:[{}, { sign: true }] };
+    return openpgp.generateKey(opt).then(async function({ privateKey: key }) {
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2389,12 +2384,12 @@ function versionSpecificTests() {
     });
   });
 
-  it('Reformat key - one signing subkey', function() {
+  it('Reformat key - one signing subkey', async function() {
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: [userID], subkeys:[{}, { sign: true }] };
-    return openpgp.generateKey(opt).then(async function({ key }) {
-      return openpgp.reformatKey({ privateKey: key, userIDs: [userID] });
-    }).then(async function({ privateKeyArmored }) {
+    const opt = { userIDs: [userID], format: 'object', subkeys:[{}, { sign: true }] };
+    const { privateKey } = await openpgp.generateKey(opt);
+
+    return openpgp.reformatKey({ privateKey, userIDs: [userID] }).then(async function({ privateKeyArmored }) {
       const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
@@ -2413,9 +2408,9 @@ function versionSpecificTests() {
     openpgp.config.minRSABits = rsaBits;
 
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { type: 'rsa', rsaBits, userIDs: [userID], passphrase: '123', subkeys:[{ type: 'ecc', curve: 'curve25519' }] };
+    const opt = { type: 'rsa', rsaBits, userIDs: [userID], passphrase: '123', format: 'object', subkeys:[{ type: 'ecc', curve: 'curve25519' }] };
     try {
-      const { key } = await openpgp.generateKey(opt);
+      const { privateKey: key } = await openpgp.generateKey(opt);
       expect(key.users.length).to.equal(1);
       expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
       expect(key.users[0].selfCertifications[0].isPrimaryUserID).to.be.true;
@@ -2427,39 +2422,11 @@ function versionSpecificTests() {
     }
   });
 
-  it('Encrypt key with new passphrase', async function() {
-    const userID = { name: 'test', email: 'a@b.com' };
-    const passphrase = 'passphrase';
-    const newPassphrase = 'new_passphrase';
-    const privateKey = (await openpgp.generateKey({ userIDs: userID, passphrase })).key;
-    const armor1 = privateKey.armor();
-    const armor2 = privateKey.armor();
-    expect(armor1).to.equal(armor2);
-
-    const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase });
-    expect(decryptedKey.isDecrypted()).to.be.true;
-
-    const newEncryptedKey = await openpgp.encryptKey({
-      privateKey: decryptedKey, passphrase: newPassphrase
-    });
-    expect(newEncryptedKey.isDecrypted()).to.be.false;
-    await expect(openpgp.decryptKey({
-      privateKey: newEncryptedKey, passphrase
-    })).to.be.rejectedWith('Incorrect key passphrase');
-    expect(newEncryptedKey.isDecrypted()).to.be.false;
-    const newDecryptedKey = await openpgp.decryptKey({ privateKey: newEncryptedKey, passphrase: newPassphrase });
-    expect(newDecryptedKey.isDecrypted()).to.be.true;
-    const armor3 = newDecryptedKey.armor();
-    expect(armor3).to.not.equal(armor1);
-  });
-
   it('Generate key - ensure keyExpirationTime works', function() {
     const expect_delta = 365 * 24 * 60 * 60;
     const userID = { name: 'test', email: 'a@b.com' };
-    const opt = { userIDs: userID, passphrase: '123', keyExpirationTime: expect_delta };
-    return openpgp.generateKey(opt).then(async function(key) {
-      key = key.key;
-
+    const opt = { userIDs: userID, passphrase: '123', format: 'object', keyExpirationTime: expect_delta };
+    return openpgp.generateKey(opt).then(async function({ privateKey: key }) {
       const expiration = await key.getExpirationTime();
       expect(expiration).to.exist;
 
@@ -2588,27 +2555,7 @@ function versionSpecificTests() {
     }
   });
 
-  it('Reformat key without passphrase', function() {
-    const userID1 = { name: 'test', email: 'a@b.com' };
-    const userID2 = { name: 'test', email: 'b@c.com' };
-    const opt = { userIDs: userID1 };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
-      expect(key.users.length).to.equal(1);
-      expect(key.users[0].userID.userID).to.equal('test <a@b.com>');
-      expect(key.isDecrypted()).to.be.true;
-      opt.privateKey = key;
-      opt.userIDs = userID2;
-      return openpgp.reformatKey(opt).then(function(newKey) {
-        newKey = newKey.key;
-        expect(newKey.users.length).to.equal(1);
-        expect(newKey.users[0].userID.userID).to.equal('test <b@c.com>');
-        expect(newKey.isDecrypted()).to.be.true;
-      });
-    });
-  });
-
-  it('Reformat key with no subkey with passphrase', async function() {
+  it('Reformat and encrypt key with no subkey', async function() {
     const userID = { name: 'test', email: 'a@b.com' };
     const key = await openpgp.readKey({ armoredKey: key_without_subkey });
     const opt = { privateKey: key, userIDs: [userID], passphrase: "test" };
@@ -2620,29 +2567,25 @@ function versionSpecificTests() {
     });
   });
 
-  it('Reformat key with two subkeys with passphrase', function() {
-    const userID1 = { name: 'test', email: 'a@b.com' };
-    const userID2 = { name: 'test', email: 'b@c.com' };
-    const now = util.normalizeDate(new Date());
-    const before = util.normalizeDate(new Date(0));
-    const opt1 = { userIDs: [userID1], date: now };
-    return openpgp.generateKey(opt1).then(function(newKey) {
-      newKey = newKey.key;
-      expect(newKey.users[0].userID.userID).to.equal('test <a@b.com>');
-      expect(+newKey.getCreationTime()).to.equal(+now);
-      expect(+newKey.subkeys[0].getCreationTime()).to.equal(+now);
-      expect(+newKey.subkeys[0].bindingSignatures[0].created).to.equal(+now);
-      const opt2 = { privateKey: newKey, userIDs: [userID2], date: before };
-      return openpgp.reformatKey(opt2).then(function(refKey) {
-        refKey = refKey.key;
-        expect(refKey.users.length).to.equal(1);
-        expect(refKey.users[0].userID.userID).to.equal('test <b@c.com>');
-        expect(+refKey.subkeys[0].bindingSignatures[0].created).to.equal(+before);
-      });
+  it('Reformat key with one subkey', async function() {
+    const original = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const privateKey = await openpgp.decryptKey({ privateKey: original, passphrase: 'hello world' });
+
+    const userID = { name: 'test', email: 'b@c.com' };
+    const before = new Date(0);
+    expect(+privateKey.getCreationTime()).to.not.equal(+before);
+    expect(+privateKey.subkeys[0].getCreationTime()).to.not.equal(+before);
+    expect(+privateKey.subkeys[0].bindingSignatures[0].created).to.not.equal(+before);
+    const opt = { privateKey, userIDs: userID, date: before };
+    return openpgp.reformatKey(opt).then(function(refKey) {
+      refKey = refKey.key;
+      expect(refKey.users.length).to.equal(1);
+      expect(refKey.users[0].userID.userID).to.equal('test <b@c.com>');
+      expect(+refKey.subkeys[0].bindingSignatures[0].created).to.equal(+before);
     });
   });
 
-  it('Reformat key with no subkey without passphrase', async function() {
+  it('Reformat key with no subkey', async function() {
     const userID = { name: 'test', email: 'a@b.com' };
     const key = await openpgp.readKey({ armoredKey: key_without_subkey });
     const opt = { privateKey: key, userIDs: [userID] };
@@ -2664,76 +2607,69 @@ function versionSpecificTests() {
     });
   });
 
-  it('Reformat and encrypt key', function() {
+  it('Reformat and encrypt key', async function() {
+    const original = await openpgp.readKey({ armoredKey: priv_key_rsa });
+    const privateKey = await openpgp.decryptKey({ privateKey: original, passphrase: 'hello world' });
+
+    const userID1 = { name: 'test2', email: 'b@c.com' };
+    const userID2 = { name: 'test3', email: 'c@d.com' };
+    const passphrase = '123';
+    const reformatOpt = { privateKey, userIDs: [userID1, userID2], passphrase };
+    return openpgp.reformatKey(reformatOpt).then(async ({ key: refKey }) => {
+      expect(refKey.users.length).to.equal(2);
+      expect(refKey.users[0].userID.userID).to.equal('test2 <b@c.com>');
+      expect(refKey.isDecrypted()).to.be.false;
+      const decryptedKey = await openpgp.decryptKey({ privateKey: refKey, passphrase });
+      expect(decryptedKey.isDecrypted()).to.be.true;
+    });
+  });
+
+  it('Sign and encrypt with reformatted key', async function() {
     const userID1 = { name: 'test1', email: 'a@b.com' };
     const userID2 = { name: 'test2', email: 'b@c.com' };
-    const userID3 = { name: 'test3', email: 'c@d.com' };
-    const opt = { userIDs: userID1 };
-    return openpgp.generateKey(opt).then(function ({ key }) {
-      const passphrase = '123';
-      const reformatOpt = { privateKey: key, userIDs: [userID2, userID3], passphrase };
-      return openpgp.reformatKey(reformatOpt).then(async ({ key: refKey }) => {
-        expect(refKey.users.length).to.equal(2);
-        expect(refKey.users[0].userID.userID).to.equal('test2 <b@c.com>');
-        expect(refKey.isDecrypted()).to.be.false;
-        const decryptedKey = await openpgp.decryptKey({ privateKey: refKey, passphrase });
-        expect(decryptedKey.isDecrypted()).to.be.true;
+    const { privateKey } = await openpgp.generateKey({ userIDs: userID1, format: 'object' });
+
+    const opt2 = { privateKey, userIDs: userID2 };
+    return openpgp.reformatKey(opt2).then(async function(newKey) {
+      newKey = newKey.key;
+      const encrypted = await openpgp.encrypt({
+        message: await openpgp.createMessage({ text: 'hello' }), encryptionKeys: newKey.toPublic(), signingKeys: newKey, armor: true, config: { minRSABits: 1024 }
       });
+      const decrypted = await openpgp.decrypt({
+        message: await openpgp.readMessage({ armoredMessage: encrypted }), decryptionKeys: newKey, verificationKeys: newKey.toPublic(), config: { minRSABits: 1024 }
+      });
+      expect(decrypted.data).to.equal('hello');
+      expect(decrypted.signatures[0].valid).to.be.true;
     });
   });
 
-  it('Sign and encrypt with reformatted key', function() {
-    const userID1 = { name: 'test1', email: 'a@b.com' };
-    const userID2 = { name: 'test2', email: 'b@c.com' };
-    const opt = { userIDs: userID1 };
-    return openpgp.generateKey(opt).then(function(key) {
-      key = key.key;
-      opt.privateKey = key;
-      opt.userIDs = userID2;
-      return openpgp.reformatKey(opt).then(async function(newKey) {
-        newKey = newKey.key;
-        return openpgp.encrypt({ message: await openpgp.createMessage({ text: 'hello' }), encryptionKeys: newKey.toPublic(), signingKeys: newKey, armor: true }).then(async function(encrypted) {
-          return openpgp.decrypt({ message: await openpgp.readMessage({ armoredMessage: encrypted }), decryptionKeys: newKey, verificationKeys: newKey.toPublic() }).then(function(decrypted) {
-            expect(decrypted.data).to.equal('hello');
-            expect(decrypted.signatures[0].valid).to.be.true;
-          });
-        });
-      });
+  it('Reject with user-friendly error when reformatting encrypted key', async function() {
+    const privateKey = await openpgp.readKey({ armoredKey: priv_key_rsa });
+
+    await expect(
+      openpgp.reformatKey({ privateKey, userIDs: { name: 'test2', email: 'a@b.com' }, passphrase: '1234' })
+    ).to.be.rejectedWith('Error reformatting keypair: Key is not decrypted');
+  });
+
+  it('Revoke generated key with revocation certificate', async function() {
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234', format: 'object' };
+    const { publicKey, revocationCertificate } = await openpgp.generateKey(opt);
+    return openpgp.revokeKey({ key: publicKey, revocationCertificate }).then(async function(revKey) {
+      revKey = revKey.publicKey;
+      expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
+      expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
+      await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
     });
   });
 
-  it('Reject with user-friendly error when reformatting encrypted key', function() {
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234' };
-    return openpgp.generateKey(opt).then(function(original) {
-      return openpgp.reformatKey({ privateKey: original.key, userIDs: { name: 'test2', email: 'a@b.com' }, passphrase: '1234' }).then(function() {
-        throw new Error('reformatKey should result in error when key not decrypted');
-      }).catch(function(error) {
-        expect(error.message).to.equal('Error reformatting keypair: Key is not decrypted');
-      });
-    });
-  });
-
-  it('Revoke generated key with revocation certificate', function() {
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234' };
-    return openpgp.generateKey(opt).then(function(original) {
-      return openpgp.revokeKey({ key: original.key.toPublic(), revocationCertificate: original.revocationCertificate }).then(async function(revKey) {
-        revKey = revKey.publicKey;
-        expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
-        expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
-        await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
-      });
-    });
-  });
-
-  it('Revoke generated key with private key', function() {
-    const opt = { userIDs: { name: 'test', email: 'a@b.com' } };
-    return openpgp.generateKey(opt).then(async function(original) {
-      return openpgp.revokeKey({ key: original.key, reasonForRevocation: { string: 'Testing key revocation' } }).then(async function(revKey) {
-        revKey = revKey.publicKey;
-        expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
-        expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('Testing key revocation');
-        await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
-      });
+  it('Revoke generated key with private key', async function() {
+    const opt = { userIDs: { name: 'test', email: 'a@b.com' }, format: 'object' };
+    const { privateKey: key } = await openpgp.generateKey(opt);
+    return openpgp.revokeKey({ key, reasonForRevocation: { string: 'Testing key revocation' } }).then(async function(revKey) {
+      revKey = revKey.publicKey;
+      expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
+      expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('Testing key revocation');
+      await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
     });
   });
 
@@ -2990,7 +2926,7 @@ module.exports = () => describe('Key', function() {
   });
 
   it("validate() - don't throw if key parameters correspond", async function() {
-    const { key } = await openpgp.generateKey({ userIDs: {}, curve: 'ed25519' });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs: {}, curve: 'ed25519', format: 'object' });
     await expect(key.validate()).to.not.be.rejected;
   });
 
@@ -3016,7 +2952,7 @@ module.exports = () => describe('Key', function() {
 
   it("isDecrypted() - should reflect whether all (sub)keys are encrypted", async function() {
     const passphrase = '12345678';
-    const { key } = await openpgp.generateKey({ userIDs: {}, curve: 'ed25519', passphrase });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs: {}, curve: 'ed25519', passphrase, format: 'object' });
     expect(key.isDecrypted()).to.be.false;
     await key.subkeys[0].keyPacket.decrypt(passphrase);
     expect(key.isDecrypted()).to.be.true;
@@ -3035,14 +2971,14 @@ module.exports = () => describe('Key', function() {
   });
 
   it('makeDummy() - the converted key can be parsed', async function() {
-    const { key } = await openpgp.generateKey({ userIDs: { name: 'dummy', email: 'dummy@alice.com' } });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs: { name: 'dummy', email: 'dummy@alice.com' }, format: 'object' });
     key.keyPacket.makeDummy();
     const parsedKeys = await openpgp.readKey({ armoredKey: key.armor() });
     expect(parsedKeys).to.not.be.empty;
   });
 
   it('makeDummy() - the converted key can be encrypted and decrypted', async function() {
-    const { key } = await openpgp.generateKey({ userIDs: { name: 'dummy', email: 'dummy@alice.com' } });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs: { name: 'dummy', email: 'dummy@alice.com' }, format: 'object' });
     const passphrase = 'passphrase';
     key.keyPacket.makeDummy();
     expect(key.isDecrypted()).to.be.true;
@@ -3618,9 +3554,8 @@ VYGdb3eNlV8CfoEC
   });
 
   it("Should throw when trying to encrypt a key that's already encrypted", async function() {
-    const passphrase = 'pass';
-    const { privateKeyArmored } = await openpgp.generateKey({ userIDs: [{ email: 'hello@user.com' }], passphrase });
-    const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+    const passphrase = 'hello world';
+    const key = await openpgp.readKey({ armoredKey: priv_key_rsa });
     const decryptedKey = await openpgp.decryptKey({ privateKey: key, passphrase });
     const encryptedKey = await openpgp.encryptKey({ privateKey: decryptedKey, passphrase });
     await expect(openpgp.encryptKey({ privateKey: encryptedKey, passphrase })).to.be.eventually.rejectedWith(/Key packet is already encrypted/);
@@ -3628,7 +3563,6 @@ VYGdb3eNlV8CfoEC
 
   describe('addSubkey functionality testing', function() {
     const rsaBits = 1024;
-    const rsaOpt = { type: 'rsa' };
     let minRSABits;
     beforeEach(function() {
       minRSABits = openpgp.config.minRSABits;
@@ -3644,7 +3578,7 @@ VYGdb3eNlV8CfoEC
         passphrase: 'hello world'
       });
       const total = privateKey.subkeys.length;
-      let newPrivateKey = await privateKey.addSubkey(rsaOpt);
+      let newPrivateKey = await privateKey.addSubkey({ type: 'rsa' });
       const armoredKey = newPrivateKey.armor();
       newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
       const subkey = newPrivateKey.subkeys[total];
@@ -3660,18 +3594,18 @@ VYGdb3eNlV8CfoEC
 
     it('Add a new default subkey to an rsaSign key', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { type: 'rsa', rsaBits, userIDs: [userID], subkeys: [] };
-      const { key } = await openpgp.generateKey(opt);
+      const opt = { type: 'rsa', rsaBits, userIDs: [userID], format: 'object', subkeys: [] };
+      const { privateKey: key } = await openpgp.generateKey(opt);
       expect(key.subkeys).to.have.length(0);
-      key.keyPacket.algorithm = "rsaSign";
+      key.getAlgorithmInfo().algorithm = "rsaSign";
       const newKey = await key.addSubkey();
       expect(newKey.subkeys[0].getAlgorithmInfo().algorithm).to.equal('rsaEncryptSign');
     });
 
     it('Add a new default subkey to an ecc key', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { type: 'ecc', userIDs: [userID], subkeys: [] };
-      const { key } = await openpgp.generateKey(opt);
+      const opt = { type: 'ecc', userIDs: [userID], format: 'object', subkeys: [] };
+      const { privateKey: key } = await openpgp.generateKey(opt);
       expect(key.subkeys).to.have.length(0);
       const newKey = await key.addSubkey();
       expect(newKey.subkeys[0].getAlgorithmInfo().algorithm).to.equal('ecdh');
@@ -3703,7 +3637,7 @@ VYGdb3eNlV8CfoEC
       const total = privateKey.subkeys.length;
 
       const passphrase = '12345678';
-      const newPrivateKey = await privateKey.addSubkey(rsaOpt);
+      const newPrivateKey = await privateKey.addSubkey({ type: 'rsa' });
       const encNewPrivateKey = await openpgp.encryptKey({ privateKey: newPrivateKey, passphrase });
       expect(encNewPrivateKey.subkeys.length).to.be.equal(total + 1);
 
@@ -3718,14 +3652,13 @@ VYGdb3eNlV8CfoEC
       await subkey.verify();
     });
 
-    it('create and add a new ec subkey to a ec key', async function() {
+    it('create and add a new eddsa subkey to a eddsa key', async function() {
       const passphrase = '12345678';
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { curve: 'curve25519', userIDs: [userID], subkeys:[] };
-      const privateKey = (await openpgp.generateKey(opt)).key;
+      const { privateKey } = await openpgp.generateKey({ curve: 'curve25519', userIDs: [userID], format: 'object', subkeys:[] });
       const total = privateKey.subkeys.length;
-      const opt2 = { curve: 'curve25519', userIDs: [userID], sign: true };
-      let newPrivateKey = await privateKey.addSubkey(opt2);
+
+      let newPrivateKey = await privateKey.addSubkey({ curve: 'curve25519', userIDs: [userID], sign: true });
       const subkey1 = newPrivateKey.subkeys[total];
       const encNewPrivateKey = await openpgp.encryptKey({ privateKey: newPrivateKey, passphrase });
       newPrivateKey = await openpgp.decryptKey({
@@ -3746,8 +3679,7 @@ VYGdb3eNlV8CfoEC
 
     it('create and add a new ecdsa subkey to a eddsa key', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { curve: 'ed25519', userIDs: [userID], subkeys:[] };
-      const privateKey = (await openpgp.generateKey(opt)).key;
+      const { privateKey } = await openpgp.generateKey({ curve: 'ed25519', userIDs: [userID], format: 'object', subkeys:[] });
       const total = privateKey.subkeys.length;
       let newPrivateKey = await privateKey.addSubkey({ curve: 'p256', sign: true });
       newPrivateKey = await openpgp.readKey({ armoredKey: newPrivateKey.armor() });
@@ -3782,12 +3714,12 @@ VYGdb3eNlV8CfoEC
 
     it('create and add a new rsa subkey to a ecc key', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { curve: 'ed25519', userIDs: [userID], subkeys:[] };
-      const privateKey = (await openpgp.generateKey(opt)).key;
+      const opt = { curve: 'ed25519', userIDs: [userID], format: 'object', subkeys:[] };
+      const { privateKey } = await openpgp.generateKey(opt);
       const total = privateKey.subkeys.length;
       let newPrivateKey = await privateKey.addSubkey({ type: 'rsa' });
       const armoredKey = newPrivateKey.armor();
-      newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
+      newPrivateKey = await openpgp.readKey({ armoredKey });
       const subkey = newPrivateKey.subkeys[total];
       expect(subkey).to.exist;
       expect(newPrivateKey.subkeys.length).to.be.equal(total + 1);
@@ -3811,13 +3743,15 @@ VYGdb3eNlV8CfoEC
 
     it('sign/verify data with the new subkey correctly using curve25519', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
-      const opt = { curve: 'curve25519', userIDs: [userID], subkeys:[] };
-      const privateKey = (await openpgp.generateKey(opt)).key;
+      const opt = { curve: 'curve25519', userIDs: [userID], format: 'object', subkeys:[] };
+      const { privateKey } = await openpgp.generateKey(opt);
+
       const total = privateKey.subkeys.length;
       const opt2 = { sign: true };
       let newPrivateKey = await privateKey.addSubkey(opt2);
       const armoredKey = newPrivateKey.armor();
       newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
+
       const subkey = newPrivateKey.subkeys[total];
       const subkeyOid = subkey.keyPacket.publicParams.oid;
       const pkOid = newPrivateKey.keyPacket.publicParams.oid;
@@ -3837,8 +3771,8 @@ VYGdb3eNlV8CfoEC
     it('encrypt/decrypt data with the new subkey correctly using curve25519', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
       const vData = 'the data to encrypted!';
-      const opt = { curve: 'curve25519', userIDs: [userID], subkeys:[] };
-      const privateKey = (await openpgp.generateKey(opt)).key;
+      const opt = { curve: 'curve25519', userIDs: [userID], format: 'object', subkeys:[] };
+      const { privateKey } = await openpgp.generateKey(opt);
       const total = privateKey.subkeys.length;
       let newPrivateKey = await privateKey.addSubkey();
       const armoredKey = newPrivateKey.armor();
@@ -3869,6 +3803,7 @@ VYGdb3eNlV8CfoEC
       let newPrivateKey = await privateKey.addSubkey(opt2);
       const armoredKey = newPrivateKey.armor();
       newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
+
       const subkey = newPrivateKey.subkeys[total];
       expect(subkey.getAlgorithmInfo().algorithm).to.be.equal('rsaEncryptSign');
       await subkey.verify();
@@ -3888,9 +3823,10 @@ VYGdb3eNlV8CfoEC
         passphrase: 'hello world'
       });
       const total = privateKey.subkeys.length;
-      let newPrivateKey = await privateKey.addSubkey(rsaOpt);
+      let newPrivateKey = await privateKey.addSubkey({ type: 'rsa' });
       const armoredKey = newPrivateKey.armor();
       newPrivateKey = await openpgp.readKey({ armoredKey: armoredKey });
+
       const subkey = newPrivateKey.subkeys[total];
       const publicKey = newPrivateKey.toPublic();
       const vData = 'the data to encrypted!';
@@ -3909,12 +3845,13 @@ VYGdb3eNlV8CfoEC
   });
 
   it('Subkey.verify returns the latest valid signature', async function () {
-    const { key: encryptionKey } = await openpgp.generateKey({ userIDs: { name: "purple" } });
+    const { privateKey: encryptionKey } = await openpgp.generateKey({ userIDs: { name: "purple" }, format: 'object' });
     const encryptionKeySignature = await encryptionKey.getSubkeys()[0].verify();
     expect(encryptionKeySignature instanceof openpgp.SignaturePacket).to.be.true;
     expect(encryptionKeySignature.keyFlags[0] & openpgp.enums.keyFlags.encryptCommunication).to.be.equals(openpgp.enums.keyFlags.encryptCommunication);
     expect(encryptionKeySignature.keyFlags[0] & openpgp.enums.keyFlags.encryptStorage).to.be.equals(openpgp.enums.keyFlags.encryptStorage);
-    const { key: signingKey } = await openpgp.generateKey({ userIDs: { name: "purple" }, subkeys: [{ sign: true }] });
+
+    const { privateKey: signingKey } = await openpgp.generateKey({ userIDs: { name: "purple" }, format: 'object', subkeys: [{ sign: true }] });
     const signingKeySignature = await signingKey.getSubkeys()[0].verify();
     expect(signingKeySignature instanceof openpgp.SignaturePacket).to.be.true;
     expect(signingKeySignature.keyFlags[0] & openpgp.enums.keyFlags.signData).to.be.equals(openpgp.enums.keyFlags.signData);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1022,6 +1022,32 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     });
   });
 
+  describe('reformatKey - unit tests', function() {
+    it('should output keypair with expected format', async function() {
+      const encryptedKey = await openpgp.readKey({ armoredKey: priv_key });
+      const original = await openpgp.decryptKey({
+        privateKey: encryptedKey,
+        passphrase: passphrase
+      });
+
+      const opt = {
+        privateKey: original,
+        userIDs: { name: 'Test User', email: 'text@example.com' }
+      };
+      const armored = await openpgp.reformatKey({ ...opt, format: 'armor' });
+      expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPublic()).to.be.true;
+
+      const binary = await openpgp.reformatKey({ ...opt, format: 'binary' });
+      expect((await openpgp.readKey({ binaryKey: binary.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ binaryKey: binary.publicKey })).isPublic()).to.be.true;
+
+      const { privateKey, publicKey } = await openpgp.reformatKey({ ...opt, format: 'object' });
+      expect(privateKey.isPrivate()).to.be.true;
+      expect(publicKey.isPublic()).to.be.true;
+    });
+  });
+
   describe('decryptKey - unit tests', function() {
     it('should work for correct passphrase', async function() {
       const privateKey = await openpgp.readKey({ armoredKey: priv_key });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1057,13 +1057,16 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       });
 
       const armored = await openpgp.revokeKey({ key, format: 'armor' });
-      expect((await openpgp.readKey({ armoredKey: armored })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPublic()).to.be.true;
 
       const binary = await openpgp.revokeKey({ key, format: 'binary' });
-      expect((await openpgp.readKey({ binaryKey: binary })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ binaryKey: binary.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ binaryKey: binary.publicKey })).isPublic()).to.be.true;
 
-      const revokedKey = await openpgp.revokeKey({ key, format: 'object' });
-      expect(revokedKey.isPrivate()).to.be.true;
+      const { privateKey, publicKey } = await openpgp.revokeKey({ key, format: 'object' });
+      expect(privateKey.isPrivate()).to.be.true;
+      expect(publicKey.isPublic()).to.be.true;
     });
   });
 
@@ -3268,7 +3271,7 @@ aOU=
         return openpgp.revokeKey({
           key: privateKey,
           format: 'object'
-        }).then(async function(revKey) {
+        }).then(async function({ publicKey: revKey }) {
           return openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
             encryptionKeys: revKey

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -6,6 +6,7 @@ const crypto = require('../../src/crypto');
 const random = require('../../src/crypto/random');
 const util = require('../../src/util');
 const keyIDType = require('../../src/type/keyid');
+const { isAEADSupported } = require('../../src/key');
 
 const stream = require('@openpgp/web-stream-tools');
 
@@ -981,43 +982,43 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       const opt = {
         userIDs: { name: 'Test User', email: 'text@example.com' },
         passphrase: 'secret',
-        date: now
+        date: now,
+        format: 'object'
       };
-      return openpgp.generateKey(opt).then(async function(newKey) {
-        expect(newKey.key).to.exist;
-        expect(newKey.key.users.length).to.equal(1);
-        expect(newKey.key.users[0].userID.name).to.equal('Test User');
-        expect(newKey.key.users[0].userID.email).to.equal('text@example.com');
-        expect(newKey.key.getAlgorithmInfo().rsaBits).to.equal(undefined);
-        expect(newKey.key.getAlgorithmInfo().curve).to.equal('ed25519');
-        expect(+newKey.key.getCreationTime()).to.equal(+now);
-        expect(await newKey.key.getExpirationTime()).to.equal(Infinity);
-        expect(newKey.key.subkeys.length).to.equal(1);
-        expect(newKey.key.subkeys[0].getAlgorithmInfo().rsaBits).to.equal(undefined);
-        expect(newKey.key.subkeys[0].getAlgorithmInfo().curve).to.equal('curve25519');
-        expect(+newKey.key.subkeys[0].getCreationTime()).to.equal(+now);
-        expect(await newKey.key.subkeys[0].getExpirationTime()).to.equal(Infinity);
-        expect(newKey.privateKeyArmored).to.exist;
-        expect(newKey.publicKeyArmored).to.exist;
+      return openpgp.generateKey(opt).then(async function({ privateKey, publicKey }) {
+        for (const key of [publicKey, privateKey]) {
+          expect(key).to.exist;
+          expect(key.users.length).to.equal(1);
+          expect(key.users[0].userID.name).to.equal('Test User');
+          expect(key.users[0].userID.email).to.equal('text@example.com');
+          expect(key.getAlgorithmInfo().rsaBits).to.equal(undefined);
+          expect(key.getAlgorithmInfo().curve).to.equal('ed25519');
+          expect(+key.getCreationTime()).to.equal(+now);
+          expect(await key.getExpirationTime()).to.equal(Infinity);
+          expect(key.subkeys.length).to.equal(1);
+          expect(key.subkeys[0].getAlgorithmInfo().rsaBits).to.equal(undefined);
+          expect(key.subkeys[0].getAlgorithmInfo().curve).to.equal('curve25519');
+          expect(+key.subkeys[0].getCreationTime()).to.equal(+now);
+          expect(await key.subkeys[0].getExpirationTime()).to.equal(Infinity);
+        }
       });
     });
 
-    it('should throw if missing userIDs', async function() {
-      await expect(openpgp.generateKey({})).to.be.rejectedWith(/UserIDs are required/);
-    });
-  });
-
-  describe('generateKey - integration tests', function() {
-    it('should work', function() {
+    it('should output keypair with expected format', async function() {
       const opt = {
-        userIDs: [{ name: 'Test User', email: 'text@example.com' }]
+        userIDs: { name: 'Test User', email: 'text@example.com' }
       };
+      const armored = await openpgp.generateKey({ ...opt, format: 'armor' });
+      expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPublic()).to.be.true;
 
-      return openpgp.generateKey(opt).then(function(newKey) {
-        expect(newKey.key.getUserIDs()[0]).to.equal('Test User <text@example.com>');
-        expect(newKey.publicKeyArmored).to.match(/^-----BEGIN PGP PUBLIC/);
-        expect(newKey.privateKeyArmored).to.match(/^-----BEGIN PGP PRIVATE/);
-      });
+      const binary = await openpgp.generateKey({ ...opt, format: 'binary' });
+      expect((await openpgp.readKey({ binaryKey: binary.privateKey })).isPrivate()).to.be.true;
+      expect((await openpgp.readKey({ binaryKey: binary.publicKey })).isPublic()).to.be.true;
+
+      const { privateKey, publicKey } = await openpgp.generateKey({ ...opt, format: 'object' });
+      expect(privateKey.isPrivate()).to.be.true;
+      expect(publicKey.isPublic()).to.be.true;
     });
   });
 
@@ -1094,10 +1095,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
 
   describe('encryptKey - unit tests', function() {
     it('should not change original key', async function() {
-      const { privateKeyArmored } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }] });
+      const { privateKey: armoredKey } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }] });
       // read both keys from armored data to make sure all fields are exactly the same
-      const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
-      const originalKey = await openpgp.readKey({ armoredKey: privateKeyArmored });
+      const key = await openpgp.readKey({ armoredKey });
+      const originalKey = await openpgp.readKey({ armoredKey });
       return openpgp.encryptKey({
         privateKey: key,
         passphrase: passphrase
@@ -1114,9 +1115,9 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     });
 
     it('encrypted key can be decrypted', async function() {
-      const { key } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }] });
+      const { privateKey } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }], format: 'object' });
       const locked = await openpgp.encryptKey({
-        privateKey: key,
+        privateKey,
         passphrase: passphrase
       });
       expect(locked.isDecrypted()).to.be.false;
@@ -1128,10 +1129,10 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
     });
 
     it('should support multiple passphrases', async function() {
-      const { key } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }] });
+      const { privateKey } = await openpgp.generateKey({ userIDs: [{ name: 'test', email: 'test@test.com' }], format: 'object' });
       const passphrases = ['123', '456'];
       const locked = await openpgp.encryptKey({
-        privateKey: key,
+        privateKey,
         passphrase: passphrases
       });
       expect(locked.isDecrypted()).to.be.false;
@@ -2116,8 +2117,8 @@ aOU=
           };
 
           return openpgp.generateKey(genOpt).then(async function(newKey) {
-            const newPublicKey = await openpgp.readKey({ armoredKey: newKey.publicKeyArmored });
-            const newPrivateKey = await openpgp.readKey({ armoredKey: newKey.privateKeyArmored });
+            const newPublicKey = await openpgp.readKey({ armoredKey: newKey.publicKey });
+            const newPrivateKey = await openpgp.readKey({ armoredKey: newKey.privateKey });
 
             const encOpt = {
               message: await openpgp.createMessage({ text: plaintext }),
@@ -2146,8 +2147,8 @@ aOU=
           const newKey = await openpgp.generateKey({
             userIDs: [{ name: 'Test User', email: 'text@example.com' }]
           });
-          const newPublicKey = await openpgp.readKey({ armoredKey: newKey.publicKeyArmored });
-          const newPrivateKey = await openpgp.readKey({ armoredKey: newKey.privateKeyArmored });
+          const newPublicKey = await openpgp.readKey({ armoredKey: newKey.publicKey });
+          const newPrivateKey = await openpgp.readKey({ armoredKey: newKey.privateKey });
 
           const encrypted = await openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
@@ -2441,8 +2442,10 @@ aOU=
         });
 
         it('should fail to decrypt modified message', async function() {
-          const { privateKeyArmored } = await openpgp.generateKey({ curve: 'curve25519', userIDs: [{ email: 'test@email.com' }] });
-          const key = await openpgp.readKey({ armoredKey: privateKeyArmored });
+          const allowUnauthenticatedStream = openpgp.config.allowUnauthenticatedStream;
+          const { privateKey: key } = await openpgp.generateKey({ userIDs: [{ email: 'test@email.com' }], format: 'object' });
+          expect(await isAEADSupported([key])).to.equal(openpgp.config.aeadProtect);
+
           const data = await openpgp.encrypt({ message: await openpgp.createMessage({ binary: new Uint8Array(500) }), encryptionKeys: [key.toPublic()] });
           let badSumEncrypted = data.replace(/\n=[a-zA-Z0-9/+]{4}/, '\n=aaaa');
           if (badSumEncrypted === data) { // checksum was already =aaaa
@@ -2453,55 +2456,59 @@ aOU=
           }
           const badBodyEncrypted = data.replace(/\n=([a-zA-Z0-9/+]{4})/, 'aaa\n=$1');
           await stream.loadStreamsPonyfill();
-          for (let allow_streaming = 1; allow_streaming >= 0; allow_streaming--) {
-            openpgp.config.allowUnauthenticatedStream = !!allow_streaming;
-            await Promise.all([badSumEncrypted, badBodyEncrypted].map(async (encrypted, i) => {
-              await Promise.all([
-                encrypted,
-                new stream.ReadableStream({
-                  start(controller) {
-                    controller.enqueue(encrypted);
-                    controller.close();
-                  }
-                }),
-                new stream.ReadableStream({
-                  start() {
-                    this.remaining = encrypted.split('\n');
-                  },
-                  async pull(controller) {
-                    if (this.remaining.length) {
-                      await new Promise(res => setTimeout(res));
-                      controller.enqueue(this.remaining.shift() + '\n');
-                    } else {
+          try {
+            for (const allowStreaming of [true, false]) {
+              openpgp.config.allowUnauthenticatedStream = allowStreaming;
+              await Promise.all([badSumEncrypted, badBodyEncrypted].map(async (encrypted, i) => {
+                await Promise.all([
+                  encrypted,
+                  new stream.ReadableStream({
+                    start(controller) {
+                      controller.enqueue(encrypted);
                       controller.close();
                     }
+                  }),
+                  new stream.ReadableStream({
+                    start() {
+                      this.remaining = encrypted.split('\n');
+                    },
+                    async pull(controller) {
+                      if (this.remaining.length) {
+                        await new Promise(res => setTimeout(res));
+                        controller.enqueue(this.remaining.shift() + '\n');
+                      } else {
+                        controller.close();
+                      }
+                    }
+                  })
+                ].map(async (encrypted, j) => {
+                  let stepReached = 0;
+                  try {
+                    const message = await openpgp.readMessage({ armoredMessage: encrypted });
+                    stepReached = 1;
+                    const { data: decrypted } = await openpgp.decrypt({ message: message, decryptionKeys: [key] });
+                    stepReached = 2;
+                    await stream.readToEnd(decrypted);
+                  } catch (e) {
+                    expect(e.message).to.match(/Ascii armor integrity check on message failed/);
+                    expect(stepReached).to.equal(
+                      j === 0 ? 0 :
+                        (openpgp.config.aeadChunkSizeByte === 0 && (j === 2 || util.detectNode() || util.getHardwareConcurrency() < 8)) || (!openpgp.config.aeadProtect && openpgp.config.allowUnauthenticatedStream) ? 2 :
+                          1
+                    );
+                    return;
                   }
-                })
-              ].map(async (encrypted, j) => {
-                let stepReached = 0;
-                try {
-                  const message = await openpgp.readMessage({ armoredMessage: encrypted });
-                  stepReached = 1;
-                  const { data: decrypted } = await openpgp.decrypt({ message: message, decryptionKeys: [key] });
-                  stepReached = 2;
-                  await stream.readToEnd(decrypted);
-                } catch (e) {
-                  expect(e.message).to.match(/Ascii armor integrity check on message failed/);
-                  expect(stepReached).to.equal(
-                    j === 0 ? 0 :
-                      (openpgp.config.aeadChunkSizeByte === 0 && (j === 2 || util.detectNode() || util.getHardwareConcurrency() < 8)) || (!openpgp.config.aeadProtect && openpgp.config.allowUnauthenticatedStream) ? 2 :
-                        1
-                  );
-                  return;
-                }
-                throw new Error(`Expected "Ascii armor integrity check on message failed" error in subtest ${i}.${j}`);
+                  throw new Error(`Expected "Ascii armor integrity check on message failed" error in subtest ${i}.${j}`);
+                }));
               }));
-            }));
+            }
+          } finally {
+            openpgp.config.allowUnauthenticatedStream = allowUnauthenticatedStream;
           }
         });
 
         it('should fail to decrypt unarmored message with garbage data appended', async function() {
-          const { key } = await openpgp.generateKey({ userIDs: {} });
+          const key = privateKey;
           const message = await openpgp.encrypt({ message: await openpgp.createMessage({ text: 'test' }), encryptionKeys: key, signingKeys: key, armor: false });
           const encrypted = util.concat([message, new Uint8Array([11])]);
           await expect((async () => {
@@ -3414,7 +3421,7 @@ amnR6g==
       curves.forEach(curve => {
         it(`sign/verify with ${curve}`, async function() {
           const plaintext = 'short message';
-          const key = (await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' } })).key;
+          const { privateKey: key } = await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' }, format: 'object' });
           const signed = await openpgp.sign({ signingKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }) });
           const verified = await openpgp.verify({ verificationKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }) });
           expect(verified.signatures[0].valid).to.be.true;

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -853,11 +853,12 @@ AkLaG/AkATpuH+DMkYDmKbDLGgD+N4yuxXBJmBfC2IBe4J1S2Gg=
       privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
       passphrase: 'hello world'
     });
-    const { key: expiredKey } = await openpgp.reformatKey({
+    const { privateKey: expiredKey } = await openpgp.reformatKey({
       privateKey: key,
       userIDs: key.users.map(user => user.userID),
       keyExpirationTime: 1,
-      date: key.keyPacket.created
+      date: key.keyPacket.created,
+      format: 'object'
     });
     await stream.loadStreamsPonyfill();
     const { signatures: [sigInfo] } = await openpgp.verify({
@@ -883,11 +884,12 @@ aMsUdQBgnPAcSGVsbG8gV29ybGQgOik=
       privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
       passphrase: 'hello world'
     });
-    const { key: expiredKey } = await openpgp.reformatKey({
+    const { privateKey: expiredKey } = await openpgp.reformatKey({
       privateKey: key,
       userIDs: key.users.map(user => user.userID),
       keyExpirationTime: 1,
-      date: key.keyPacket.created
+      date: key.keyPacket.created,
+      format: 'object'
     });
     await stream.loadStreamsPonyfill();
     const { signatures: [sigInfo] } = await openpgp.verify({
@@ -912,11 +914,12 @@ eSvSZutLuKKbidSYMLhWROPlwKc2GU2ws6PrLZAyCAel/lU=
       privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
       passphrase: 'hello world'
     });
-    const { key: expiredKey } = await openpgp.reformatKey({
+    const { privateKey: expiredKey } = await openpgp.reformatKey({
       privateKey: key,
       userIDs: key.users.map(user => user.userID),
       keyExpirationTime: 1,
-      date: key.keyPacket.created
+      date: key.keyPacket.created,
+      format: 'object'
     });
     await stream.loadStreamsPonyfill();
     const { signatures: [sigInfo] } = await openpgp.verify({
@@ -941,11 +944,12 @@ eSvSZutLuKKbidSYMLhWROPlwKc2GU2ws6PrLZAyCAel/lU=
       privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
       passphrase: 'hello world'
     });
-    const { key: expiredKey } = await openpgp.reformatKey({
+    const { privateKey: expiredKey } = await openpgp.reformatKey({
       privateKey: key,
       userIDs: key.users.map(user => user.userID),
       keyExpirationTime: 1,
-      date: key.keyPacket.created
+      date: key.keyPacket.created,
+      format: 'object'
     });
     const { signatures: [sigInfo] } = await openpgp.verify({
       verificationKeys: expiredKey,

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -382,18 +382,17 @@ function omnibus() {
   it('Omnibus Ed25519/Curve25519 Test', function() {
     const options = {
       userIDs: { name: "Hi", email: "hi@hel.lo" },
-      curve: "ed25519"
+      curve: "ed25519",
+      format: 'object'
     };
-    return openpgp.generateKey(options).then(async function(firstKey) {
-      expect(firstKey).to.exist;
-      expect(firstKey.privateKeyArmored).to.exist;
-      expect(firstKey.publicKeyArmored).to.exist;
-      expect(firstKey.key).to.exist;
-      expect(firstKey.key.keyPacket).to.exist;
-      expect(firstKey.key.subkeys).to.have.length(1);
-      expect(firstKey.key.subkeys[0].keyPacket).to.exist;
+    return openpgp.generateKey(options).then(async function({ privateKey, publicKey }) {
+      expect(privateKey).to.exist;
+      expect(publicKey).to.exist;
+      expect(privateKey.keyPacket).to.exist;
+      expect(privateKey.subkeys).to.have.length(1);
+      expect(privateKey.subkeys[0].keyPacket).to.exist;
 
-      const hi = firstKey.key;
+      const hi = privateKey;
       const primaryKey = hi.keyPacket;
       const subkey = hi.subkeys[0];
       expect(hi.getAlgorithmInfo().curve).to.equal('ed25519');
@@ -411,10 +410,11 @@ function omnibus() {
 
       const options = {
         userIDs: { name: "Bye", email: "bye@good.bye" },
-        curve: "curve25519"
+        curve: "curve25519",
+        format: 'object'
       };
-      return openpgp.generateKey(options).then(async function(secondKey) {
-        const bye = secondKey.key;
+
+      return openpgp.generateKey(options).then(async function({ privateKey: bye }) {
         expect(bye.getAlgorithmInfo().curve).to.equal('ed25519');
         expect(bye.getAlgorithmInfo().algorithm).to.equal('eddsa');
         expect(bye.subkeys[0].getAlgorithmInfo().curve).to.equal('curve25519');

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -8,24 +8,23 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 async function generateTestData() {
-  const victimPrivKey = (await openpgp.generateKey({
+  const { privateKey: victimPrivKey } = await openpgp.generateKey({
     userIDs: [{ name: 'Victim', email: 'victim@example.com' }],
     type: 'rsa',
     rsaBits: 2048,
-    subkeys: [{
-      sign: true
-    }]
-  })).key;
-  victimPrivKey.revocationSignatures = [];
+    subkeys: [{ sign: true }],
+    format: 'object'
+  });
 
-  const attackerPrivKey = (await openpgp.generateKey({
+  const { privateKey: attackerPrivKey } = await openpgp.generateKey({
     userIDs: [{ name: 'Attacker', email: 'attacker@example.com' }],
     type: 'rsa',
     rsaBits: 2048,
     subkeys: [],
-    sign: false
-  })).key;
-  attackerPrivKey.revocationSignatures = [];
+    sign: false,
+    format: 'object'
+  });
+
   const signed = await openpgp.sign({
     message: await createCleartextMessage({ text: 'I am batman' }),
     signingKeys: victimPrivKey,

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -41,8 +41,14 @@ import {
   await revokeKey({ key: privateKey });
   // @ts-expect-error for missing revocation certificate
   try { await revokeKey({ key: publicKey }); } catch (e) {}
-  await revokeKey({ key: privateKey, revocationCertificate, format: 'object' }) as PrivateKey;
-  await revokeKey({ key: publicKey, revocationCertificate, format: 'object' }) as PublicKey;
+  const { privateKey: revokedPrivateKey, publicKey: revokedPublicKey } = await revokeKey({ key: privateKey, revocationCertificate, format: 'object' });
+  expect(revokedPrivateKey).to.be.instanceOf(PrivateKey);
+  expect(revokedPublicKey).to.be.instanceOf(PublicKey);
+  const revokedKeyPair = await revokeKey({ key: publicKey, revocationCertificate, format: 'object' });
+  // @ts-expect-error for null private key
+  try { revokedKeyPair.privateKey.armor(); } catch (e) {}
+  expect(revokedKeyPair.privateKey).to.be.null;
+  expect(revokedKeyPair.publicKey).to.be.instanceOf(PublicKey);
 
   // Encrypt text message (armored)
   const text = 'hello';

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -8,7 +8,7 @@
 
 import { expect } from 'chai';
 import {
-  generateKey, readKey, readKeys, readPrivateKey, PrivateKey, Key, PublicKey,
+  generateKey, readKey, readKeys, readPrivateKey, PrivateKey, Key, PublicKey, revokeKey,
   readMessage, createMessage, Message, createCleartextMessage,
   encrypt, decrypt, sign, verify, config, enums,
   LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket
@@ -36,6 +36,13 @@ import {
   expect(parsedPrivateKey.isPrivate()).to.be.true;
   const parsedBinaryPrivateKey: PrivateKey = await readPrivateKey({ binaryKey: privateKeyBinary });
   expect(parsedBinaryPrivateKey.isPrivate()).to.be.true;
+
+  // Revoke keys
+  await revokeKey({ key: privateKey });
+  // @ts-expect-error for missing revocation certificate
+  try { await revokeKey({ key: publicKey }); } catch (e) {}
+  await revokeKey({ key: privateKey, revocationCertificate, format: 'object' }) as PrivateKey;
+  await revokeKey({ key: publicKey, revocationCertificate, format: 'object' }) as PublicKey;
 
   // Encrypt text message (armored)
   const text = 'hello';


### PR DESCRIPTION
This PR changes the return value of `openpgp.generateKey`, `reformatKey` and `revokeKey` and adds support for returning a key pair in binary form.

Changes:
- A `format` options has been added to all three functions, accepting the values `'armor', 'binary', 'object'` (defaulting to `armor`).
- `generateKey` and `reformatKey` now return an object of the form `{ publicKey, privateKey, revocationCertificate }`, where the type of `publicKey` and `privateKey` depends on `options.format`:
   - if `format: 'armor'` then `privateKey, publicKey` are armored strings
   -  if `format: 'binary'` then `privateKey, publicKey` are `Uint8Array`
   -  if `format: 'object'` then `privateKey, publicKey` are `PrivateKey` and `PublicKey` objects respectively
- `revokeKey` now returns `{ publicKey, privateKey }`, where:
   - if a `PrivateKey` was passed as input,  `privateKey, publicKey` are of the requested format
   - if a `PublicKey` was passed as input, `publicKey` is of the requested format, while `privateKey` is `null` (previously, in this case the `privateKey` field was not defined).

Breaking changes in `generateKey`, `reformatKey` and `revokeKey`:
- In `revokeKey`, if no `format` option is specified in input, the returned `publicKey, privateKey` are armored strings (they used to be objects).
- In `generateKey` and `reformatKey`, the `key` value is no longer returned.
- For all functions, the `publicKeyArmored` and `privateKeyArmored` values are no longer returned.
To get armored keys, either call e.g. `generateKey({ ..., format: 'armor' })` or use the `armor()` method on the object keys: 
```js
generateKey({ ..., format: 'object' }).then({ privateKey, publicKey }) => {
   console.log(privateKey.armor())
}
```

Also, superseeds #1324 