### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ const openpgp = require('openpgp'); // use as CommonJS, AMD, ES6 module or via w
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 
@@ -287,7 +287,7 @@ If you expect an encrypted message to be signed with one of the public keys you 
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 
@@ -388,7 +388,7 @@ can `.pipe()` to a `Writable` stream, for example.
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 
@@ -501,7 +501,7 @@ Using the private key:
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 
@@ -543,7 +543,7 @@ Using the private key:
     const publicKey = await openpgp.readKey({ armoredKey: publicKeyArmored });
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 
@@ -592,7 +592,7 @@ Using the private key:
     const passphrase = `yourPassphrase`; // what the private key is encrypted with
 
     const privateKey = await openpgp.decryptKey({
-        privateKey: await openpgp.readKey({ armoredKey: privateKeyArmored }),
+        privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
         passphrase
     });
 


### PR DESCRIPTION
Changed `openpgp.readKey()` to `openpgp.readPrivateKey()` where applicable. I noticed this documentation error when I was writing my own app in typescript and vscode kept yelling at me that it wanted a PrivateKey object instead of a PublicKey object, and I was confused because I wrote everything correct according to this README. I looked into the type definitions file and found that `readKey()` only returns a PublicKey object, and `readPrivateKey()` only returns a PrivateKey object, which is what was needed for `decryptKey()`.