### PR TITLE
Remove `valid` and `error` from the verification result of `openpgp.verify` and `decrypt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ and a subkey for encryption using Curve25519.
         userIDs: [{ name: 'Jon Smith', email: 'jon@example.com' }], // you can pass multiple user IDs
         passphrase: 'super long and hard to guess secret', // protects the private key
         format: 'armor' // output key format, defaults to 'armor' (other options: 'binary' or 'object')
+    });
 
     console.log(privateKey);     // '-----BEGIN PGP PRIVATE KEY BLOCK ... '
     console.log(publicKey);      // '-----BEGIN PGP PUBLIC KEY BLOCK ... '

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Using the private key:
     const { verified, keyID } = verificationResult.signatures[0];
     try {
         await verified; // throws on invalid signature
-        console.log('signed by key id ' + keyID.toHex());
+        console.log('Signed by key id ' + keyID.toHex());
     } catch (e) {
         throw new Error('Signature could not be verified: ' + e.message);
     }
@@ -574,7 +574,7 @@ Using the private key:
     const { verified, keyID } = verificationResult.signatures[0];
     try {
         await verified; // throws on invalid signature
-        console.log('signed by key id ' + keyID.toHex());
+        console.log('Signed by key id ' + keyID.toHex());
     } catch (e) {
         throw new Error('Signature could not be verified: ' + e.message);
     }
@@ -624,7 +624,7 @@ Using the private key:
 
     try {
         await verificationResult.signatures[0].verified; // throws on invalid signature
-        console.log('signed by key id ' + verificationResult.signatures[0].keyID.toHex());
+        console.log('Signed by key id ' + verificationResult.signatures[0].keyID.toHex());
      } catch (e) {
         throw new Error('Signature could not be verified: ' + e.message);
     }

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ const openpgp = require('openpgp'); // use as CommonJS, AMD, ES6 module or via w
     // check signature validity (signed messages only)
     try {
         await signatures[0].verified; // throws on invalid signature
-        console.log('signature is valid');
+        console.log('Signature is valid');
     } catch (e) {
         throw new Error('Signature could not be verified: ' + e.message);
     }

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -132,7 +132,7 @@ export class Signature {
 
 interface VerificationResult {
   keyID: KeyID;
-  verified: Promise<null | boolean>;
+  verified: Promise<true>; // throws on invalid signature
   signature: Promise<Signature>;
 }
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -38,8 +38,8 @@ export function revokeKey(options: { key: PublicKey, revocationCertificate: stri
 
 export abstract class Key {
   public readonly keyPacket: PublicKeyPacket | SecretKeyPacket;
-  public subkeys: Subkey[];
-  public users: User[];
+  public subkeys: Subkey[]; // do not add/replace users directly
+  public users: User[]; // do not add/replace subkeys directly
   public revocationSignatures: SignaturePacket[];
   public write(): Uint8Array;
   public armor(config?: Config): string;

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -58,7 +58,7 @@ export abstract class Key {
   public verifyPrimaryUser(publicKeys: PublicKey[], date?: Date, userIDs?: UserID, config?: Config): Promise<{ keyID: KeyID, valid: boolean | null }[]>;
   public verifyAllUsers(publicKeys: PublicKey[], date?: Date, config?: Config): Promise<{ userID: string, keyID: KeyID, valid: boolean | null }[]>;
   public isRevoked(signature: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
-  public getRevocationCertificate(date?: Date, config?: Config): Promise<Stream<string> | string | undefined>;
+  public getRevocationCertificate(date?: Date, config?: Config): Promise<MaybeStream<string> | undefined>;
   public getEncryptionKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getSigningKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getKeys(keyID?: KeyID): (this | Subkey)[];
@@ -265,7 +265,7 @@ export class Message<T extends MaybeStream<Data>> {
 
   /** Get literal data that is the body of the message
    */
-  public getLiteralData(): Uint8Array | Stream<Uint8Array> | null;
+  public getLiteralData(): MaybeStream<Uint8Array> | null;
 
   /** Returns the key IDs of the keys that signed the message
    */
@@ -273,7 +273,7 @@ export class Message<T extends MaybeStream<Data>> {
 
   /** Get literal data as text
    */
-  public getText(): string | Stream<string> | null;
+  public getText(): MaybeStream<string> | null;
 
   public getFilename(): string | null;
 
@@ -603,7 +603,7 @@ interface DecryptOptions {
   /** (optional) passwords to decrypt the message */
   passwords?: MaybeArray<string>;
   /** (optional) session keys in the form: { data:Uint8Array, algorithm:String } */
-  sessionKeys?: SessionKey | SessionKey[];
+  sessionKeys?: MaybeArray<SessionKey>;
   /** (optional) array of public keys or single key, to verify signatures */
   verificationKeys?: MaybeArray<PublicKey>;
   /** (optional) whether data decryption should fail if the message is not signed with the provided publicKeys */

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -83,7 +83,7 @@ export class CleartextMessage {
    * @returns {Promise<Array<{
    *   keyID: module:type/keyid~KeyID,
    *   signature: Promise<Signature>,
-   *   verified: Promise<Boolean>
+   *   verified: Promise<true>
    * }>>} List of signer's keyID and validity of signature.
    * @async
    */

--- a/src/message.js
+++ b/src/message.js
@@ -535,7 +535,7 @@ export class Message {
    * @returns {Promise<Array<{
    *   keyID: module:type/keyid~KeyID,
    *   signature: Promise<Signature>,
-   *   verified: Promise<Boolean>
+   *   verified: Promise<true>
    * }>>} List of signer's keyID and validity of signatures.
    * @async
    */
@@ -592,7 +592,7 @@ export class Message {
    * @returns {Promise<Array<{
    *   keyID: module:type/keyid~KeyID,
    *   signature: Promise<Signature>,
-   *   verified: Promise<Boolean>
+   *   verified: Promise<true>
    * }>>} List of signer's keyID and validity of signature.
    * @async
    */
@@ -699,7 +699,7 @@ export async function createSignaturePackets(literalDataPacket, signingKeys, sig
  * @returns {Promise<{
  *   keyID: module:type/keyid~KeyID,
  *   signature: Promise<Signature>,
- *   verified: Promise<Boolean>
+ *   verified: Promise<true>
  * }>} signer's keyID and validity of signature
  * @async
  * @private
@@ -767,7 +767,7 @@ async function createVerificationObject(signature, literalDataList, verification
  * @returns {Promise<Array<{
  *   keyID: module:type/keyid~KeyID,
  *   signature: Promise<Signature>,
- *   verified: Promise<Boolean>
+ *   verified: Promise<true>
  * }>>} list of signer's keyID and validity of signatures
  * @async
  * @private

--- a/test/general/ecc_nist.js
+++ b/test/general/ecc_nist.js
@@ -20,13 +20,13 @@ module.exports = () => describe('Elliptic Curve Cryptography for NIST P-256,P-38
       await openpgp.verify({
         message: await openpgp.readCleartextMessage({ cleartextMessage }),
         verificationKeys: pubHi
-      }).then(output => expect(output.signatures[0].valid).to.be.true);
+      }).then(output => expect(output.signatures[0].verified).to.eventually.be.true);
       // Verifying detached signature
       await openpgp.verify({
         message: await openpgp.createMessage({ text: util.removeTrailingSpaces(testData) }),
         verificationKeys: pubHi,
         signature: (await openpgp.readCleartextMessage({ cleartextMessage })).signature
-      }).then(output => expect(output.signatures[0].valid).to.be.true);
+      }).then(output => expect(output.signatures[0].verified).to.eventually.be.true);
 
       // Encrypting and signing
       const encrypted = await openpgp.encrypt({
@@ -39,9 +39,9 @@ module.exports = () => describe('Elliptic Curve Cryptography for NIST P-256,P-38
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         decryptionKeys: bye,
         verificationKeys: [pubHi]
-      }).then(output => {
+      }).then(async output => {
         expect(output.data).to.equal(testData2);
-        expect(output.signatures[0].valid).to.be.true;
+        await expect(output.signatures[0].verified).to.eventually.be.true;
       });
     });
   }
@@ -55,7 +55,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for NIST P-256,P-38
     const signature = await openpgp.sign({ message: await openpgp.createCleartextMessage({ text: testData }), signingKeys: privateKey });
     const msg = await openpgp.readCleartextMessage({ cleartextMessage: signature });
     const result = await openpgp.verify({ message: msg, verificationKeys: publicKey });
-    expect(result.signatures[0].valid).to.be.true;
+    expect(await result.signatures[0].verified).to.be.true;
   });
 
   it('Encrypt and sign message', async function () {
@@ -71,7 +71,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for NIST P-256,P-38
     });
     const message = await openpgp.readMessage({ armoredMessage: encrypted });
     const result = await openpgp.decrypt({ message, decryptionKeys: secondKey.privateKey, verificationKeys: firstKey.publicKey });
-    expect(result.signatures[0].valid).to.be.true;
+    expect(await result.signatures[0].verified).to.be.true;
   });
 
   // TODO find test vectors

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -177,11 +177,11 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
   it('Verify clear signed message', async function () {
     const pub = await load_pub_key('juliet');
     const msg = await openpgp.readCleartextMessage({ cleartextMessage: data.juliet.message_signed });
-    return openpgp.verify({ verificationKeys: [pub], message: msg }).then(function(result) {
+    return openpgp.verify({ verificationKeys: [pub], message: msg }).then(async function(result) {
       expect(result).to.exist;
       expect(result.data).to.equal(data.juliet.message);
       expect(result.signatures).to.have.length(1);
-      expect(result.signatures[0].valid).to.be.true;
+      expect(await result.signatures[0].verified).to.be.true;
     });
   });
   it('Sign message', async function () {
@@ -194,7 +194,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message);
     expect(result.signatures).to.have.length(1);
-    expect(result.signatures[0].valid).to.be.true;
+    expect(await result.signatures[0].verified).to.be.true;
   });
   it('Decrypt and verify message', async function () {
     const juliet = await load_pub_key('juliet');
@@ -205,7 +205,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     expect(result).to.exist;
     expect(result.data).to.equal(data.juliet.message);
     expect(result.signatures).to.have.length(1);
-    expect(result.signatures[0].valid).to.be.true;
+    expect(await result.signatures[0].verified).to.be.true;
   });
   it('Encrypt and sign message', async function () {
     const romeoPrivate = await load_priv_key('romeo');
@@ -220,7 +220,7 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
     expect(result).to.exist;
     expect(result.data).to.equal(data.romeo.message);
     expect(result.signatures).to.have.length(1);
-    expect(result.signatures[0].valid).to.be.true;
+    expect(await result.signatures[0].verified).to.be.true;
   });
   it('Generate key', function () {
     const options = {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2595,10 +2595,10 @@ function versionSpecificTests() {
         return openpgp.verify(
           { message: await openpgp.readCleartextMessage({ cleartextMessage: signed }), verificationKeys: newKeyPublic }
         ).then(async function(verified) {
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           const newSigningKey = await newKey.getSigningKey();
           expect(verified.signatures[0].keyID.toHex()).to.equal(newSigningKey.getKeyID().toHex());
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
     });
@@ -2635,7 +2635,7 @@ function versionSpecificTests() {
         message: await openpgp.readMessage({ armoredMessage: encrypted }), decryptionKeys: newKey, verificationKeys: newKeyPublic, config: { minRSABits: 1024 }
       });
       expect(decrypted.data).to.equal('hello');
-      expect(decrypted.signatures[0].valid).to.be.true;
+      expect(await decrypted.signatures[0].verified).to.be.true;
     });
   });
 
@@ -3484,7 +3484,7 @@ VYGdb3eNlV8CfoEC
       message: await openpgp.createMessage({ text: 'hello' }), passwords: 'test', signingKeys: privateKey, signingUserIDs: { name: 'Test McTestington', email: 'test@example.com' }, armor: false, config
     });
     const { signatures } = await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), passwords: 'test' });
-    expect(signatures[0].signature.packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
+    expect((await signatures[0].signature).packets[0].hashAlgorithm).to.equal(openpgp.enums.hash.sha512);
     await expect(openpgp.encrypt({
       message: await openpgp.createMessage({ text: 'hello' }), encryptionKeys: publicKey, signingKeys: privateKey, signingUserIDs: { name: 'Not Test McTestington', email: 'test@example.com' }, armor: false, config
     })).to.be.rejectedWith('Could not find user that matches that user ID');

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1261,7 +1261,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         expectSigned: true
       });
       expect(data).to.equal(plaintext);
-      expect(signatures[0].valid).to.be.true;
+      expect(await signatures[0].verified).to.be.true;
     });
 
     it('decrypt/verify should throw on missing public keys (expectSigned=true)', async function () {
@@ -1443,8 +1443,8 @@ aOU=
         });
         expect(msg.signatures).to.exist;
         expect(msg.signatures).to.have.length(1);
-        expect(msg.signatures[0].valid).to.be.true;
-        expect(msg.signatures[0].signature.packets.length).to.equal(1);
+        expect(await msg.signatures[0].verified).to.be.true;
+        expect((await msg.signatures[0].signature).packets.length).to.equal(1);
         // secret key operations involving the primary key should fail
         await expect(openpgp.sign({
           message: await openpgp.createMessage({ text: 'test' }), signingKeys: decryptedDummyKey, config: { rejectPublicKeyAlgorithms: new Set() }
@@ -1589,7 +1589,7 @@ aOU=
           expectSigned: true
         });
         expect(data).to.equal(text);
-        expect(signatures[0].valid).to.be.true;
+        expect(await signatures[0].verified).to.be.true;
       });
 
       it('verify should throw on missing signature (expectSigned=true)', async function () {
@@ -2105,10 +2105,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            expect(decrypted.signatures[0].valid).to.be.true;
+            expect(await decrypted.signatures[0].verified).to.be.true;
             const signingKey = await privateKey.getSigningKey();
             expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+            expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2129,10 +2129,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            expect(decrypted.signatures[0].valid).to.be.true;
+            expect(await decrypted.signatures[0].verified).to.be.true;
             const signingKey = await privateKey.getSigningKey();
             expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+            expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2152,10 +2152,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
-            expect(decrypted.signatures[0].valid).to.be.true;
+            expect(await decrypted.signatures[0].verified).to.be.true;
             const signingKey = await privateKey.getSigningKey();
             expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+            expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2183,10 +2183,10 @@ aOU=
               return openpgp.decrypt(decOpt);
             }).then(async function (decrypted) {
               expect(decrypted.data).to.equal(plaintext);
-              expect(decrypted.signatures[0].valid).to.be.true;
+              expect(await decrypted.signatures[0].verified).to.be.true;
               const signingKey = await newPrivateKey.getSigningKey();
               expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+              expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
             });
           });
         });
@@ -2216,10 +2216,10 @@ aOU=
             verificationKeys: newPublicKey
           });
           expect(decrypted.data).to.equal(plaintext);
-          expect(decrypted.signatures[0].valid).to.be.true;
+          expect(await decrypted.signatures[0].verified).to.be.true;
           const signingKey = await newPrivateKey.getSigningKey();
           expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+          expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
         });
 
         it('should encrypt/sign and decrypt/verify with null string input', async function () {
@@ -2237,10 +2237,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal('');
-            expect(decrypted.signatures[0].valid).to.be.true;
+            expect(await decrypted.signatures[0].verified).to.be.true;
             const signingKey = await privateKey.getSigningKey();
             expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+            expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2261,10 +2261,10 @@ aOU=
             verificationKeys: publicKey
           });
           expect(decrypted.data).to.equal(plaintext);
-          expect(decrypted.signatures[0].valid).to.be.true;
+          expect(await decrypted.signatures[0].verified).to.be.true;
           const signingKey = await privateKey.getSigningKey();
           expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+          expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
         });
 
         it('should encrypt and decrypt/verify with detached signature as input for encryption', async function () {
@@ -2307,14 +2307,14 @@ aOU=
             }).then(async function (decrypted) {
               let signingKey;
               expect(decrypted.data).to.equal(plaintext);
-              expect(decrypted.signatures[0].valid).to.be.true;
+              expect(await decrypted.signatures[0].verified).to.be.true;
               signingKey = await privateKey.getSigningKey();
               expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-              expect(decrypted.signatures[1].valid).to.be.true;
+              expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
+              expect(await decrypted.signatures[1].verified).to.be.true;
               signingKey = await privKeyDE.getSigningKey();
               expect(decrypted.signatures[1].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[1].signature.packets.length).to.equal(1);
+              expect((await decrypted.signatures[1].signature).packets.length).to.equal(1);
             });
           } finally {
             openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
@@ -2346,11 +2346,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
-            expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find signing key/);
+            await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(signatures[0].signature.packets.length).to.equal(1);
+            expect((await signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2369,11 +2368,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
-            expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find signing key/);
+            await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(signatures[0].signature.packets.length).to.equal(1);
+            expect((await signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2392,11 +2390,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal('');
-            expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find signing key/);
+            await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(signatures[0].signature.packets.length).to.equal(1);
+            expect((await signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2414,11 +2411,10 @@ aOU=
             return openpgp.decrypt(decOpt);
           }).then(async function ({ signatures, data }) {
             expect(data).to.equal(plaintext);
-            expect(signatures[0].valid).to.be.false;
-            expect(signatures[0].error).to.match(/Could not find signing key/);
+            await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
             const signingKey = await privateKey.getSigningKey();
             expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(signatures[0].signature.packets.length).to.equal(1);
+            expect((await signatures[0].signature).packets.length).to.equal(1);
           });
         });
 
@@ -2439,11 +2435,10 @@ aOU=
             verificationKeys: await openpgp.readKey({ armoredKey: wrong_pubkey })
           });
           expect(data).to.equal(plaintext);
-          expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find signing key/);
+          await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(signatures[0].signature.packets.length).to.equal(1);
+          expect((await signatures[0].signature).packets.length).to.equal(1);
         });
 
         it('should encrypt and decrypt/verify both signatures when signed with two private keys', async function () {
@@ -2475,14 +2470,14 @@ aOU=
             }).then(async function (decrypted) {
               let signingKey;
               expect(decrypted.data).to.equal(plaintext);
-              expect(decrypted.signatures[0].valid).to.be.true;
+              expect(await decrypted.signatures[0].verified).to.be.true;
               signingKey = await privateKey.getSigningKey();
               expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
-              expect(decrypted.signatures[1].valid).to.be.true;
+              expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
+              expect(await decrypted.signatures[1].verified).to.be.true;
               signingKey = await privKeyDE.getSigningKey();
               expect(decrypted.signatures[1].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[1].signature.packets.length).to.equal(1);
+              expect((await decrypted.signatures[1].signature).packets.length).to.equal(1);
             });
           } finally {
             openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
@@ -2591,10 +2586,10 @@ aOU=
             }).then(async function (decrypted) {
               expect(decrypted.data).to.exist;
               expect(decrypted.data).to.equal(plaintext);
-              expect(decrypted.signatures[0].valid).to.be.true;
+              expect(await decrypted.signatures[0].verified).to.be.true;
               const signingKey = await privKeyDE.getSigningKey();
               expect(decrypted.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-              expect(decrypted.signatures[0].signature.packets.length).to.equal(1);
+              expect((await decrypted.signatures[0].signature).packets.length).to.equal(1);
             });
           } finally {
             openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
@@ -2837,10 +2832,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
           expect(verified.data).to.equal(plaintext.replace(/[ \t]+$/mg, ''));
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           const signingKey = await privateKey.getSigningKey();
           expect(verified.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -2869,14 +2864,14 @@ aOU=
           }).then(async function (verified) {
             let signingKey;
             expect(verified.data).to.equal(plaintext.replace(/[ \t]+$/mg, ''));
-            expect(verified.signatures[0].valid).to.be.true;
+            expect(await verified.signatures[0].verified).to.be.true;
             signingKey = await privateKey.getSigningKey();
             expect(verified.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(verified.signatures[0].signature.packets.length).to.equal(1);
-            expect(verified.signatures[1].valid).to.be.true;
+            expect((await verified.signatures[0].signature).packets.length).to.equal(1);
+            expect(await verified.signatures[1].verified).to.be.true;
             signingKey = await privKeyDE.getSigningKey();
             expect(verified.signatures[1].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-            expect(verified.signatures[1].signature.packets.length).to.equal(1);
+            expect((await verified.signatures[1].signature).packets.length).to.equal(1);
           });
         } finally {
           openpgp.config.rejectPublicKeyAlgorithms = rejectPublicKeyAlgorithms;
@@ -2899,10 +2894,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
           expect(verified.data).to.equal(plaintext);
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           const signingKey = await privateKey.getSigningKey();
           expect(verified.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -2920,11 +2915,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function ({ data, signatures }) {
           expect(data).to.equal(plaintext.replace(/[ \t]+$/mg, ''));
-          expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find signing key/);
+          await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(signatures[0].signature.packets.length).to.equal(1);
+          expect((await signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -2944,11 +2938,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function ({ data, signatures }) {
           expect(data).to.equal(plaintext);
-          expect(signatures[0].valid).to.be.false;
-          expect(signatures[0].error).to.match(/Could not find signing key/);
+          await expect(signatures[0].verified).to.be.rejectedWith(/Could not find signing key/);
           const signingKey = await privateKey.getSigningKey();
           expect(signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(signatures[0].signature.packets.length).to.equal(1);
+          expect((await signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -2967,10 +2960,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
           expect(verified.data).to.equal(plaintext);
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           const signingKey = await privateKey.getSigningKey();
           expect(verified.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -2992,12 +2985,12 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
           expect(verified.data).to.equal(plaintext);
-          expect(+verified.signatures[0].signature.packets[0].created).to.be.lte(+util.normalizeDate());
-          expect(+verified.signatures[0].signature.packets[0].created).to.be.gte(+start);
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(+(await verified.signatures[0].signature).packets[0].created).to.be.lte(+util.normalizeDate());
+          expect(+(await verified.signatures[0].signature).packets[0].created).to.be.gte(+start);
+          expect(await verified.signatures[0].verified).to.be.true;
           const signingKey = await privateKey.getSigningKey();
           expect(verified.signatures[0].keyID.toHex()).to.equal(signingKey.getKeyID().toHex());
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -3019,22 +3012,22 @@ aOU=
         return openpgp.sign(signOpt).then(async function (signed) {
           verifyOpt.signature = await openpgp.readSignature({ binarySignature: signed });
           return openpgp.verify(verifyOpt).then(async function (verified) {
-            expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
+            expect(+(await verified.signatures[0].signature).packets[0].created).to.equal(+past);
             expect(verified.data).to.equal(plaintext);
-            expect(verified.signatures[0].valid).to.be.true;
+            expect(await verified.signatures[0].verified).to.be.true;
             expect(await privateKey_1337.getSigningKey(verified.signatures[0].keyID, past))
               .to.be.not.null;
-            expect(verified.signatures[0].signature.packets.length).to.equal(1);
+            expect((await verified.signatures[0].signature).packets.length).to.equal(1);
             // now check with expiration checking disabled
             verifyOpt.date = null;
             return openpgp.verify(verifyOpt);
           }).then(async function (verified) {
-            expect(+verified.signatures[0].signature.packets[0].created).to.equal(+past);
+            expect(+(await verified.signatures[0].signature).packets[0].created).to.equal(+past);
             expect(verified.data).to.equal(plaintext);
-            expect(verified.signatures[0].valid).to.be.true;
+            expect(await verified.signatures[0].verified).to.be.true;
             expect(await privateKey_1337.getSigningKey(verified.signatures[0].keyID, null))
               .to.be.not.null;
-            expect(verified.signatures[0].signature.packets.length).to.equal(1);
+            expect((await verified.signatures[0].signature).packets.length).to.equal(1);
           });
         });
       });
@@ -3059,12 +3052,12 @@ aOU=
           verifyOpt.signature = await openpgp.readSignature({ binarySignature: signed });
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
-          expect(+verified.signatures[0].signature.packets[0].created).to.equal(+future);
+          expect(+(await verified.signatures[0].signature).packets[0].created).to.equal(+future);
           expect([].slice.call(verified.data)).to.deep.equal([].slice.call(data));
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           expect(await privateKey_2038_2045.getSigningKey(verified.signatures[0].keyID, future))
             .to.be.not.null;
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -3089,10 +3082,10 @@ aOU=
           return openpgp.verify(verifyOpt);
         }).then(async function (verified) {
           expect([].slice.call(verified.data)).to.deep.equal([].slice.call(data));
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
           expect(await privateKey.getSigningKey(verified.signatures[0].keyID))
             .to.be.not.null;
-          expect(verified.signatures[0].signature.packets.length).to.equal(1);
+          expect((await verified.signatures[0].signature).packets.length).to.equal(1);
         });
       });
 
@@ -3473,7 +3466,7 @@ amnR6g==
           const { privateKey: key } = await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' }, format: 'object' });
           const signed = await openpgp.sign({ signingKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }) });
           const verified = await openpgp.verify({ verificationKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }) });
-          expect(verified.signatures[0].valid).to.be.true;
+          expect(await verified.signatures[0].verified).to.be.true;
         });
       });
 

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -683,7 +683,7 @@ function tests() {
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);
-    expect(verified.signatures[0].valid).to.be.true;
+    expect(await verified.signatures[0].verified).to.be.true;
   });
 
   it('Detached sign small message using brainpool curve keys', async function() {
@@ -722,7 +722,7 @@ function tests() {
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);
-    expect(verified.signatures[0].valid).to.be.true;
+    expect(await verified.signatures[0].verified).to.be.true;
   });
 
   it('Detached sign small message using x25519 curve keys', async function() {
@@ -761,7 +761,7 @@ function tests() {
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);
-    expect(verified.signatures[0].valid).to.be.true;
+    expect(await verified.signatures[0].verified).to.be.true;
   });
 
   it("Detached sign is expected to pull entire input stream when we're not pulling signed stream", async function() {

--- a/test/security/subkey_trust.js
+++ b/test/security/subkey_trust.js
@@ -69,8 +69,7 @@ async function testSubkeyTrust() {
     verificationKeys: fakeKey
   });
   expect(verifyAttackerIsBatman.signatures[0].keyID.equals(victimPubKey.subkeys[0].getKeyID())).to.be.true;
-  expect(verifyAttackerIsBatman.signatures[0].valid).to.be.false;
-  expect(verifyAttackerIsBatman.signatures[0].error).to.match(/Could not find valid signing key packet/);
+  await expect(verifyAttackerIsBatman.signatures[0].verified).to.be.rejectedWith(/Could not find valid signing key packet/);
 }
 
 module.exports = () => it('Does not trust subkeys without Primary Key Binding Signature', testSubkeyTrust);

--- a/test/worker/worker_example.js
+++ b/test/worker/worker_example.js
@@ -68,9 +68,7 @@ onmessage = async function({ data: { action, message }, ports: [port] }) {
           verificationKeys: publicKey,
           decryptionKeys: privateKey
         });
-        if (!signatures[0].valid) {
-          throw new Error("Couldn't veriy signature");
-        }
+        await signatures[0].verified;
         result = data;
         break;
       }


### PR DESCRIPTION
This PR removes the `valid` and `error` properties that were returned by `openpgp.verify` and `decrypt` when verifying a non-streamed message. This change is to make the code more consistent between the streaming and non-streaming cases.

The validity of a signature can be determined by using the (existing) `verified` promise:
```js
const verificationResult = await openpgp.verify({
  message,
  verificationKeys: publicKey
});

const { verified } = verificationResult.signatures[0];
try {
  await verified; // throws on invalid signature
  console.log('signature is valid');
} catch (e) {
  throw new Error('Signature could not be verified: ' + e.message);
}

// The following is no longer possible:
const { valid, error } = verificationResult.signatures[0];
if (valid) {
  console.log('signature is valid')
} else {
  console.log(error)
}
```

Close #1313 .