### PR TITLE
Replace `armor` option with `format` in `openpgp.encrypt`, `sign` and `encryptSessionKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Encryption will use the algorithm specified in config.preferredSymmetricAlgorith
     const encrypted = await openpgp.encrypt({
         message, // input as Message object
         passwords: ['secret stuff'], // multiple passwords possible
-        armor: false // don't ASCII armor (for Uint8Array output)
+        format: 'binary' // don't ASCII armor (for Uint8Array output)
     });
     console.log(encrypted); // Uint8Array
 
@@ -358,7 +358,7 @@ Where the value can be any of:
     const encrypted = await openpgp.encrypt({
         message, // input as Message object
         passwords: ['secret stuff'], // multiple passwords possible
-        armor: false // don't ASCII armor (for Uint8Array output)
+        format: 'binary' // don't ASCII armor (for Uint8Array output)
     });
     console.log(encrypted); // raw encrypted packets as ReadableStream<Uint8Array>
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -177,6 +177,9 @@ export function encryptSessionKey(options: SessionKey & {
 export function encryptSessionKey(options: SessionKey & { 
   encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format: 'binary', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
 }) : Promise<Uint8Array>;
+export function encryptSessionKey(options: SessionKey & { 
+  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format: 'object', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
+}) : Promise<Message<Data>>;
 export function decryptSessionKeys<T extends MaybeStream<Data>>(options: { message: Message<T>, decryptionKeys?: MaybeArray<PrivateKey>, passwords?: MaybeArray<string>, date?: Date, config?: PartialConfig }): Promise<SessionKey[]>;
 
 export function readMessage<T extends MaybeStream<string>>(options: { armoredMessage: T, config?: PartialConfig }): Promise<Message<T>>;
@@ -185,28 +188,31 @@ export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binary
 export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 
+export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format?: 'armor' }): Promise<
+  T extends WebStream<infer X> ? WebStream<string> :
+  T extends NodeStream<infer X> ? NodeStream<string> :
+  string
+>;
 export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format: 'binary' }): Promise<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :
   T extends NodeStream<infer X> ? NodeStream<Uint8Array> :
   Uint8Array
 >;
-export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T> }): Promise<
+export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format: 'object' }): Promise<Message<T>>;
+
+export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format?: 'armor' }): Promise<
   T extends WebStream<infer X> ? WebStream<string> :
   T extends NodeStream<infer X> ? NodeStream<string> :
   string
 >;
-
 export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format: 'binary' }): Promise<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :
   T extends NodeStream<infer X> ? NodeStream<Uint8Array> :
   Uint8Array
 >;
-export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T> }): Promise<
-  T extends WebStream<infer X> ? WebStream<string> :
-  T extends NodeStream<infer X> ? NodeStream<string> :
-  string
->;
-export function sign(options: SignOptions & { message: CleartextMessage }): Promise<string>;
+export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format: 'object' }): Promise<Message<T>>;
+export function sign(options: SignOptions & { message: CleartextMessage, format?: 'armor' }): Promise<string>;
+export function sign(options: SignOptions & { message: CleartextMessage, format: 'object' }): Promise<CleartextMessage>;
 
 export function decrypt<T extends MaybeStream<Data>>(options: DecryptOptions & { message: Message<T>, format: 'binary' }): Promise<DecryptMessageResult & {
   data:
@@ -577,7 +583,7 @@ interface EncryptOptions {
   /** (optional) session key */
   sessionKey?: SessionKey;
   /** if the return values should be ascii armored or the message/signature objects */
-  format?: 'armor' | 'binary';
+  format?: 'armor' | 'binary' | 'object';
   /** (optional) if the signature should be detached (if true, signature will be added to returned object) */
   signature?: Signature;
   /** (optional) encrypt as of a certain date */
@@ -620,7 +626,7 @@ interface DecryptOptions {
 interface SignOptions {
   message: CleartextMessage | Message<MaybeStream<Data>>;
   signingKeys?: MaybeArray<PrivateKey>;
-  format?: 'armor' | 'binary';
+  format?: 'armor' | 'binary' | 'object';
   dataType?: DataPacketType;
   detached?: boolean;
   signingKeyIDs?: MaybeArray<KeyID>;

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -172,10 +172,10 @@ export class CleartextMessage {
 /* ############## v5 MSG #################### */
 export function generateSessionKey(options: { encryptionKeys: MaybeArray<PublicKey>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig }): Promise<SessionKey>;
 export function encryptSessionKey(options: SessionKey & { 
-  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, armor?: true, wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
+  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format?: 'armor', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
 }) : Promise<string>;
 export function encryptSessionKey(options: SessionKey & { 
-  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, armor: false, wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
+  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format: 'binary', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
 }) : Promise<Uint8Array>;
 export function decryptSessionKeys<T extends MaybeStream<Data>>(options: { message: Message<T>, decryptionKeys?: MaybeArray<PrivateKey>, passwords?: MaybeArray<string>, date?: Date, config?: PartialConfig }): Promise<SessionKey[]>;
 
@@ -185,7 +185,7 @@ export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binary
 export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 
-export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, armor: false }): Promise<
+export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format: 'binary' }): Promise<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :
   T extends NodeStream<infer X> ? NodeStream<Uint8Array> :
   Uint8Array
@@ -196,7 +196,7 @@ export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & {
   string
 >;
 
-export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, armor: false }): Promise<
+export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format: 'binary' }): Promise<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :
   T extends NodeStream<infer X> ? NodeStream<Uint8Array> :
   Uint8Array
@@ -577,7 +577,7 @@ interface EncryptOptions {
   /** (optional) session key */
   sessionKey?: SessionKey;
   /** if the return values should be ascii armored or the message/signature objects */
-  armor?: boolean;
+  format?: 'armor' | 'binary';
   /** (optional) if the signature should be detached (if true, signature will be added to returned object) */
   signature?: Signature;
   /** (optional) encrypt as of a certain date */
@@ -620,7 +620,7 @@ interface DecryptOptions {
 interface SignOptions {
   message: CleartextMessage | Message<MaybeStream<Data>>;
   signingKeys?: MaybeArray<PrivateKey>;
-  armor?: boolean;
+  format?: 'armor' | 'binary';
   dataType?: DataPacketType;
   detached?: boolean;
   signingKeyIDs?: MaybeArray<KeyID>;

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -132,7 +132,7 @@ export class CleartextMessage {
  * @async
  * @static
  */
-export async function readCleartextMessage({ cleartextMessage, config }) {
+export async function readCleartextMessage({ cleartextMessage, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   if (!cleartextMessage) {
     throw new Error('readCleartextMessage: must pass options object containing `cleartextMessage`');
@@ -140,6 +140,8 @@ export async function readCleartextMessage({ cleartextMessage, config }) {
   if (!util.isString(cleartextMessage)) {
     throw new Error('readCleartextMessage: options.cleartextMessage must be a string');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   const input = await unarmor(cleartextMessage);
   if (input.type !== enums.armor.signed) {
     throw new Error('No cleartext signed message.');
@@ -203,12 +205,14 @@ function verifyHeaders(headers, packetlist) {
  * @static
  * @async
  */
-export async function createCleartextMessage({ text }) {
+export async function createCleartextMessage({ text, ...rest }) {
   if (!text) {
     throw new Error('createCleartextMessage: must pass options object containing `text`');
   }
   if (!util.isString(text)) {
     throw new Error('createCleartextMessage: options.text must be a string');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   return new CleartextMessage(text);
 }

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -275,7 +275,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
  * @async
  * @static
  */
-export async function readKey({ armoredKey, binaryKey, config }) {
+export async function readKey({ armoredKey, binaryKey, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   if (!armoredKey && !binaryKey) {
     throw new Error('readKey: must pass options object containing `armoredKey` or `binaryKey`');
@@ -286,6 +286,8 @@ export async function readKey({ armoredKey, binaryKey, config }) {
   if (binaryKey && !util.isUint8Array(binaryKey)) {
     throw new Error('readKey: options.binaryKey must be a Uint8Array');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   let input;
   if (armoredKey) {
     const { type, data } = await unarmor(armoredKey, config);
@@ -310,7 +312,7 @@ export async function readKey({ armoredKey, binaryKey, config }) {
  * @async
  * @static
  */
-export async function readPrivateKey({ armoredKey, binaryKey, config }) {
+export async function readPrivateKey({ armoredKey, binaryKey, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   if (!armoredKey && !binaryKey) {
     throw new Error('readPrivateKey: must pass options object containing `armoredKey` or `binaryKey`');
@@ -321,6 +323,8 @@ export async function readPrivateKey({ armoredKey, binaryKey, config }) {
   if (binaryKey && !util.isUint8Array(binaryKey)) {
     throw new Error('readPrivateKey: options.binaryKey must be a Uint8Array');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   let input;
   if (armoredKey) {
     const { type, data } = await unarmor(armoredKey, config);
@@ -345,7 +349,7 @@ export async function readPrivateKey({ armoredKey, binaryKey, config }) {
  * @async
  * @static
  */
-export async function readKeys({ armoredKeys, binaryKeys, config }) {
+export async function readKeys({ armoredKeys, binaryKeys, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   let input = armoredKeys || binaryKeys;
   if (!input) {
@@ -357,6 +361,8 @@ export async function readKeys({ armoredKeys, binaryKeys, config }) {
   if (binaryKeys && !util.isUint8Array(binaryKeys)) {
     throw new Error('readKeys: options.binaryKeys must be a Uint8Array');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (armoredKeys) {
     const { type, data } = await unarmor(armoredKeys, config);
     if (type !== enums.armor.publicKey && type !== enums.armor.privateKey) {

--- a/src/message.js
+++ b/src/message.js
@@ -790,7 +790,7 @@ export async function createVerificationObjects(signatureList, literalDataList, 
  * @async
  * @static
  */
-export async function readMessage({ armoredMessage, binaryMessage, config }) {
+export async function readMessage({ armoredMessage, binaryMessage, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   let input = armoredMessage || binaryMessage;
   if (!input) {
@@ -802,6 +802,8 @@ export async function readMessage({ armoredMessage, binaryMessage, config }) {
   if (binaryMessage && !util.isUint8Array(binaryMessage) && !util.isStream(binaryMessage)) {
     throw new Error('readMessage: options.binaryMessage must be a Uint8Array or stream');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   const streamType = util.isStream(input);
   if (streamType) {
     await stream.loadStreamsPonyfill();
@@ -832,7 +834,7 @@ export async function readMessage({ armoredMessage, binaryMessage, config }) {
  * @async
  * @static
  */
-export async function createMessage({ text, binary, filename, date = new Date(), format = text !== undefined ? 'utf8' : 'binary' }) {
+export async function createMessage({ text, binary, filename, date = new Date(), format = text !== undefined ? 'utf8' : 'binary', ...rest }) {
   let input = text !== undefined ? text : binary;
   if (input === undefined) {
     throw new Error('createMessage: must pass options object containing `text` or `binary`');
@@ -843,6 +845,8 @@ export async function createMessage({ text, binary, filename, date = new Date(),
   if (binary && !util.isUint8Array(binary) && !util.isStream(binary)) {
     throw new Error('createMessage: options.binary must be a Uint8Array or stream');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   const streamType = util.isStream(input);
   if (streamType) {
     await stream.loadStreamsPonyfill();

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -32,6 +32,7 @@ import util from './util';
 
 /**
  * Generates a new OpenPGP key pair. Supports RSA and ECC keys. By default, primary and subkeys will be of same type.
+ * The primary key will not have encryption capabilities.
  * @param {Object} options
  * @param {Object|Array<Object>} options.userIDs - User IDs as objects: `{ name: 'Jo Doe', email: 'info@jo.com' }`
  * @param {'ecc'|'rsa'} [options.type='ecc'] - The primary key algorithm type: ECC (default) or RSA
@@ -51,9 +52,11 @@ import util from './util';
  * @async
  * @static
  */
-export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc', rsaBits = 4096, curve = 'curve25519', keyExpirationTime = 0, date = new Date(), subkeys = [{}], format = 'armor', config }) {
+export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc', rsaBits = 4096, curve = 'curve25519', keyExpirationTime = 0, date = new Date(), subkeys = [{}], format = 'armor', config, ...rest }) {
   config = { ...defaultConfig, ...config };
   userIDs = toArray(userIDs);
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (userIDs.length === 0) {
     throw new Error('UserIDs are required for key generation');
   }
@@ -90,9 +93,11 @@ export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc',
  * @async
  * @static
  */
-export async function reformatKey({ privateKey, userIDs = [], passphrase = '', keyExpirationTime = 0, date, format = 'armor', config }) {
+export async function reformatKey({ privateKey, userIDs = [], passphrase = '', keyExpirationTime = 0, date, format = 'armor', config, ...rest }) {
   config = { ...defaultConfig, ...config };
   userIDs = toArray(userIDs);
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (userIDs.length === 0) {
     throw new Error('UserIDs are required for key reformat');
   }
@@ -129,8 +134,10 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase = '', k
  * @async
  * @static
  */
-export async function revokeKey({ key, revocationCertificate, reasonForRevocation, date = new Date(), format = 'armor', config }) {
+export async function revokeKey({ key, revocationCertificate, reasonForRevocation, date = new Date(), format = 'armor', config, ...rest }) {
   config = { ...defaultConfig, ...config };
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   try {
     const revokedKey = revocationCertificate ?
       await key.applyRevocationCertificate(revocationCertificate, date, config) :
@@ -158,8 +165,10 @@ export async function revokeKey({ key, revocationCertificate, reasonForRevocatio
  * @returns {Promise<PrivateKey>} The unlocked key object.
  * @async
  */
-export async function decryptKey({ privateKey, passphrase, config }) {
+export async function decryptKey({ privateKey, passphrase, config, ...rest }) {
   config = { ...defaultConfig, ...config };
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (!privateKey.isPrivate()) {
     throw new Error('Cannot decrypt a public key');
   }
@@ -190,8 +199,10 @@ export async function decryptKey({ privateKey, passphrase, config }) {
  * @returns {Promise<PrivateKey>} The locked key object.
  * @async
  */
-export async function encryptKey({ privateKey, passphrase, config }) {
+export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
   config = { ...defaultConfig, ...config };
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (!privateKey.isPrivate()) {
     throw new Error('Cannot encrypt a public key');
   }
@@ -233,7 +244,7 @@ export async function encryptKey({ privateKey, passphrase, config }) {
  * @param {PrivateKey|PrivateKey[]} [options.signingKeys] - Private keys for signing. If omitted message will not be signed
  * @param {String|String[]} [options.passwords] - Array of passwords or a single password to encrypt the message
  * @param {Object} [options.sessionKey] - Session key in the form: `{ data:Uint8Array, algorithm:String }`
- * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
+ * @param {'armor'|'binary'} [options.format='armor'] - Format of the returned message
  * @param {Signature} [options.signature] - A detached signature to add to the encrypted message
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
  * @param {KeyID|KeyID[]} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each `signingKeyIDs[i]` corresponds to `signingKeys[i]`
@@ -246,20 +257,23 @@ export async function encryptKey({ privateKey, passphrase, config }) {
  * @async
  * @static
  */
-export async function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, armor = true, signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
+export async function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, format = 'armor', signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkMessage(message); encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords);
+  checkMessage(message); checkMessageFormat(format);
+  encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords);
   signingKeyIDs = toArray(signingKeyIDs); encryptionKeyIDs = toArray(encryptionKeyIDs); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.detached) {
     throw new Error("The `detached` option has been removed from openpgp.encrypt, separately call openpgp.sign instead. Don't forget to remove the `privateKeys` option as well.");
   }
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.encrypt, pass `encryptionKeys` instead');
   if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.encrypt, pass `signingKeys` instead');
+  if (rest.armor !== undefined) throw new Error('The `armor` option has been removed from openpgp.encrypt, pass `format` instead.');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   if (!signingKeys) {
     signingKeys = [];
   }
-
+  const armor = format === 'armor';
   const streaming = message.fromStream;
   try {
     if (signingKeys.length || signature) { // sign the message only if signing keys or signature is specified
@@ -313,6 +327,7 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
   checkMessage(message); verificationKeys = toArray(verificationKeys); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords); sessionKeys = toArray(sessionKeys);
   if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.decrypt, pass `decryptionKeys` instead');
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.decrypt, pass `verificationKeys` instead');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   try {
     const decrypted = await message.decrypt(decryptionKeys, passwords, sessionKeys, date, config);
@@ -359,7 +374,7 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  * @param {Object} options
  * @param {CleartextMessage|Message} options.message - (cleartext) message to be signed
  * @param {PrivateKey|PrivateKey[]} options.signingKeys - Array of keys or single key with decrypted secret key data to sign cleartext
- * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
+ * @param {'armor'|'binary'} [options.format='armor'] - Format of the returned message
  * @param {Boolean} [options.detached=false] - If the return value should contain a detached signature
  * @param {KeyID|KeyID[]} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
  * @param {Date} [options.date=current date] - Override the creation date of the signature
@@ -369,14 +384,19 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  * @async
  * @static
  */
-export async function sign({ message, signingKeys, armor = true, detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
+export async function sign({ message, signingKeys, format = 'armor', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkCleartextOrMessage(message);
-  if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead');
-  if (message instanceof CleartextMessage && !armor) throw new Error("Can't sign non-armored cleartext message");
-  if (message instanceof CleartextMessage && detached) throw new Error("Can't detach-sign a cleartext message");
-
+  checkCleartextOrMessage(message); checkMessageFormat(format);
   signingKeys = toArray(signingKeys); signingKeyIDs = toArray(signingKeyIDs); signingUserIDs = toArray(signingUserIDs);
+
+  if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead');
+  if (rest.armor !== undefined) throw new Error('The `armor` option has been removed from openpgp.sign, pass `format` instead.');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
+  const armor = format === 'armor';
+  if (message instanceof CleartextMessage && !armor) throw new Error('Cannot return signed cleartext message in binary format');
+  if (message instanceof CleartextMessage && detached) throw new Error('Cannot detach-sign a cleartext message');
+
   if (!signingKeys || signingKeys.length === 0) {
     throw new Error('No signing keys provided');
   }
@@ -431,12 +451,12 @@ export async function sign({ message, signingKeys, armor = true, detached = fals
  */
 export async function verify({ message, verificationKeys, expectSigned = false, format = 'utf8', signature = null, date = new Date(), config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkCleartextOrMessage(message);
+  checkCleartextOrMessage(message); verificationKeys = toArray(verificationKeys);
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.verify, pass `verificationKeys` instead');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (message instanceof CleartextMessage && format === 'binary') throw new Error("Can't return cleartext message data as binary");
   if (message instanceof CleartextMessage && signature) throw new Error("Can't verify detached cleartext signature");
-
-  verificationKeys = toArray(verificationKeys);
 
   try {
     const result = {};
@@ -487,6 +507,7 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
   config = { ...defaultConfig, ...config };
   encryptionKeys = toArray(encryptionKeys); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.generateSessionKey, pass `encryptionKeys` instead');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   try {
     const sessionKeys = await Message.generateSessionKey(encryptionKeys, date, encryptionUserIDs, config);
@@ -505,7 +526,7 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
  * @param {String} [options.aeadAlgorithm] - AEAD algorithm, e.g. 'eax' or 'ocb'
  * @param {PublicKey|PublicKey[]} [options.encryptionKeys] - Array of public keys or single key, used to encrypt the key
  * @param {String|String[]} [options.passwords] - Passwords for the message
- * @param {Boolean} [options.armor=true] - Whether the return values should be ascii armored (true, the default) or binary (false)
+ * @param {'armor'|'binary'} [options.format='armor'] - Format of the returned value
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
  * @param {KeyID|KeyID[]} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each encryptionKeyIDs[i] corresponds to encryptionKeys[i]
  * @param {Date} [options.date=current date] - Override the date
@@ -515,14 +536,16 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
  * @async
  * @static
  */
-export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, armor = true, wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
+export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, format = 'armor', wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkBinary(data); checkString(algorithm, 'algorithm'); encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionKeyIDs = toArray(encryptionKeyIDs); encryptionUserIDs = toArray(encryptionUserIDs);
+  checkBinary(data); checkString(algorithm, 'algorithm'); checkMessageFormat(format);
+  encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionKeyIDs = toArray(encryptionKeyIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.encryptSessionKey, pass `encryptionKeys` instead');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   try {
     const message = await Message.encryptSessionKey(data, algorithm, aeadAlgorithm, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);
-    return armor ? message.armor(config) : message.write();
+    return format === 'armor' ? message.armor(config) : message.write();
   } catch (err) {
     throw util.wrapError('Error encrypting session key', err);
   }
@@ -547,6 +570,7 @@ export async function decryptSessionKeys({ message, decryptionKeys, passwords, d
   config = { ...defaultConfig, ...config };
   checkMessage(message); decryptionKeys = toArray(decryptionKeys); passwords = toArray(passwords);
   if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.decryptSessionKeys, pass `decryptionKeys` instead');
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   try {
     const sessionKeys = await message.decryptSessionKeys(decryptionKeys, passwords, date, config);
@@ -586,6 +610,11 @@ function checkMessage(message) {
 function checkCleartextOrMessage(message) {
   if (!(message instanceof CleartextMessage) && !(message instanceof Message)) {
     throw new Error('Parameter [message] needs to be of type Message or CleartextMessage');
+  }
+}
+function checkMessageFormat(format) {
+  if (format !== 'armor' && format !== 'binary') {
+    throw new Error(`Unsupported format ${format}`);
   }
 }
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -32,7 +32,7 @@ import util from './util';
 
 /**
  * Generates a new OpenPGP key pair. Supports RSA and ECC keys. By default, primary and subkeys will be of same type.
- * The primary key will not have encryption capabilities.
+ * The generated primary key will have signing capabilities. By default, one subkey with encryption capabilities is also generated.
  * @param {Object} options
  * @param {Object|Array<Object>} options.userIDs - User IDs as objects: `{ name: 'Jo Doe', email: 'info@jo.com' }`
  * @param {'ecc'|'rsa'} [options.type='ecc'] - The primary key algorithm type: ECC (default) or RSA

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -259,7 +259,7 @@ export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
  */
 export async function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, format = 'armor', signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkMessage(message); checkMessageFormat(format);
+  checkMessage(message); checkOutputMessageFormat(format);
   encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords);
   signingKeyIDs = toArray(signingKeyIDs); encryptionKeyIDs = toArray(encryptionKeyIDs); signingUserIDs = toArray(signingUserIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.detached) {
@@ -386,7 +386,7 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  */
 export async function sign({ message, signingKeys, format = 'armor', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkCleartextOrMessage(message); checkMessageFormat(format);
+  checkCleartextOrMessage(message); checkOutputMessageFormat(format);
   signingKeys = toArray(signingKeys); signingKeyIDs = toArray(signingKeyIDs); signingUserIDs = toArray(signingUserIDs);
 
   if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead');
@@ -538,7 +538,7 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
  */
 export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, format = 'armor', wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
-  checkBinary(data); checkString(algorithm, 'algorithm'); checkMessageFormat(format);
+  checkBinary(data); checkString(algorithm, 'algorithm'); checkOutputMessageFormat(format);
   encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionKeyIDs = toArray(encryptionKeyIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.encryptSessionKey, pass `encryptionKeys` instead');
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
@@ -612,7 +612,7 @@ function checkCleartextOrMessage(message) {
     throw new Error('Parameter [message] needs to be of type Message or CleartextMessage');
   }
 }
-function checkMessageFormat(format) {
+function checkOutputMessageFormat(format) {
   if (format !== 'armor' && format !== 'binary') {
     throw new Error(`Unsupported format ${format}`);
   }

--- a/src/signature.js
+++ b/src/signature.js
@@ -71,7 +71,7 @@ export class Signature {
  * @async
  * @static
  */
-export async function readSignature({ armoredSignature, binarySignature, config }) {
+export async function readSignature({ armoredSignature, binarySignature, config, ...rest }) {
   config = { ...defaultConfig, ...config };
   let input = armoredSignature || binarySignature;
   if (!input) {
@@ -83,6 +83,8 @@ export async function readSignature({ armoredSignature, binarySignature, config 
   if (binarySignature && !util.isUint8Array(binarySignature)) {
     throw new Error('readSignature: options.binarySignature must be a Uint8Array');
   }
+  const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
   if (armoredSignature) {
     const { type, data } = await unarmor(input, config);
     if (type !== enums.armor.signature) {

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -182,11 +182,11 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
       const { privateKey } = await openpgp.generateKey({ userIDs, format: 'object' });
 
-      const encKey = await openpgp.encryptKey({ privateKey, userIDs, passphrase });
+      const encKey = await openpgp.encryptKey({ privateKey, passphrase });
       expect(encKey.keyPacket.s2k.c).to.equal(openpgp.config.s2kIterationCountByte);
 
       const config = { s2kIterationCountByte: 123 };
-      const encKey2 = await openpgp.encryptKey({ privateKey, userIDs, passphrase, config });
+      const encKey2 = await openpgp.encryptKey({ privateKey, passphrase, config });
       expect(encKey2.keyPacket.s2k.c).to.equal(config.s2kIterationCountByte);
     } finally {
       openpgp.config.s2kIterationCountByte = s2kIterationCountByteVal;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1906,7 +1906,6 @@ aOU=
       expect(parsedBinary.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)).to.have.length(1);
 
       const objectMessage = await openpgp.encryptSessionKey({ ...sessionKey, passwords, format: 'object' });
-      console.log(objectMessage);
       expect(objectMessage.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)).to.have.length(1);
       const [decryptedSessionKey] = await openpgp.decryptSessionKeys({ message: objectMessage, passwords });
       expect(decryptedSessionKey).to.deep.equal(sessionKey);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1783,7 +1783,7 @@ aOU=
             data: sk,
             algorithm: 'aes128',
             encryptionKeys: publicKey,
-            armor: false
+            format: 'binary'
           }).then(async function(encrypted) {
             const message = await openpgp.readMessage({ binaryMessage: encrypted });
             return openpgp.decryptSessionKeys({
@@ -1800,7 +1800,7 @@ aOU=
             data: sk,
             algorithm: 'aes128',
             passwords: password1,
-            armor: false
+            format: 'binary'
           }).then(async function(encrypted) {
             const message = await openpgp.readMessage({ binaryMessage: encrypted });
             return openpgp.decryptSessionKeys({
@@ -1817,7 +1817,7 @@ aOU=
             data: sk,
             algorithm: 'aes128',
             encryptionKeys: publicKey,
-            armor: false
+            format: 'binary'
           }).then(async function(encrypted) {
             const message = await openpgp.readMessage({ binaryMessage: encrypted });
             const invalidPrivateKey = await openpgp.readKey({ armoredKey: priv_key });
@@ -2552,7 +2552,7 @@ aOU=
 
         it('should fail to decrypt unarmored message with garbage data appended', async function() {
           const key = privateKey;
-          const message = await openpgp.encrypt({ message: await openpgp.createMessage({ text: 'test' }), encryptionKeys: key, signingKeys: key, armor: false });
+          const message = await openpgp.encrypt({ message: await openpgp.createMessage({ text: 'test' }), encryptionKeys: key, signingKeys: key, format: 'binary' });
           const encrypted = util.concat([message, new Uint8Array([11])]);
           await expect((async () => {
             await openpgp.decrypt({ message: await openpgp.readMessage({ binaryMessage: encrypted }), decryptionKeys: key, verificationKeys: key });
@@ -2705,7 +2705,7 @@ aOU=
           const encOpt = {
             message: await openpgp.createMessage({ text: plaintext }),
             passwords: password1,
-            armor: false
+            format: 'binary'
           };
           const decOpt = {
             passwords: password1
@@ -2723,7 +2723,7 @@ aOU=
           const encOpt = {
             message: await openpgp.createMessage({ binary: new Uint8Array([0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01]) }),
             passwords: password1,
-            armor: false
+            format: 'binary'
           };
           const decOpt = {
             passwords: password1,
@@ -2950,7 +2950,7 @@ aOU=
         const signOpt = {
           message,
           signingKeys: privateKey,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           verificationKeys: publicKey
@@ -2974,7 +2974,7 @@ aOU=
           message,
           signingKeys: privateKey,
           detached: true,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           message,
@@ -3002,7 +3002,7 @@ aOU=
           signingKeys: privateKey_1337,
           detached: true,
           date: past,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           message,
@@ -3040,7 +3040,7 @@ aOU=
           signingKeys: privateKey_2038_2045,
           detached: true,
           date: future,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           verificationKeys: publicKey_2038_2045,
@@ -3066,7 +3066,7 @@ aOU=
         const signOpt = {
           message: await openpgp.createMessage({ binary: data }),
           signingKeys: privateKey,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           verificationKeys: publicKey,
@@ -3105,7 +3105,7 @@ aOU=
         const signOpt = {
           message: await openpgp.createMessage({ binary: dataStream }),
           signingKeys: privateKey,
-          armor: false
+          format: 'binary'
         };
         const verifyOpt = {
           verificationKeys: publicKey,
@@ -3140,7 +3140,7 @@ aOU=
           message: await openpgp.createMessage({ text: plaintext, date: future }),
           encryptionKeys: publicKey_2038_2045,
           date: future,
-          armor: false
+          format: 'binary'
         };
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
@@ -3161,7 +3161,7 @@ aOU=
           message: await openpgp.createMessage({ binary: data, date: past }),
           encryptionKeys: publicKey_2000_2008,
           date: past,
-          armor: false
+          format: 'binary'
         };
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
@@ -3182,7 +3182,7 @@ aOU=
           encryptionKeys: publicKey_2000_2008,
           signingKeys: privateKey_2000_2008,
           date: past,
-          armor: false
+          format: 'binary'
         };
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
@@ -3210,7 +3210,7 @@ aOU=
           encryptionKeys: publicKey_2038_2045,
           signingKeys: privateKey_2038_2045,
           date: future,
-          armor: false
+          format: 'binary'
         };
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {
@@ -3239,7 +3239,7 @@ aOU=
           encryptionKeys: publicKey_2038_2045,
           signingKeys: privateKey_2038_2045,
           date: future,
-          armor: false
+          format: 'binary'
         };
 
         return openpgp.encrypt(encryptOpt).then(async function (encrypted) {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1462,7 +1462,7 @@ hkJiXopCSWKSlQInL1devkJJUWJmTmZeugJYlpdLAagQJM0JpsCqIQZwKgAA
     });
 
     const config = { minRSABits: 1024 };
-    return openpgp.sign({ signingKeys: privKey, message: await openpgp.createMessage({ binary: plaintext }), armor: false, config }).then(async signed => {
+    return openpgp.sign({ signingKeys: privKey, message: await openpgp.createMessage({ binary: plaintext }), format: 'binary', config }).then(async signed => {
 
       const message = await openpgp.readMessage({ binaryMessage: signed });
       return openpgp.verify({ verificationKeys: pubKey, message, format: 'binary', config });

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -257,7 +257,7 @@ function tests() {
     const encrypted = await openpgp.encrypt({
       message: await openpgp.createMessage({ binary: data }),
       passwords: ['test'],
-      armor: false
+      format: 'binary'
     });
     expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -285,7 +285,7 @@ function tests() {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
         passwords: ['test'],
-        armor: false
+        format: 'binary'
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -316,7 +316,7 @@ function tests() {
         message: await openpgp.createMessage({ binary: data }),
         encryptionKeys: pubKey,
         signingKeys: privKey,
-        armor: false,
+        format: 'binary',
         config: { minRSABits: 1024 }
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
@@ -352,7 +352,7 @@ function tests() {
         message: await openpgp.createMessage({ binary: data }),
         encryptionKeys: pub,
         signingKeys: priv,
-        armor: false
+        format: 'binary'
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -387,7 +387,7 @@ function tests() {
         message: await openpgp.createMessage({ binary: data }),
         encryptionKeys: pub,
         signingKeys: priv,
-        armor: false
+        format: 'binary'
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -814,7 +814,7 @@ function tests() {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
         passwords: ['test'],
-        armor: false
+        format: 'binary'
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -1035,7 +1035,7 @@ module.exports = () => describe('Streaming', function() {
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
         passwords: ['test'],
-        armor: false
+        format: 'binary'
       });
       expect(stream.isStream(encrypted)).to.equal('node');
 

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -121,8 +121,8 @@ import {
   const textSignedArmor: string = await sign({ signingKeys: privateKeys, message: textMessage });
   expect(textSignedArmor).to.include('-----BEGIN PGP MESSAGE-----');
   // Sign text message (unarmored)
-  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: textMessage, format: 'binary' });
-  expect(textSignedBinary).to.be.instanceOf(Uint8Array);
+  const binarySignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'binary' });
+  expect(binarySignedBinary).to.be.instanceOf(Uint8Array);
   // Sign text and binary messages (inspect packages)
   const binarySignedObject: Message<Uint8Array> = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'object' });
   expect(binarySignedObject).to.be.instanceOf(Message);
@@ -136,7 +136,7 @@ import {
   expect(verifiedTextData).to.equal(text);
 
   // Verify signed binary message (unarmored)
-  const message = await readMessage({ binaryMessage: textSignedBinary });
+  const message = await readMessage({ binaryMessage: binarySignedBinary });
   const verifiedBinary = await verify({ verificationKeys: publicKeys, message, format: 'binary' });
   const verifiedBinaryData: Uint8Array = verifiedBinary.data;
   expect(verifiedBinaryData).to.deep.equal(binary);

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -12,7 +12,7 @@ import {
   readMessage, createMessage, Message, createCleartextMessage,
   encrypt, decrypt, sign, verify, config, enums,
   generateSessionKey, encryptSessionKey, decryptSessionKeys,
-  LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket
+  LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket, CleartextMessage
 } from '../..';
 
 (async () => {
@@ -91,14 +91,17 @@ import {
   expect(decryptedBinaryData).to.deep.equal(binary);
 
   // Encrypt message (inspect packets)
-  const encryptedMessage = await readMessage({ binaryMessage: encryptedBinary });
-  expect(encryptedMessage).to.be.instanceOf(Message);
+  const encryptedBinaryObject: Message<Uint8Array> = await encrypt({ encryptionKeys: publicKeys, message: binaryMessage, format: 'object' });
+  expect(encryptedBinaryObject).to.be.instanceOf(Message);
+  const encryptedTextObject: Message<string> = await encrypt({ encryptionKeys: publicKeys, message: textMessage, format: 'object' });
+  expect(encryptedTextObject).to.be.instanceOf(Message);
 
   // Session key functions
+  // Get session keys from encrypted message
   const sessionKeys = await decryptSessionKeys({ message: await readMessage({ binaryMessage: encryptedBinary }), decryptionKeys: privateKeys });
   expect(sessionKeys).to.have.length(1);
-  // eslint-disable-next-line no-unused-vars
   const encryptedSessionKeys: string = await encryptSessionKey({ ...sessionKeys[0], passwords: 'pass', algorithm: 'aes128', aeadAlgorithm: 'eax' });
+  expect(encryptedSessionKeys).to.include('-----BEGIN PGP MESSAGE-----');
   const newSessionKey = await generateSessionKey({ encryptionKeys: privateKey.toPublic() });
   expect(newSessionKey.data).to.exist;
   expect(newSessionKey.algorithm).to.exist;
@@ -107,6 +110,8 @@ import {
   const cleartextMessage = await createCleartextMessage({ text: 'hello' });
   const clearSignedArmor = await sign({ signingKeys: privateKeys, message: cleartextMessage });
   expect(clearSignedArmor).to.include('-----BEGIN PGP SIGNED MESSAGE-----');
+  const clearSignedObject: CleartextMessage = await sign({ signingKeys: privateKeys, message: cleartextMessage, format: 'object' });
+  expect(clearSignedObject).to.be.instanceOf(CleartextMessage);
   // @ts-expect-error PublicKey not assignable to PrivateKey
   try { await sign({ signingKeys: publicKeys, message: cleartextMessage }); } catch (e) {}
   // @ts-expect-error Key not assignable to PrivateKey
@@ -115,10 +120,14 @@ import {
   // Sign text message (armored)
   const textSignedArmor: string = await sign({ signingKeys: privateKeys, message: textMessage });
   expect(textSignedArmor).to.include('-----BEGIN PGP MESSAGE-----');
-
   // Sign text message (unarmored)
-  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'binary' });
+  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: textMessage, format: 'binary' });
   expect(textSignedBinary).to.be.instanceOf(Uint8Array);
+  // Sign text and binary messages (inspect packages)
+  const binarySignedObject: Message<Uint8Array> = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'object' });
+  expect(binarySignedObject).to.be.instanceOf(Message);
+  const textSignedObject: Message<string> = await sign({ signingKeys: privateKeys, message: textMessage, format: 'object' });
+  expect(textSignedObject).to.be.instanceOf(Message);
 
   // Verify signed text message (armored)
   const signedMessage = await readMessage({ armoredMessage: textSignedArmor });

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -121,8 +121,8 @@ import {
   const textSignedArmor: string = await sign({ signingKeys: privateKeys, message: textMessage });
   expect(textSignedArmor).to.include('-----BEGIN PGP MESSAGE-----');
   // Sign text message (unarmored)
-  const binarySignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'binary' });
-  expect(binarySignedBinary).to.be.instanceOf(Uint8Array);
+  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'binary' });
+  expect(textSignedBinary).to.be.instanceOf(Uint8Array);
   // Sign text and binary messages (inspect packages)
   const binarySignedObject: Message<Uint8Array> = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'object' });
   expect(binarySignedObject).to.be.instanceOf(Message);
@@ -136,7 +136,7 @@ import {
   expect(verifiedTextData).to.equal(text);
 
   // Verify signed binary message (unarmored)
-  const message = await readMessage({ binaryMessage: binarySignedBinary });
+  const message = await readMessage({ binaryMessage: textSignedBinary });
   const verifiedBinary = await verify({ verificationKeys: publicKeys, message, format: 'binary' });
   const verifiedBinaryData: Uint8Array = verifiedBinary.data;
   expect(verifiedBinaryData).to.deep.equal(binary);

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -18,7 +18,7 @@ import {
 (async () => {
 
   // Generate keys
-  const keyOptions = { userIDs: [{ email: "user@corp.co" }], config: { v5Keys: true } };
+  const keyOptions = { userIDs: [{ email: 'user@corp.co' }], config: { v5Keys: true } };
   const { privateKey: privateKeyArmored, publicKey: publicKeyArmored } = await generateKey(keyOptions);
   const { privateKey: privateKeyBinary } = await generateKey({ ...keyOptions, format: 'binary' });
   const { privateKey, publicKey, revocationCertificate } = await generateKey({ ...keyOptions, format: 'object' });
@@ -75,7 +75,7 @@ import {
   // Encrypt binary message (unarmored)
   const binary = new Uint8Array([1, 2]);
   const binaryMessage = await createMessage({ binary });
-  const encryptedBinary: Uint8Array = await encrypt({ encryptionKeys: publicKeys, message: binaryMessage, armor: false });
+  const encryptedBinary: Uint8Array = await encrypt({ encryptionKeys: publicKeys, message: binaryMessage, format: 'binary' });
   expect(encryptedBinary).to.be.instanceOf(Uint8Array);
 
   // Decrypt text message (armored)
@@ -117,7 +117,7 @@ import {
   expect(textSignedArmor).to.include('-----BEGIN PGP MESSAGE-----');
 
   // Sign text message (unarmored)
-  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, armor: false });
+  const textSignedBinary: Uint8Array = await sign({ signingKeys: privateKeys, message: binaryMessage, format: 'binary' });
   expect(textSignedBinary).to.be.instanceOf(Uint8Array);
 
   // Verify signed text message (armored)
@@ -168,7 +168,7 @@ import {
 
   // // Detached - sign binary message (unarmored)
   // const message = await createMessage({ text });
-  // const signed = await sign({ privateKeys, message, detached: true, armor: false });
+  // const signed = await sign({ privateKeys, message, detached: true, format: 'binary' });
   // console.log(signed); // Uint8Array
 
   // // Streaming - encrypt text message on Node.js (armored)
@@ -182,7 +182,7 @@ import {
   // // Streaming - encrypt binary message on Node.js (unarmored)
   // const data = fs.createReadStream(filename);
   // const message = await createMessage({ binary: data });
-  // const encrypted = await encrypt({ publicKeys, message, armor: false });
+  // const encrypted = await encrypt({ publicKeys, message, format: 'binary' });
   // encrypted.pipe(targetStream);
 
   console.log('TypeScript definitions are correct');


### PR DESCRIPTION
Breaking changes to top-level functions:
- The `format` option has been added to `openpgp.encrypt`, `sign` and `encryptSessionKey` to select the format of the output message. `format` replaces the existing `armor` option, and accepts three values:
  - if `format: 'armor'` (default), an armored signed/encrypted message is returned (same as `armor: true`).
  - if `format: 'binary'`,  a binary signed/encrypted message is returned (same as `armor: false`).
  - if `format: 'object'`, a Message or Signature object is returned (this was not supported before).

  This change is to uniform the output format selection across all top-level functions (following up to #1345).
- All top-level functions now throw if unrecognised options are passed, to make library users aware that those options are not being applied.