### PR TITLE
Rename `config.tolerant` to `config.ignoreUnsupportedPackets`, add `config.ignoreMalformedPackets`

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -321,7 +321,8 @@ interface Config {
   minRSABits: number;
   passwordCollisionCheck: boolean;
   revocationsExpire: boolean;
-  tolerant: boolean;
+  ignoreUnsupportedPackets: boolean;
+  ignoreMalformedPackets: boolean;
   versionString: string;
   commentString: string;
   allowInsecureDecryptionWithSigningKeys: boolean;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -136,10 +136,14 @@ export default {
   minBytesForWebCrypto: 1000,
   /**
    * @memberof module:config
-   * @property {Boolean} tolerant Ignore unsupported/unrecognizable packets instead of throwing an error
+   * @property {Boolean} ignoreUnsupportedPackets Ignore unsupported/unrecognizable packets on parsing instead of throwing an error
    */
-  tolerant: true,
-
+  ignoreUnsupportedPackets: true,
+  /**
+   * @memberof module:config
+   * @property {Boolean} ignoreMalformedPackets Ignore malformed packets on parsing instead of throwing an error
+   */
+  ignoreMalformedPackets: false,
   /**
    * @memberof module:config
    * @property {Boolean} showVersion Whether to include {@link module:config/config.versionString} in armored messages

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -82,8 +82,9 @@ class PacketList extends Array {
               await packet.read(parsed.packet, config);
               await writer.write(packet);
             } catch (e) {
-              const isTolerableError = config.tolerant && e instanceof UnsupportedError;
-              if (!isTolerableError || supportsStreaming(parsed.tag)) {
+              const throwUnsupportedError = !config.ignoreUnsupportedPackets && e instanceof UnsupportedError;
+              const throwMalformedError = !config.ignoreMalformedPackets && !(e instanceof UnsupportedError);
+              if (throwUnsupportedError || throwMalformedError || supportsStreaming(parsed.tag)) {
                 // The packets that support streaming are the ones that contain message data.
                 // Those are also the ones we want to be more strict about and throw on parse errors
                 // (since we likely cannot process the message without these packets anyway).

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -8,11 +8,11 @@ module.exports = () => describe('Custom configuration', function() {
     const message = await openpgp.readMessage({ armoredMessage });
     message.packets.findPacket(openpgp.SymEncryptedSessionKeyPacket.tag).version = 1; // unsupported SKESK version
 
-    const config = { tolerant: true };
+    const config = { ignoreUnsupportedPackets: true };
     const parsedMessage = await openpgp.readMessage({ armoredMessage: message.armor(), config });
     expect(parsedMessage.packets.length).to.equal(1);
 
-    config.tolerant = false;
+    config.ignoreUnsupportedPackets = false;
     await expect(
       openpgp.readMessage({ armoredMessage: message.armor(), config })
     ).to.be.rejectedWith(/Version 1 of the SKESK packet is unsupported/);
@@ -30,11 +30,11 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
     const signature = await openpgp.readSignature({ armoredSignature });
     signature.packets[0].signatureData[0] = 1; // set unsupported signature version
 
-    const config = { tolerant: true };
+    const config = { ignoreUnsupportedPackets: true };
     const parsedSignature = await openpgp.readSignature({ armoredSignature: signature.armor(), config });
     expect(parsedSignature.packets.length).to.equal(0);
 
-    config.tolerant = false;
+    config.ignoreUnsupportedPackets = false;
     await expect(
       openpgp.readSignature({ armoredSignature: signature.armor(), config })
     ).to.be.rejectedWith(/Version 1 of the signature packet is unsupported/);
@@ -43,10 +43,10 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
   it('openpgp.readKey', async function() {
     const { privateKey: armoredKey } = await openpgp.generateKey({ userIDs:[{ name:'test', email:'test@a.it' }] });
     await expect(
-      openpgp.readKey({ armoredKey, config: { tolerant: false, maxUserIDLength: 2 } })
+      openpgp.readKey({ armoredKey, config: { ignoreUnsupportedPackets: false, maxUserIDLength: 2 } })
     ).to.be.rejectedWith(/User ID string is too long/);
     await expect(
-      openpgp.readKey({ armoredKey, config: { tolerant: true, maxUserIDLength: 2 } })
+      openpgp.readKey({ armoredKey, config: { ignoreUnsupportedPackets: true, maxUserIDLength: 2 } })
     ).to.be.rejectedWith(/User ID string is too long/);
   });
 


### PR DESCRIPTION
- Rename `config.tolerant` to `config.ignoreUnsupportedPackets`. This still defaults to `true`.
- Add `config.ignoreMalformedPackets` to also ignore packets that fail to parse (when possible). This defaults to `false`.

