### PR TITLE
Add `config.rejectCurves` and prevent generating keys using blacklisted algos

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -337,6 +337,7 @@ interface Config {
   rejectHashAlgorithms: Set<enums.hash>;
   rejectMessageHashAlgorithms: Set<enums.hash>;
   rejectPublicKeyAlgorithms: Set<enums.publicKey>;
+  rejectCurves: Set<enums.curve>;
 }
 export var config: Config;
 
@@ -812,6 +813,18 @@ export namespace enums {
     eddsa = 22,
     aedh = 23,
     aedsa = 24,
+  }
+
+  enum curve {
+    p256 = 'p256',
+    p384 = 'p384',
+    p521 = 'p521',
+    ed25519 = 'ed25519',
+    curve25519 = 'curve25519',
+    secp256k1 = 'secp256k1',
+    brainpoolP256r1 = 'brainpoolP256r1',
+    brainpoolP384r1 = 'brainpoolP384r1',
+    brainpoolP512r1 = 'brainpoolP512r1'
   }
 
   export type symmetricNames = 'plaintext' | 'idea' | 'tripledes' | 'cast5' | 'blowfish' | 'aes128' | 'aes192' | 'aes256' | 'twofish';

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -179,8 +179,11 @@ export default {
    */
   knownNotations: ['preferred-email-encoding@pgp.com', 'pka-address@gnupg.org'],
   /**
+   * Whether to use the indutny/elliptic library for NIST and Brainpool curves that are not supported by the available native crypto library.
+   * When false, certain standard curves will not be supported (depending on the platform).
+   * Note: the indutny/elliptic curve library is not designed to be constant time.
    * @memberof module:config
-   * @property {Boolean} useIndutnyElliptic Whether to use the indutny/elliptic library. When false, certain curves will not be supported.
+   * @property {Boolean} useIndutnyElliptic
    */
   useIndutnyElliptic: true,
   /**
@@ -196,9 +199,15 @@ export default {
    */
   rejectMessageHashAlgorithms: new Set([enums.hash.md5, enums.hash.ripemd, enums.hash.sha1]),
   /**
-   * Reject insecure public key algorithms for message encryption, signing or verification
+   * Reject insecure public key algorithms for key generation and message encryption, signing or verification
    * @memberof module:config
    * @property {Set<Integer>} rejectPublicKeyAlgorithms {@link module:enums.publicKey}
    */
-  rejectPublicKeyAlgorithms: new Set([enums.publicKey.elgamal, enums.publicKey.dsa])
+  rejectPublicKeyAlgorithms: new Set([enums.publicKey.elgamal, enums.publicKey.dsa]),
+  /**
+   * Reject non-standard curves for key generation, message encryption, signing or verification
+   * @memberof module:config
+   * @property {Set<String>} rejectCurves {@link module:enums.curve}
+   */
+  rejectCurves: new Set([enums.curve.brainpoolP256r1, enums.curve.brainpoolP384r1, enums.curve.brainpoolP512r1])
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -179,7 +179,7 @@ export default {
    */
   knownNotations: ['preferred-email-encoding@pgp.com', 'pka-address@gnupg.org'],
   /**
-   * Whether to use the indutny/elliptic library for NIST and Brainpool curves that are not supported by the available native crypto library.
+   * Whether to use the indutny/elliptic library for curves (other than Curve25519) that are not supported by the available native crypto API.
    * When false, certain standard curves will not be supported (depending on the platform).
    * Note: the indutny/elliptic curve library is not designed to be constant time.
    * @memberof module:config

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -209,5 +209,5 @@ export default {
    * @memberof module:config
    * @property {Set<String>} rejectCurves {@link module:enums.curve}
    */
-  rejectCurves: new Set([enums.curve.brainpoolP256r1, enums.curve.brainpoolP384r1, enums.curve.brainpoolP512r1])
+  rejectCurves: new Set([enums.curve.brainpoolP256r1, enums.curve.brainpoolP384r1, enums.curve.brainpoolP512r1, enums.curve.secp256k1])
 };

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -254,7 +254,7 @@ class Key {
           await helper.getLatestValidSignature(
             [bindingSignature.embeddedSignature], subkey.keyPacket, enums.signature.keyBinding, dataToVerify, date, config
           );
-          helper.checkKeyStrength(subkey.keyPacket, config);
+          helper.checkKeyRequirements(subkey.keyPacket, config);
           return subkey;
         } catch (e) {
           exception = e;
@@ -266,7 +266,7 @@ class Key {
       const primaryUser = await this.getPrimaryUser(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
           helper.isValidSigningKeyPacket(primaryKey, primaryUser.selfCertification, config)) {
-        helper.checkKeyStrength(primaryKey, config);
+        helper.checkKeyRequirements(primaryKey, config);
         return this;
       }
     } catch (e) {
@@ -298,7 +298,7 @@ class Key {
           const dataToVerify = { key: primaryKey, bind: subkey.keyPacket };
           const bindingSignature = await helper.getLatestValidSignature(subkey.bindingSignatures, primaryKey, enums.signature.subkeyBinding, dataToVerify, date, config);
           if (helper.isValidEncryptionKeyPacket(subkey.keyPacket, bindingSignature)) {
-            helper.checkKeyStrength(subkey.keyPacket, config);
+            helper.checkKeyRequirements(subkey.keyPacket, config);
             return subkey;
           }
         } catch (e) {
@@ -312,7 +312,7 @@ class Key {
       const primaryUser = await this.getPrimaryUser(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
           helper.isValidEncryptionKeyPacket(primaryKey, primaryUser.selfCertification)) {
-        helper.checkKeyStrength(primaryKey, config);
+        helper.checkKeyRequirements(primaryKey, config);
         return this;
       }
     } catch (e) {

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -69,7 +69,7 @@ export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc',
 
   try {
     const { key, revocationCertificate } = await generate(options, config);
-    checkKeyRequirements(key.keyPacket, config);
+    key.getKeys().forEach(({ keyPacket }) => checkKeyRequirements(keyPacket, config));
 
     return {
       privateKey: formatObject(key, format, config),

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -21,6 +21,7 @@ import { CleartextMessage } from './cleartext';
 import { generate, reformat, getPreferredAlgo } from './key';
 import defaultConfig from './config';
 import util from './util';
+import { checkKeyRequirements } from './key/helper';
 
 
 //////////////////////
@@ -63,10 +64,12 @@ export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc',
   if (type === 'rsa' && rsaBits < config.minRSABits) {
     throw new Error(`rsaBits should be at least ${config.minRSABits}, got: ${rsaBits}`);
   }
+
   const options = { userIDs, passphrase, type, rsaBits, curve, keyExpirationTime, date, subkeys };
 
   try {
     const { key, revocationCertificate } = await generate(options, config);
+    checkKeyRequirements(key.keyPacket, config);
 
     return {
       privateKey: formatObject(key, format, config),

--- a/test/crypto/validate.js
+++ b/test/crypto/validate.js
@@ -81,7 +81,8 @@ async function cloneKeyPacket(key) {
 }
 
 async function generatePrivateKeyObject(options) {
-  const { privateKey } = await openpgp.generateKey({ ...options, userIDs: [{ name: 'Test', email: 'test@test.com' }], format: 'object' });
+  const config = { rejectCurves: new Set() };
+  const { privateKey } = await openpgp.generateKey({ ...options, userIDs: [{ name: 'Test', email: 'test@test.com' }], format: 'object', config });
   return privateKey;
 }
 

--- a/test/general/ecc_secp256k1.js
+++ b/test/general/ecc_secp256k1.js
@@ -12,6 +12,17 @@ module.exports = () => describe('Elliptic Curve Cryptography for secp256k1 curve
       this.skip(); // eslint-disable-line no-invalid-this
     });
   }
+
+  let rejectCurvesVal;
+  beforeEach(() => {
+    rejectCurvesVal = openpgp.config.rejectCurves;
+    openpgp.config.rejectCurves = new Set();
+  });
+
+  afterEach(() => {
+    openpgp.config.rejectCurves = rejectCurvesVal;
+  });
+
   const data = {
     romeo: {
       id: 'c2b12389b401a43d',

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -3724,10 +3724,11 @@ amnR6g==
       const curves = ['secp256k1' , 'p256', 'p384', 'p521', 'curve25519', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'];
       curves.forEach(curve => {
         it(`sign/verify with ${curve}`, async function() {
+          const config = { rejectCurves: new Set() };
           const plaintext = 'short message';
-          const { privateKey: key } = await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' }, format: 'object' });
-          const signed = await openpgp.sign({ signingKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }) });
-          const verified = await openpgp.verify({ verificationKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }) });
+          const { privateKey: key } = await openpgp.generateKey({ curve, userIDs: { name: 'Alice', email: 'info@alice.com' }, format: 'object', config });
+          const signed = await openpgp.sign({ signingKeys:[key], message: await openpgp.createCleartextMessage({ text: plaintext }), config });
+          const verified = await openpgp.verify({ verificationKeys:[key], message: await openpgp.readCleartextMessage({ cleartextMessage: signed }), config });
           expect(await verified.signatures[0].verified).to.be.true;
         });
       });

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -383,11 +383,13 @@ function tests() {
     });
 
     try {
+      const config = { rejectCurves: new Set() };
       const encrypted = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: data }),
         encryptionKeys: pub,
         signingKeys: priv,
-        format: 'binary'
+        format: 'binary',
+        config
       });
       expect(stream.isStream(encrypted)).to.equal(expectedType);
 
@@ -396,7 +398,8 @@ function tests() {
         verificationKeys: pub,
         decryptionKeys: priv,
         message,
-        format: 'binary'
+        format: 'binary',
+        config
       });
       expect(stream.isStream(decrypted.data)).to.equal(expectedType);
       const reader = stream.getReader(decrypted.data);
@@ -706,11 +709,13 @@ function tests() {
       privateKey: await openpgp.readKey({ armoredKey: brainpoolPriv }),
       passphrase: brainpoolPass
     });
+    const config = { rejectCurves: new Set() };
 
     const signed = await openpgp.sign({
       message: await openpgp.createMessage({ binary: data }),
       signingKeys: priv,
-      detached: true
+      detached: true,
+      config
     });
     expect(stream.isStream(signed)).to.equal(expectedType);
     const armoredSignature = await stream.readToEnd(signed);
@@ -718,7 +723,8 @@ function tests() {
     const verified = await openpgp.verify({
       signature,
       verificationKeys: pub,
-      message: await openpgp.createMessage({ text: 'hello world' })
+      message: await openpgp.createMessage({ text: 'hello world' }),
+      config
     });
     expect(verified.data).to.equal('hello world');
     expect(verified.signatures).to.exist.and.have.length(1);


### PR DESCRIPTION
Breaking changes:
- throw error on key generation if the requested public key algorithm is included in `config.rejectPublicKeyAlgorithms`;
- add `config.rejectCurves` to blacklist a set of ECC curves, to prevent keys using those curves from being generated, or being used to encrypt/decrypt/sign/verify messages.
By default, `config.rejectCurves` includes the brainpool curves (`brainpoolP256r1`, `brainpoolP384r1`, `brainpoolP512r1`) and the Bitcoin curve (`secp256k1`). This is because [it's unclear whether these curves will be standardised](https://gitlab.com/openpgp-wg/rfc4880bis/-/merge_requests/47#note_634199141), and we prefer to blacklist them already, rather than introduce a breaking change after release.
