### PR TITLE
Rename `format: 'armor'` option to `'armored'` in top-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ and a subkey for encryption using Curve25519.
         curve: 'curve25519', // ECC curve name, defaults to curve25519
         userIDs: [{ name: 'Jon Smith', email: 'jon@example.com' }], // you can pass multiple user IDs
         passphrase: 'super long and hard to guess secret', // protects the private key
-        format: 'armor' // output key format, defaults to 'armor' (other options: 'binary' or 'object')
+        format: 'armored' // output key format, defaults to 'armored' (other options: 'binary' or 'object')
     });
 
     console.log(privateKey);     // '-----BEGIN PGP PRIVATE KEY BLOCK ... '
@@ -476,7 +476,7 @@ Using a revocation certificate:
     const { publicKey: revokedKeyArmored } = await openpgp.revokeKey({
         key: await openpgp.readKey({ armoredKey: publicKeyArmored }),
         revocationCertificate,
-        format: 'armor' // output armored keys
+        format: 'armored' // output armored keys
     });
     console.log(revokedKeyArmored); // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 })();
@@ -487,7 +487,7 @@ Using the private key:
 (async () => {
     const { publicKey: revokedKeyArmored } = await openpgp.revokeKey({
         key: await openpgp.readKey({ armoredKey: privateKeyArmored }),
-        format: 'armor' // output armored keys
+        format: 'armored' // output armored keys
     });
     console.log(revokedKeyArmored); // '-----BEGIN PGP PUBLIC KEY BLOCK ... '
 })();

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -18,21 +18,21 @@ export function readPrivateKey(options: { armoredKey: string, config?: PartialCo
 export function readPrivateKey(options: { binaryKey: Uint8Array, config?: PartialConfig }): Promise<PrivateKey>;
 export function readPrivateKeys(options: { armoredKeys: string, config?: PartialConfig }): Promise<PrivateKey[]>;
 export function readPrivateKeys(options: { binaryKeys: Uint8Array, config?: PartialConfig }): Promise<PrivateKey[]>;
-export function generateKey(options: KeyOptions & { format?: 'armor' }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
+export function generateKey(options: KeyOptions & { format?: 'armored' }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
 export function generateKey(options: KeyOptions & { format: 'binary' }): Promise<SerializedKeyPair<Uint8Array> & { revocationCertificate: string }>;
 export function generateKey(options: KeyOptions & { format: 'object' }): Promise<KeyPair & { revocationCertificate: string }>;
 export function decryptKey(options: { privateKey: PrivateKey; passphrase?: MaybeArray<string>; config?: PartialConfig }): Promise<PrivateKey>;
 export function encryptKey(options: { privateKey: PrivateKey; passphrase?: MaybeArray<string>; config?: PartialConfig }): Promise<PrivateKey>;
-export function reformatKey(options: { privateKey: PrivateKey; userIDs?: MaybeArray<UserID>; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
+export function reformatKey(options: { privateKey: PrivateKey; userIDs?: MaybeArray<UserID>; passphrase?: string; keyExpirationTime?: number; date?: Date, format?: 'armored', config?: PartialConfig }): Promise<SerializedKeyPair<string> & { revocationCertificate: string }>;
 export function reformatKey(options: { privateKey: PrivateKey; userIDs?: MaybeArray<UserID>; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array> & { revocationCertificate: string }>;
 export function reformatKey(options: { privateKey: PrivateKey; userIDs?: MaybeArray<UserID>; passphrase?: string; keyExpirationTime?: number; date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair & { revocationCertificate: string }>;
-export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
+export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format?: 'armored', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
 export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
 export function revokeKey(options: { key: PrivateKey, reasonForRevocation?: ReasonForRevocation, date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
-export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
+export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format?: 'armored', config?: PartialConfig }): Promise<SerializedKeyPair<string>>;
 export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<SerializedKeyPair<Uint8Array>>;
 export function revokeKey(options: { key: PrivateKey, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<KeyPair>;
-export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format?: 'armor', config?: PartialConfig }): Promise<{ publicKey: string, privateKey: null }>;
+export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format?: 'armored', config?: PartialConfig }): Promise<{ publicKey: string, privateKey: null }>;
 export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format: 'binary', config?: PartialConfig }): Promise<{ publicKey: Uint8Array, privateKey: null }>;
 export function revokeKey(options: { key: PublicKey, revocationCertificate: string, date?: Date, format: 'object', config?: PartialConfig }): Promise<{ publicKey: PublicKey, privateKey: null }>;
 
@@ -172,7 +172,7 @@ export class CleartextMessage {
 /* ############## v5 MSG #################### */
 export function generateSessionKey(options: { encryptionKeys: MaybeArray<PublicKey>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig }): Promise<SessionKey>;
 export function encryptSessionKey(options: SessionKey & { 
-  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format?: 'armor', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
+  encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format?: 'armored', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
 }) : Promise<string>;
 export function encryptSessionKey(options: SessionKey & { 
   encryptionKeys?: MaybeArray<PublicKey>, passwords?: MaybeArray<string>, format: 'binary', wildcard?: boolean, encryptionKeyIDs?: MaybeArray<KeyID>, date?: Date, encryptionUserIDs?: MaybeArray<UserID>, config?: PartialConfig
@@ -188,7 +188,7 @@ export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binary
 export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
 
-export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format?: 'armor' }): Promise<
+export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format?: 'armored' }): Promise<
   T extends WebStream<infer X> ? WebStream<string> :
   T extends NodeStream<infer X> ? NodeStream<string> :
   string
@@ -200,7 +200,7 @@ export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & {
 >;
 export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format: 'object' }): Promise<Message<T>>;
 
-export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format?: 'armor' }): Promise<
+export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format?: 'armored' }): Promise<
   T extends WebStream<infer X> ? WebStream<string> :
   T extends NodeStream<infer X> ? NodeStream<string> :
   string
@@ -211,7 +211,7 @@ export function sign<T extends MaybeStream<Data>>(options: SignOptions & { messa
   Uint8Array
 >;
 export function sign<T extends MaybeStream<Data>>(options: SignOptions & { message: Message<T>, format: 'object' }): Promise<Message<T>>;
-export function sign(options: SignOptions & { message: CleartextMessage, format?: 'armor' }): Promise<string>;
+export function sign(options: SignOptions & { message: CleartextMessage, format?: 'armored' }): Promise<string>;
 export function sign(options: SignOptions & { message: CleartextMessage, format: 'object' }): Promise<CleartextMessage>;
 
 export function decrypt<T extends MaybeStream<Data>>(options: DecryptOptions & { message: Message<T>, format: 'binary' }): Promise<DecryptMessageResult & {
@@ -583,7 +583,7 @@ interface EncryptOptions {
   /** (optional) session key */
   sessionKey?: SessionKey;
   /** if the return values should be ascii armored or the message/signature objects */
-  format?: 'armor' | 'binary' | 'object';
+  format?: 'armored' | 'binary' | 'object';
   /** (optional) if the signature should be detached (if true, signature will be added to returned object) */
   signature?: Signature;
   /** (optional) encrypt as of a certain date */
@@ -626,7 +626,7 @@ interface DecryptOptions {
 interface SignOptions {
   message: CleartextMessage | Message<MaybeStream<Data>>;
   signingKeys?: MaybeArray<PrivateKey>;
-  format?: 'armor' | 'binary' | 'object';
+  format?: 'armored' | 'binary' | 'object';
   dataType?: DataPacketType;
   detached?: boolean;
   signingKeyIDs?: MaybeArray<KeyID>;
@@ -672,7 +672,7 @@ interface KeyOptions {
   keyExpirationTime?: number;
   date?: Date;
   subkeys?: SubkeyOptions[];
-  format?: 'armor' | 'object' | 'binary';
+  format?: 'armored' | 'object' | 'binary';
   config?: PartialConfig;
 }
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -45,14 +45,14 @@ import util from './util';
  * @param {Number} [options.keyExpirationTime=0 (never expires)] - Number of seconds from the key creation time after which the key expires
  * @param {Array<Object>} [options.subkeys=a single encryption subkey] - Options for each subkey e.g. `[{sign: true, passphrase: '123'}]`
  *                                             default to main key options, except for `sign` parameter that defaults to false, and indicates whether the subkey should sign rather than encrypt
- * @param {'armor'|'binary'|'object'} [options.format='armor'] - format of the output keys
+ * @param {'armored'|'binary'|'object'} [options.format='armored'] - format of the output keys
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object>} The generated key object in the form:
  *                                     { privateKey:PrivateKey|Uint8Array|String, publicKey:PublicKey|Uint8Array|String, revocationCertificate:String }
  * @async
  * @static
  */
-export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc', rsaBits = 4096, curve = 'curve25519', keyExpirationTime = 0, date = new Date(), subkeys = [{}], format = 'armor', config, ...rest }) {
+export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc', rsaBits = 4096, curve = 'curve25519', keyExpirationTime = 0, date = new Date(), subkeys = [{}], format = 'armored', config, ...rest }) {
   config = { ...defaultConfig, ...config };
   userIDs = toArray(userIDs);
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
@@ -86,14 +86,14 @@ export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc',
  * @param {String} [options.passphrase=(not protected)] - The passphrase used to encrypt the reformatted private key. If omitted, the key won't be encrypted.
  * @param {Number} [options.keyExpirationTime=0 (never expires)] - Number of seconds from the key creation time after which the key expires
  * @param {Date}   [options.date] - Override the creation date of the key signatures
- * @param {'armor'|'binary'|'object'} [options.format='armor'] - format of the output keys
+ * @param {'armored'|'binary'|'object'} [options.format='armored'] - format of the output keys
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object>} The generated key object in the form:
  *                                     { privateKey:PrivateKey|Uint8Array|String, publicKey:PublicKey|Uint8Array|String, revocationCertificate:String }
  * @async
  * @static
  */
-export async function reformatKey({ privateKey, userIDs = [], passphrase = '', keyExpirationTime = 0, date, format = 'armor', config, ...rest }) {
+export async function reformatKey({ privateKey, userIDs = [], passphrase = '', keyExpirationTime = 0, date, format = 'armored', config, ...rest }) {
   config = { ...defaultConfig, ...config };
   userIDs = toArray(userIDs);
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
@@ -126,7 +126,7 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase = '', k
  * @param {module:enums.reasonForRevocation} [options.reasonForRevocation.flag=[noReason]{@link module:enums.reasonForRevocation}] - Flag indicating the reason for revocation
  * @param {String} [options.reasonForRevocation.string=""] - String explaining the reason for revocation
  * @param {Date} [options.date] - Use the given date instead of the current time to verify validity of revocation certificate (if provided), or as creation time of the revocation signature
- * @param {'armor'|'binary'|'object'} [options.format='armor'] - format of the output key(s)
+ * @param {'armored'|'binary'|'object'} [options.format='armored'] - format of the output key(s)
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object>} The revoked key in the form:
  *                              { privateKey:PrivateKey|Uint8Array|String, publicKey:PublicKey|Uint8Array|String } if private key is passed, or
@@ -134,7 +134,7 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase = '', k
  * @async
  * @static
  */
-export async function revokeKey({ key, revocationCertificate, reasonForRevocation, date = new Date(), format = 'armor', config, ...rest }) {
+export async function revokeKey({ key, revocationCertificate, reasonForRevocation, date = new Date(), format = 'armored', config, ...rest }) {
   config = { ...defaultConfig, ...config };
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
@@ -244,7 +244,7 @@ export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
  * @param {PrivateKey|PrivateKey[]} [options.signingKeys] - Private keys for signing. If omitted message will not be signed
  * @param {String|String[]} [options.passwords] - Array of passwords or a single password to encrypt the message
  * @param {Object} [options.sessionKey] - Session key in the form: `{ data:Uint8Array, algorithm:String }`
- * @param {'armor'|'binary'|'object'} [options.format='armor'] - Format of the returned message
+ * @param {'armored'|'binary'|'object'} [options.format='armored'] - Format of the returned message
  * @param {Signature} [options.signature] - A detached signature to add to the encrypted message
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
  * @param {KeyID|KeyID[]} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each `signingKeyIDs[i]` corresponds to `signingKeys[i]`
@@ -257,7 +257,7 @@ export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
  * @async
  * @static
  */
-export async function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, format = 'armor', signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
+export async function encrypt({ message, encryptionKeys, signingKeys, passwords, sessionKey, format = 'armored', signature = null, wildcard = false, signingKeyIDs = [], encryptionKeyIDs = [], date = new Date(), signingUserIDs = [], encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkMessage(message); checkOutputMessageFormat(format);
   encryptionKeys = toArray(encryptionKeys); signingKeys = toArray(signingKeys); passwords = toArray(passwords);
@@ -285,7 +285,7 @@ export async function encrypt({ message, encryptionKeys, signingKeys, passwords,
     message = await message.encrypt(encryptionKeys, passwords, sessionKey, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);
     if (format === 'object') return message;
     // serialize data
-    const armor = format === 'armor';
+    const armor = format === 'armored';
     const data = armor ? message.armor(config) : message.write();
     return convertStream(data, streaming, armor ? 'utf8' : 'binary');
   } catch (err) {
@@ -376,7 +376,7 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  * @param {Object} options
  * @param {CleartextMessage|Message} options.message - (cleartext) message to be signed
  * @param {PrivateKey|PrivateKey[]} options.signingKeys - Array of keys or single key with decrypted secret key data to sign cleartext
- * @param {'armor'|'binary'|'object'} [options.format='armor'] - Format of the returned message
+ * @param {'armored'|'binary'|'object'} [options.format='armored'] - Format of the returned message
  * @param {Boolean} [options.detached=false] - If the return value should contain a detached signature
  * @param {KeyID|KeyID[]} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
  * @param {Date} [options.date=current date] - Override the creation date of the signature
@@ -386,7 +386,7 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  * @async
  * @static
  */
-export async function sign({ message, signingKeys, format = 'armor', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
+export async function sign({ message, signingKeys, format = 'armored', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkCleartextOrMessage(message); checkOutputMessageFormat(format);
   signingKeys = toArray(signingKeys); signingKeyIDs = toArray(signingKeyIDs); signingUserIDs = toArray(signingUserIDs);
@@ -411,7 +411,7 @@ export async function sign({ message, signingKeys, format = 'armor', detached = 
     }
     if (format === 'object') return signature;
 
-    const armor = format === 'armor';
+    const armor = format === 'armored';
     signature = armor ? signature.armor(config) : signature.write();
     if (detached) {
       signature = stream.transformPair(message.packets.write(), async (readable, writable) => {
@@ -530,7 +530,7 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
  * @param {String} [options.aeadAlgorithm] - AEAD algorithm, e.g. 'eax' or 'ocb'
  * @param {PublicKey|PublicKey[]} [options.encryptionKeys] - Array of public keys or single key, used to encrypt the key
  * @param {String|String[]} [options.passwords] - Passwords for the message
- * @param {'armor'|'binary'} [options.format='armor'] - Format of the returned value
+ * @param {'armored'|'binary'} [options.format='armored'] - Format of the returned value
  * @param {Boolean} [options.wildcard=false] - Use a key ID of 0 instead of the public key IDs
  * @param {KeyID|KeyID[]} [options.encryptionKeyIDs=latest-created valid encryption (sub)keys] - Array of key IDs to use for encryption. Each encryptionKeyIDs[i] corresponds to encryptionKeys[i]
  * @param {Date} [options.date=current date] - Override the date
@@ -540,7 +540,7 @@ export async function generateSessionKey({ encryptionKeys, date = new Date(), en
  * @async
  * @static
  */
-export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, format = 'armor', wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
+export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryptionKeys, passwords, format = 'armored', wildcard = false, encryptionKeyIDs = [], date = new Date(), encryptionUserIDs = [], config, ...rest }) {
   config = { ...defaultConfig, ...config };
   checkBinary(data); checkString(algorithm, 'algorithm'); checkOutputMessageFormat(format);
   encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionKeyIDs = toArray(encryptionKeyIDs); encryptionUserIDs = toArray(encryptionUserIDs);
@@ -617,7 +617,7 @@ function checkCleartextOrMessage(message) {
   }
 }
 function checkOutputMessageFormat(format) {
-  if (format !== 'armor' && format !== 'binary' && format !== 'object') {
+  if (format !== 'armored' && format !== 'binary' && format !== 'object') {
     throw new Error(`Unsupported format ${format}`);
   }
 }
@@ -687,7 +687,7 @@ function linkStreams(result, message) {
 /**
  * Convert the object to the given format
  * @param {Key|Message} object
- * @param {'armor'|'binary'|'object'} format
+ * @param {'armored'|'binary'|'object'} format
  * @param {Object} config - Full configuration
  * @returns {String|Uint8Array|Object}
  */
@@ -695,7 +695,7 @@ function formatObject(object, format, config) {
   switch (format) {
     case 'object':
       return object;
-    case 'armor':
+    case 'armored':
       return object.armor(config);
     case 'binary':
       return object.write();

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1008,7 +1008,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
       const opt = {
         userIDs: { name: 'Test User', email: 'text@example.com' }
       };
-      const armored = await openpgp.generateKey({ ...opt, format: 'armor' });
+      const armored = await openpgp.generateKey({ ...opt, format: 'armored' });
       expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
       expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPrivate()).to.be.false;
 
@@ -1034,7 +1034,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         privateKey: original,
         userIDs: { name: 'Test User', email: 'text@example.com' }
       };
-      const armored = await openpgp.reformatKey({ ...opt, format: 'armor' });
+      const armored = await openpgp.reformatKey({ ...opt, format: 'armored' });
       expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
       expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPrivate()).to.be.false;
 
@@ -1056,7 +1056,7 @@ module.exports = () => describe('OpenPGP.js public api tests', function() {
         passphrase: passphrase
       });
 
-      const armored = await openpgp.revokeKey({ key, format: 'armor' });
+      const armored = await openpgp.revokeKey({ key, format: 'armored' });
       expect((await openpgp.readKey({ armoredKey: armored.privateKey })).isPrivate()).to.be.true;
       expect((await openpgp.readKey({ armoredKey: armored.publicKey })).isPrivate()).to.be.false;
 
@@ -1649,7 +1649,7 @@ aOU=
       });
       const config = { minRSABits: 1024 };
 
-      const cleartextMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armor' });
+      const cleartextMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armored' });
       const parsedArmored = await openpgp.readCleartextMessage({ cleartextMessage });
       expect(parsedArmored.text).to.equal(text);
       expect(parsedArmored.signature.packets.filterByTag(openpgp.enums.packet.signature)).to.have.length(1);
@@ -1671,7 +1671,7 @@ aOU=
       });
       const config = { minRSABits: 1024 };
 
-      const armoredMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armor' });
+      const armoredMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armored' });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.onePassSignature)).to.have.length(1);
 
@@ -1694,7 +1694,7 @@ aOU=
       });
       const config = { minRSABits: 1024 };
 
-      const armoredMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armor' });
+      const armoredMessage = await openpgp.sign({ message, signingKeys: privateKey, config, format: 'armored' });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.onePassSignature)).to.have.length(1);
 
@@ -1719,7 +1719,7 @@ aOU=
       const armoredMessage = await openpgp.sign({
         message: await openpgp.createMessage({ text: stream.toStream(text) }),
         signingKeys: privateKey,
-        format: 'armor',
+        format: 'armored',
         config
       });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
@@ -1757,7 +1757,7 @@ aOU=
       });
       const config = { minRSABits: 1024 };
 
-      const armoredSignature = await openpgp.sign({ message, signingKeys: privateKey, detached: true, config, format: 'armor' });
+      const armoredSignature = await openpgp.sign({ message, signingKeys: privateKey, detached: true, config, format: 'armored' });
       const parsedArmored = await openpgp.readSignature({ armoredSignature });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.signature)).to.have.length(1);
 
@@ -1783,7 +1783,7 @@ aOU=
         message: await openpgp.createMessage({ text: stream.toStream(text) }),
         signingKeys: privateKey,
         detached: true,
-        format: 'armor',
+        format: 'armored',
         config
       });
       const parsedArmored = await openpgp.readSignature({ armoredSignature: await stream.readToEnd(armoredSignature) });
@@ -1839,7 +1839,7 @@ aOU=
         passphrase
       });
 
-      const armoredMessage = await openpgp.encrypt({ message, passwords, format: 'armor' });
+      const armoredMessage = await openpgp.encrypt({ message, passwords, format: 'armored' });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)).to.have.length(1);
 
@@ -1865,7 +1865,7 @@ aOU=
       const armoredMessage = await openpgp.encrypt({
         message: await openpgp.createMessage({ text: stream.toStream(text) }),
         passwords,
-        format: 'armor'
+        format: 'armored'
       });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)).to.have.length(1);
@@ -1897,7 +1897,7 @@ aOU=
       const passwords = 'password';
       const sessionKey = { data: new Uint8Array(16).fill(1), algorithm: 'aes128' };
 
-      const armoredMessage = await openpgp.encryptSessionKey({ ...sessionKey, passwords, format: 'armor' });
+      const armoredMessage = await openpgp.encryptSessionKey({ ...sessionKey, passwords, format: 'armored' });
       const parsedArmored = await openpgp.readMessage({ armoredMessage });
       expect(parsedArmored.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)).to.have.length(1);
 


### PR DESCRIPTION
The `format` option in `openpgp.generateKey, reformatKey, revokeKey, encrypt, sign, encryptSessionKey` (introduced in #1345 and #1354 ) now expects the value `'armored'` instead of `'armor'` to output armored data. The other format options (i.e. `'binary'` and `'object'`) remain unchanged.

TODO:
- [x] Merge after #1354 