### PR TITLE
Enable use with Vite

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -26,7 +26,10 @@
 import * as stream from '@openpgp/web-stream-tools';
 import { getBigInteger } from './biginteger';
 
-const debugMode = globalThis.process && globalThis.process.env.NODE_ENV === 'development';
+
+const envVar = 'NODE_ENV';
+
+const debugMode = globalThis.process && globalThis.process.env[envVar] === 'development';
 
 const util = {
   isString: function(data) {


### PR DESCRIPTION
Adjust the way openpgp accesses the NODE_ENV, so that it works in both webpack and vite. should close: https://github.com/openpgpjs/openpgpjs/issues/1332