### PR TITLE
CI: Ignore unhandled rejections in tests in Safari 14.1

### DIFF
--- a/test/unittests.js
+++ b/test/unittests.js
@@ -31,9 +31,13 @@ describe('Unit Tests', function () {
   openpgp.config.s2kIterationCountByte = 0;
 
   if (typeof window !== 'undefined') {
-    window.addEventListener('unhandledrejection', function (event) {
-      throw event.reason;
-    });
+    // Safari 14.1.* seem to have issues handling rejections when their native TransformStream implementation is involved,
+    // so for now we ignore unhandled rejections for those browser versions.
+    if (!window.navigator.userAgent.match(/Version\/14\.1(\.\d)* Safari/)) {
+      window.addEventListener('unhandledrejection', function (event) {
+        throw event.reason;
+      });
+    }
 
     window.location.search.substr(1).split('&').forEach(param => {
       const [key, value] = param.split('=');


### PR DESCRIPTION
Something seems off with Safari's promise rejection handling, as the tests throw errors for no apparent reason. The problem is likely related to the native TransformStream implementation added in Safari 14.1 (in fact, using a polyfilled TransformStream solves all issues).

For now, the CI will just ignore unhandled rejections in Safari 14.1 (following up to #1333).