### PR TITLE
Simplify revoke method return

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -360,6 +360,7 @@ export function unarmor(input, config = defaultConfig) {
  * @static
  */
 export function armor(messageType, body, partIndex, partTotal, customComment, config = defaultConfig) {
+  config = { ...defaultConfig, ...config };
   let text;
   let hash;
   if (messageType === enums.armor.signed) {

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -139,20 +139,7 @@ export async function revokeKey({ key, revocationCertificate, reasonForRevocatio
       await key.applyRevocationCertificate(revocationCertificate, date, config) :
       await key.revoke(reasonForRevocation, date, config);
 
-    if (revokedKey.isPrivate()) {
-      const publicKey = revokedKey.toPublic();
-      return {
-        privateKey: revokedKey,
-        privateKeyArmored: revokedKey.armor(config),
-        publicKey: publicKey,
-        publicKeyArmored: publicKey.armor(config)
-      };
-    }
-
-    return {
-      publicKey: revokedKey,
-      publicKeyArmored: revokedKey.armor(config)
-    };
+    return revokedKey;
   } catch (err) {
     throw util.wrapError('Error revoking key', err);
   }

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -136,11 +136,11 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       const { key, revocationCertificate } = await openpgp.generateKey({ userIDs });
 
       const opt = { key };
-      const { privateKeyArmored: revKeyArmored } = await openpgp.revokeKey(opt);
+      const revKeyArmored = await openpgp.revokeKey(opt).then(revKey => revKey.armor(opt.config));
       expect(revKeyArmored.indexOf(openpgp.config.commentString) > 0).to.be.false;
 
       const opt2 = { key, config: { showComment: true } };
-      const { privateKeyArmored: revKeyArmored2 } = await openpgp.revokeKey(opt2);
+      const revKeyArmored2 = await openpgp.revokeKey(opt2).then(revKey2 => revKey2.armor(opt2.config));
       expect(revKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
 
       const opt3 = {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2717,7 +2717,6 @@ function versionSpecificTests() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' }, passphrase: '1234' };
     return openpgp.generateKey(opt).then(function(original) {
       return openpgp.revokeKey({ key: original.key.toPublic(), revocationCertificate: original.revocationCertificate }).then(async function(revKey) {
-        revKey = revKey.publicKey;
         expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
         expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('');
         await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');
@@ -2729,7 +2728,6 @@ function versionSpecificTests() {
     const opt = { userIDs: { name: 'test', email: 'a@b.com' } };
     return openpgp.generateKey(opt).then(async function(original) {
       return openpgp.revokeKey({ key: original.key, reasonForRevocation: { string: 'Testing key revocation' } }).then(async function(revKey) {
-        revKey = revKey.publicKey;
         expect(revKey.revocationSignatures[0].reasonForRevocationFlag).to.equal(openpgp.enums.reasonForRevocation.noReason);
         expect(revKey.revocationSignatures[0].reasonForRevocationString).to.equal('Testing key revocation');
         await expect(revKey.verifyPrimaryKey()).to.be.rejectedWith('Primary key is revoked');

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -3218,7 +3218,7 @@ aOU=
         }).then(async function(revKey) {
           return openpgp.encrypt({
             message: await openpgp.createMessage({ text: plaintext }),
-            encryptionKeys: revKey.publicKey
+            encryptionKeys: revKey
           }).then(function() {
             throw new Error('Should not encrypt with revoked key');
           }).catch(function(error) {


### PR DESCRIPTION
The wrapper object is not necessary and performs extra work that may be unnecessary for a client. Passing the revoked key allows the consumer to decide to armor or create public key. See https://github.com/openpgpjs/openpgpjs/pull/1324/files#r650742027 for more detail/inspiration.