### PR TITLE
chore: extend BaseStream<> from AsyncIterable<>

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -531,7 +531,7 @@ export class PacketList<T extends AnyPacket> extends Array<T> {
 /* ############## v5 STREAM #################### */
 
 type Data = Uint8Array | string;
-interface BaseStream<T extends Data> { }
+interface BaseStream<T extends Data> extends AsyncIterable<T> { }
 interface WebStream<T extends Data> extends BaseStream<T> { // copied+simplified version of ReadableStream from lib.dom.d.ts
   readonly locked: boolean; getReader: Function; pipeThrough: Function; pipeTo: Function; tee: Function;
   cancel(reason?: any): Promise<void>;


### PR DESCRIPTION
AsyncIterable<> is the intersection of the support in NodeJS and web-streams-polyfill. Fixes #1370.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8a2b906bd9d69170099083d29b275fb5b832d3bc/types/node/globals.d.ts#L191

https://github.com/MattiasBuelens/web-streams-polyfill/blob/36c08de41aa3a5699afab717b0e64af13dada56f/src/lib/readable-stream.ts#L314

`lib.es2018.asynciterable.d.ts#AsyncIterable<>`:
```typescript
interface AsyncIterable<T> {
    [Symbol.asyncIterator](): AsyncIterator<T>;
}
```