### PR TITLE
Replace strings with integer algorithm identifiers in packet classes

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -185,8 +185,8 @@ export function decryptSessionKeys<T extends MaybeStream<Data>>(options: { messa
 export function readMessage<T extends MaybeStream<string>>(options: { armoredMessage: T, config?: PartialConfig }): Promise<Message<T>>;
 export function readMessage<T extends MaybeStream<Uint8Array>>(options: { binaryMessage: T, config?: PartialConfig }): Promise<Message<T>>;
 
-export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
-export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, type?: DataPacketType }): Promise<Message<T>>;
+export function createMessage<T extends MaybeStream<string>>(options: { text: T, filename?: string, date?: Date, format?: enums.literalFormatNames }): Promise<Message<T>>;
+export function createMessage<T extends MaybeStream<Uint8Array>>(options: { binary: T, filename?: string, date?: Date, format?: enums.literalFormatNames }): Promise<Message<T>>;
 
 export function encrypt<T extends MaybeStream<Data>>(options: EncryptOptions & { message: Message<T>, format?: 'armored' }): Promise<
   T extends WebStream<infer X> ? WebStream<string> :
@@ -438,8 +438,8 @@ export class LiteralDataPacket extends BasePacket {
   static readonly tag: enums.packet.literalData;
   private getText(clone?: boolean): MaybeStream<string>;
   private getBytes(clone?: boolean): MaybeStream<Uint8Array>;
-  private setText(text: MaybeStream<string>, format?: DataPacketType);
-  private setBytes(bytes: MaybeStream<Uint8Array>, format?: DataPacketType);
+  private setText(text: MaybeStream<string>, format?: enums.literal);
+  private setBytes(bytes: MaybeStream<Uint8Array>, format: enums.literal);
   private setFilename(filename: string);
   private getFilename(): string;
   private writeHeader(): Uint8Array;
@@ -533,8 +533,6 @@ export class TrustPacket extends BasePacket {
 export type AnyPacket = BasePacket;
 export type AnySecretKeyPacket = SecretKeyPacket | SecretSubkeyPacket;
 export type AnyKeyPacket = BasePublicKeyPacket;
-
-type DataPacketType = 'utf8' | 'binary' | 'text' | 'mime';
 
 type AllowedPackets = Map<enums.packet, object>; // mapping to Packet classes (i.e. typeof LiteralDataPacket etc.)
 export class PacketList<T extends AnyPacket> extends Array<T> {
@@ -639,7 +637,6 @@ interface SignOptions {
   message: CleartextMessage | Message<MaybeStream<Data>>;
   signingKeys?: MaybeArray<PrivateKey>;
   format?: 'armored' | 'binary' | 'object';
-  dataType?: DataPacketType;
   detached?: boolean;
   signingKeyIDs?: MaybeArray<KeyID>;
   date?: Date;
@@ -884,5 +881,13 @@ export namespace enums {
     eax = 1,
     ocb = 2,
     experimentalGCM = 100 // Private algorithm
+  }
+
+  export type literalFormatNames = 'utf8' | 'binary' | 'text' | 'mime'
+  enum literal {
+    binary = 98,
+    text = 116,
+    utf8 = 117,
+    mime = 109
   }
 }

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -359,7 +359,7 @@ declare abstract class BasePacket {
  * - A Subkey Packet cannot always be used when a Primary Key Packet is expected (and vice versa).
  */
 declare abstract class BasePublicKeyPacket extends BasePacket {
-  public algorithm: enums.publicKeyNames;
+  public algorithm: enums.publicKey;
   public created: Date;
   public version: number;
   public getAlgorithmInfo(): AlgorithmInfo;
@@ -417,8 +417,8 @@ export class SymEncryptedIntegrityProtectedDataPacket extends BasePacket {
 
 export class AEADEncryptedDataPacket extends BasePacket {
   static readonly tag: enums.packet.aeadEncryptedData;
-  private decrypt(sessionKeyAlgorithm: string, sessionKey: Uint8Array, config?: Config): void;
-  private encrypt(sessionKeyAlgorithm: string, sessionKey: Uint8Array, config?: Config): void;
+  private decrypt(sessionKeyAlgorithm: enums.symmetric, sessionKey: Uint8Array, config?: Config): void;
+  private encrypt(sessionKeyAlgorithm: enums.symmetric, sessionKey: Uint8Array, config?: Config): void;
   private crypt(fn: Function, sessionKey: Uint8Array, data: MaybeStream<Uint8Array>): MaybeStream<Uint8Array>
 }
 

--- a/src/crypto/cipher/aes.js
+++ b/src/crypto/cipher/aes.js
@@ -1,6 +1,9 @@
 import { AES_ECB } from '@openpgp/asmcrypto.js/dist_es8/aes/ecb';
 
-// TODO use webCrypto or nodeCrypto when possible.
+/**
+ * Javascript AES implementation.
+ * This is used as fallback if the native Crypto APIs are not available.
+ */
 function aes(length) {
   const C = function(key) {
     const aesECB = new AES_ECB(key);

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -348,7 +348,8 @@ export async function validateParams(algo, publicParams, privateParams) {
  * @async
  */
 export async function getPrefixRandom(algo) {
-  const prefixrandom = await getRandomBytes(cipher[algo].blockSize);
+  const algoName = enums.read(enums.symmetric, algo);
+  const prefixrandom = await getRandomBytes(cipher[algoName].blockSize);
   const repeat = new Uint8Array([prefixrandom[prefixrandom.length - 2], prefixrandom[prefixrandom.length - 1]]);
   return util.concat([prefixrandom, repeat]);
 }
@@ -361,5 +362,6 @@ export async function getPrefixRandom(algo) {
  * @async
  */
 export function generateSessionKey(algo) {
-  return getRandomBytes(cipher[algo].keySize);
+  const algoName = enums.read(enums.symmetric, algo);
+  return getRandomBytes(cipher[algoName].keySize);
 }

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -370,7 +370,7 @@ export function generateSessionKey(algo) {
 /**
  * Get implementation of the given AEAD mode
  * @param {enums.aead} algo
- * @returns {Function} with signature (cipher: Function, key: Uint8Array) => { encrypt: Function, decrypt: Function }
+ * @returns {Object}
  * @throws {Error} on invalid algo
  */
 export function getAEADMode(algo) {
@@ -381,7 +381,7 @@ export function getAEADMode(algo) {
 /**
  * Get implementation of the given cipher
  * @param {enums.symmetric} algo
- * @returns {Function} with signature (key: Uint8Array) => { keySize: Integer, blockSize: Integer, encrypt: Function, decrypt: Function }
+ * @returns {Object}
  * @throws {Error} on invalid algo
  */
 export function getCipher(algo) {

--- a/src/crypto/hash/index.js
+++ b/src/crypto/hash/index.js
@@ -16,6 +16,7 @@ import * as stream from '@openpgp/web-stream-tools';
 import md5 from './md5';
 import util from '../../util';
 import defaultConfig from '../../config';
+import enums from '../../enums';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -143,18 +144,18 @@ export default {
    */
   getHashByteLength: function(algo) {
     switch (algo) {
-      case 1: // - MD5 [HAC]
+      case enums.hash.md5: // - MD5 [HAC]
         return 16;
-      case 2: // - SHA-1 [FIPS180]
-      case 3: // - RIPE-MD/160 [HAC]
+      case enums.hash.sha1: // - SHA-1 [FIPS180]
+      case enums.hash.ripemd: // - RIPE-MD/160 [HAC]
         return 20;
-      case 8: // - SHA256 [FIPS180]
+      case enums.hash.sha256: // - SHA256 [FIPS180]
         return 32;
-      case 9: // - SHA384 [FIPS180]
+      case enums.hash.sha384: // - SHA384 [FIPS180]
         return 48;
-      case 10: // - SHA512 [FIPS180]
+      case enums.hash.sha512: // - SHA512 [FIPS180]
         return 64;
-      case 11: // - SHA224 [FIPS180]
+      case enums.hash.sha224: // - SHA224 [FIPS180]
         return 28;
       default:
         throw new Error('Invalid hash algorithm.');

--- a/src/crypto/hash/index.js
+++ b/src/crypto/hash/index.js
@@ -111,26 +111,19 @@ export default {
    */
   digest: function(algo, data) {
     switch (algo) {
-      case 1:
-        // - MD5 [HAC]
+      case enums.hash.md5:
         return this.md5(data);
-      case 2:
-        // - SHA-1 [FIPS180]
+      case enums.hash.sha1:
         return this.sha1(data);
-      case 3:
-        // - RIPE-MD/160 [HAC]
+      case enums.hash.ripemd:
         return this.ripemd(data);
-      case 8:
-        // - SHA256 [FIPS180]
+      case enums.hash.sha256:
         return this.sha256(data);
-      case 9:
-        // - SHA384 [FIPS180]
+      case enums.hash.sha384:
         return this.sha384(data);
-      case 10:
-        // - SHA512 [FIPS180]
+      case enums.hash.sha512:
         return this.sha512(data);
-      case 11:
-        // - SHA224 [FIPS180]
+      case enums.hash.sha224:
         return this.sha224(data);
       default:
         throw new Error('Invalid hash function.');
@@ -144,18 +137,18 @@ export default {
    */
   getHashByteLength: function(algo) {
     switch (algo) {
-      case enums.hash.md5: // - MD5 [HAC]
+      case enums.hash.md5:
         return 16;
-      case enums.hash.sha1: // - SHA-1 [FIPS180]
-      case enums.hash.ripemd: // - RIPE-MD/160 [HAC]
+      case enums.hash.sha1:
+      case enums.hash.ripemd:
         return 20;
-      case enums.hash.sha256: // - SHA256 [FIPS180]
+      case enums.hash.sha256:
         return 32;
-      case enums.hash.sha384: // - SHA384 [FIPS180]
+      case enums.hash.sha384:
         return 48;
-      case enums.hash.sha512: // - SHA512 [FIPS180]
+      case enums.hash.sha512:
         return 64;
-      case enums.hash.sha224: // - SHA224 [FIPS180]
+      case enums.hash.sha224:
         return 28;
       default:
         throw new Error('Invalid hash algorithm.');

--- a/src/crypto/mode/cfb.js
+++ b/src/crypto/mode/cfb.js
@@ -27,6 +27,7 @@ import { AES_CFB } from '@openpgp/asmcrypto.js/dist_es8/aes/cfb';
 import * as stream from '@openpgp/web-stream-tools';
 import * as cipher from '../cipher';
 import util from '../../util';
+import enums from '../../enums';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -43,15 +44,25 @@ const nodeAlgos = {
   /* twofish is not implemented in OpenSSL */
 };
 
+/**
+ * CFB encryption
+ * @param {enums.symmetric} algo - block cipher algorithm
+ * @param {Uint8Array} key
+ * @param {MaybeStream<Uint8Array>} plaintext
+ * @param {Uint8Array} iv
+ * @param {Object} config - full configuration, defaults to openpgp.config
+ * @returns MaybeStream<Uint8Array>
+ */
 export async function encrypt(algo, key, plaintext, iv, config) {
-  if (util.getNodeCrypto() && nodeAlgos[algo]) { // Node crypto library.
+  const algoName = enums.read(enums.symmetric, algo);
+  if (util.getNodeCrypto() && nodeAlgos[algoName]) { // Node crypto library.
     return nodeEncrypt(algo, key, plaintext, iv);
   }
-  if (algo.substr(0, 3) === 'aes') {
+  if (algoName.substr(0, 3) === 'aes') {
     return aesEncrypt(algo, key, plaintext, iv, config);
   }
 
-  const cipherfn = new cipher[algo](key);
+  const cipherfn = new cipher[algoName](key);
   const block_size = cipherfn.blockSize;
 
   const blockc = iv.slice();
@@ -76,15 +87,24 @@ export async function encrypt(algo, key, plaintext, iv, config) {
   return stream.transform(plaintext, process, process);
 }
 
+/**
+ * CFB decryption
+ * @param {enums.symmetric} algo - block cipher algorithm
+ * @param {Uint8Array} key
+ * @param {MaybeStream<Uint8Array>} ciphertext
+ * @param {Uint8Array} iv
+ * @returns MaybeStream<Uint8Array>
+ */
 export async function decrypt(algo, key, ciphertext, iv) {
-  if (util.getNodeCrypto() && nodeAlgos[algo]) { // Node crypto library.
+  const algoName = enums.read(enums.symmetric, algo);
+  if (util.getNodeCrypto() && nodeAlgos[algoName]) { // Node crypto library.
     return nodeDecrypt(algo, key, ciphertext, iv);
   }
-  if (algo.substr(0, 3) === 'aes') {
+  if (algoName.substr(0, 3) === 'aes') {
     return aesDecrypt(algo, key, ciphertext, iv);
   }
 
-  const cipherfn = new cipher[algo](key);
+  const cipherfn = new cipher[algoName](key);
   const block_size = cipherfn.blockSize;
 
   let blockp = iv;
@@ -140,7 +160,8 @@ function xorMut(a, b) {
 async function webEncrypt(algo, key, pt, iv) {
   const ALGO = 'AES-CBC';
   const _key = await webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt']);
-  const { blockSize } = cipher[algo];
+  const algoName = enums.read(enums.symmetric, algo);
+  const { blockSize } = cipher[algoName];
   const cbc_pt = util.concatUint8Array([new Uint8Array(blockSize), pt]);
   const ct = new Uint8Array(await webCrypto.encrypt({ name: ALGO, iv }, _key, cbc_pt)).subarray(0, pt.length);
   xorMut(ct, pt);
@@ -148,11 +169,13 @@ async function webEncrypt(algo, key, pt, iv) {
 }
 
 function nodeEncrypt(algo, key, pt, iv) {
-  const cipherObj = new nodeCrypto.createCipheriv(nodeAlgos[algo], key, iv);
+  const algoName = enums.read(enums.symmetric, algo);
+  const cipherObj = new nodeCrypto.createCipheriv(nodeAlgos[algoName], key, iv);
   return stream.transform(pt, value => new Uint8Array(cipherObj.update(value)));
 }
 
 function nodeDecrypt(algo, key, ct, iv) {
-  const decipherObj = new nodeCrypto.createDecipheriv(nodeAlgos[algo], key, iv);
+  const algoName = enums.read(enums.symmetric, algo);
+  const decipherObj = new nodeCrypto.createDecipheriv(nodeAlgos[algoName], key, iv);
   return stream.transform(ct, value => new Uint8Array(decipherObj.update(value)));
 }

--- a/src/crypto/mode/cfb.js
+++ b/src/crypto/mode/cfb.js
@@ -160,8 +160,7 @@ function xorMut(a, b) {
 async function webEncrypt(algo, key, pt, iv) {
   const ALGO = 'AES-CBC';
   const _key = await webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt']);
-  const algoName = enums.read(enums.symmetric, algo);
-  const { blockSize } = cipher[algoName];
+  const { blockSize } = crypto.getCipher(algo);
   const cbc_pt = util.concatUint8Array([new Uint8Array(blockSize), pt]);
   const ct = new Uint8Array(await webCrypto.encrypt({ name: ALGO, iv }, _key, cbc_pt)).subarray(0, pt.length);
   xorMut(ct, pt);

--- a/src/crypto/mode/eax.js
+++ b/src/crypto/mode/eax.js
@@ -77,7 +77,7 @@ async function CTR(key) {
  * @param {String} cipher - The symmetric cipher algorithm to use e.g. 'aes128'
  * @param {Uint8Array} key - The encryption key
  */
-async function EAX(cipher, key) {
+async function EAX(cipher, key) { // TODO take integer
   if (cipher.substr(0, 3) !== 'aes') {
     throw new Error('EAX mode supports only AES cipher');
   }

--- a/src/crypto/mode/eax.js
+++ b/src/crypto/mode/eax.js
@@ -25,6 +25,7 @@
 import { AES_CTR } from '@openpgp/asmcrypto.js/dist_es8/aes/ctr';
 import CMAC from '../cmac';
 import util from '../../util';
+import enums from '../../enums';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -74,11 +75,13 @@ async function CTR(key) {
 
 /**
  * Class to en/decrypt using EAX mode.
- * @param {String} cipher - The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param {enums.symmetric} cipher - The symmetric cipher algorithm to use
  * @param {Uint8Array} key - The encryption key
  */
 async function EAX(cipher, key) { // TODO take integer
-  if (cipher.substr(0, 3) !== 'aes') {
+  if (cipher !== enums.symmetric.aes128 &&
+    cipher !== enums.symmetric.aes192 &&
+    cipher !== enums.symmetric.aes256) {
     throw new Error('EAX mode supports only AES cipher');
   }
 

--- a/src/crypto/mode/eax.js
+++ b/src/crypto/mode/eax.js
@@ -78,7 +78,7 @@ async function CTR(key) {
  * @param {enums.symmetric} cipher - The symmetric cipher algorithm to use
  * @param {Uint8Array} key - The encryption key
  */
-async function EAX(cipher, key) { // TODO take integer
+async function EAX(cipher, key) {
   if (cipher !== enums.symmetric.aes128 &&
     cipher !== enums.symmetric.aes192 &&
     cipher !== enums.symmetric.aes256) {

--- a/src/crypto/mode/gcm.js
+++ b/src/crypto/mode/gcm.js
@@ -24,6 +24,7 @@
 
 import { AES_GCM } from '@openpgp/asmcrypto.js/dist_es8/aes/gcm';
 import util from '../../util';
+import enums from '../../enums';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -36,12 +37,14 @@ const ALGO = 'AES-GCM';
 
 /**
  * Class to en/decrypt using GCM mode.
- * @param {String} cipher - The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param {enums.symmetric} cipher - The symmetric cipher algorithm to use
  * @param {Uint8Array} key - The encryption key
  */
 async function GCM(cipher, key) {
-  if (cipher.substr(0, 3) !== 'aes') {
-    throw new Error('GCM mode supports only AES cipher');
+  if (cipher !== enums.symmetric.aes128 &&
+    cipher !== enums.symmetric.aes192 &&
+    cipher !== enums.symmetric.aes256) {
+    throw new Error('EAX mode supports only AES cipher');
   }
 
   if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support

--- a/src/crypto/mode/gcm.js
+++ b/src/crypto/mode/gcm.js
@@ -44,7 +44,7 @@ async function GCM(cipher, key) {
   if (cipher !== enums.symmetric.aes128 &&
     cipher !== enums.symmetric.aes192 &&
     cipher !== enums.symmetric.aes256) {
-    throw new Error('EAX mode supports only AES cipher');
+    throw new Error('GCM mode supports only AES cipher');
   }
 
   if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support

--- a/src/crypto/mode/ocb.js
+++ b/src/crypto/mode/ocb.js
@@ -23,7 +23,7 @@
 
 import * as ciphers from '../cipher';
 import util from '../../util';
-
+import enums from '../../enums';
 
 const blockLength = 16;
 const ivLength = 15;
@@ -59,7 +59,7 @@ const one = new Uint8Array([1]);
 
 /**
  * Class to en/decrypt using OCB mode.
- * @param {String} cipher - The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param {enums.symmetric} cipher - The symmetric cipher algorithm to use
  * @param {Uint8Array} key - The encryption key
  */
 async function OCB(cipher, key) {
@@ -72,7 +72,8 @@ async function OCB(cipher, key) {
   constructKeyVariables(cipher, key);
 
   function constructKeyVariables(cipher, key) {
-    const aes = new ciphers[cipher](key);
+    const cipherName = enums.read(enums.symmetric, cipher);
+    const aes = new ciphers[cipherName](key);
     encipher = aes.encrypt.bind(aes);
     decipher = aes.decrypt.bind(aes);
 

--- a/src/crypto/public_key/elliptic/curves.js
+++ b/src/crypto/public_key/elliptic/curves.js
@@ -223,7 +223,7 @@ async function generate(curve) {
 /**
  * Get preferred hash algo to use with the given curve
  * @param {module:type/oid} oid - curve oid
- * @returns {module:enums.hash} hash algorithm
+ * @returns {enums.hash} hash algorithm
  */
 function getPreferredHashAlgo(oid) {
   return curves[enums.write(enums.curve, oid.toHex())].hash;

--- a/src/crypto/public_key/elliptic/curves.js
+++ b/src/crypto/public_key/elliptic/curves.js
@@ -220,6 +220,11 @@ async function generate(curve) {
   };
 }
 
+/**
+ * Get preferred hash algo to use with the given curve
+ * @param {module:type/oid} oid - curve oid
+ * @returns {module:enums.hash} hash algorithm
+ */
 function getPreferredHashAlgo(oid) {
   return curves[enums.write(enums.curve, oid.toHex())].hash;
 }

--- a/src/enums.js
+++ b/src/enums.js
@@ -448,7 +448,13 @@ export default {
     v5Keys: 4
   },
 
-  /** Asserts validity and converts from string/integer to integer. */
+  /**
+   * Asserts validity of given value and converts from string/integer to integer.
+   * @param {Object} type target enum type
+   * @param {String|Integer} e value to check and/or convert
+   * @returns {Integer} enum value if it exists
+   * @throws {Error} if the value is invalid
+   */
   write: function(type, e) {
     if (typeof e === 'number') {
       e = this.read(type, e);
@@ -461,7 +467,13 @@ export default {
     throw new Error('Invalid enum value.');
   },
 
-  /** Converts from an integer to string. */
+  /**
+   * Converts enum integer value to the corresponding string, if it exists.
+   * @param {Object} type target enum type
+   * @param {Integer} e value to convert
+   * @returns {String} name of enum value if it exists
+   * @throws {Error} if the value is invalid
+   */
   read: function(type, e) {
     if (!type[byValue]) {
       type[byValue] = [];
@@ -476,5 +488,4 @@ export default {
 
     throw new Error('Invalid enum value.');
   }
-
 };

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -115,7 +115,7 @@ export async function createBindingSignature(subkey, primaryKey, options, config
  * @param {Date} [date] - Use the given date for verification instead of the current time
  * @param {Object} [userID] - User ID
  * @param {Object} config - full configuration
- * @returns {Promise<String>}
+ * @returns {Promise<enums.hash>}
  * @async
  */
 export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), userID = {}, config) {

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -147,7 +147,7 @@ export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), us
 
 /**
  * Returns the preferred symmetric/aead/compression algorithm for a set of keys
- * @param {symmetric|aead|compression} type - Type of preference to return
+ * @param {'symmetric'|'aead'|'compression'} type - Type of preference to return
  * @param {Array<Key>} [keys] - Set of keys
  * @param {Date} [date] - Use the given date for verification instead of the current time
  * @param {Array} [userIDs] - User IDs

--- a/src/message.js
+++ b/src/message.js
@@ -507,7 +507,7 @@ export class Message {
     }
 
     const compressed = new CompressedDataPacket(config);
-    compressed.algorithm = enums.read(enums.compression, algo);
+    compressed.algorithm = algo;
     compressed.packets = this.packets;
 
     const packetList = new PacketList();

--- a/src/message.js
+++ b/src/message.js
@@ -862,9 +862,9 @@ export async function createMessage({ text, binary, filename, date = new Date(),
   }
   const literalDataPacket = new LiteralDataPacket(date);
   if (text !== undefined) {
-    literalDataPacket.setText(input, format);
+    literalDataPacket.setText(input, enums.write(enums.literal, format));
   } else {
-    literalDataPacket.setBytes(input, format);
+    literalDataPacket.setBytes(input, enums.write(enums.literal, format));
   }
   if (filename !== undefined) {
     literalDataPacket.setFilename(filename);

--- a/src/message.js
+++ b/src/message.js
@@ -128,7 +128,7 @@ export class Message {
 
       try {
         const algo = enums.write(enums.symmetric, algorithmName);
-        await symEncryptedPacket.decrypt(algo, data, config); // TODO pass integer
+        await symEncryptedPacket.decrypt(algo, data, config);
       } catch (e) {
         util.printDebugError(e);
         exception = e;

--- a/src/message.js
+++ b/src/message.js
@@ -107,7 +107,7 @@ export class Message {
    * @async
    */
   async decrypt(decryptionKeys, passwords, sessionKeys, date = new Date(), config = defaultConfig) {
-    const keyObjs = sessionKeys || await this.decryptSessionKeys(decryptionKeys, passwords, date, config);
+    const sessionKeyObjs = sessionKeys || await this.decryptSessionKeys(decryptionKeys, passwords, date, config);
 
     const symEncryptedPacketlist = this.packets.filterByTag(
       enums.packet.symmetricallyEncryptedData,
@@ -121,13 +121,14 @@ export class Message {
 
     const symEncryptedPacket = symEncryptedPacketlist[0];
     let exception = null;
-    const decryptedPromise = Promise.all(keyObjs.map(async keyObj => {
-      if (!keyObj || !util.isUint8Array(keyObj.data) || !util.isString(keyObj.algorithm)) {
+    const decryptedPromise = Promise.all(sessionKeyObjs.map(async ({ algorithm: algorithmName, data }) => {
+      if (!util.isUint8Array(data) || !util.isString(algorithmName)) {
         throw new Error('Invalid session key for decryption.');
       }
 
       try {
-        await symEncryptedPacket.decrypt(keyObj.algorithm, keyObj.data, config);
+        const algo = enums.write(enums.symmetric, algorithmName);
+        await symEncryptedPacket.decrypt(algo, data, config); // TODO pass integer
       } catch (e) {
         util.printDebugError(e);
         exception = e;
@@ -216,7 +217,7 @@ export class Message {
             }
             try {
               await keyPacket.decrypt(decryptionKeyPacket);
-              if (!algos.includes(enums.write(enums.symmetric, keyPacket.sessionKeyAlgorithm))) {
+              if (!algos.includes(keyPacket.sessionKeyAlgorithm)) {
                 throw new Error('A non-preferred symmetric algorithm was used.');
               }
               keyPackets.push(keyPacket);
@@ -247,7 +248,10 @@ export class Message {
         });
       }
 
-      return keyPackets.map(packet => ({ data: packet.sessionKey, algorithm: packet.sessionKeyAlgorithm }));
+      return keyPackets.map(packet => ({
+        data: packet.sessionKey,
+        algorithm: enums.read(enums.symmetric, packet.sessionKeyAlgorithm)
+      }));
     }
     throw exception || new Error('Session key decryption failed.');
   }
@@ -295,13 +299,14 @@ export class Message {
    * @async
    */
   static async generateSessionKey(encryptionKeys = [], date = new Date(), userIDs = [], config = defaultConfig) {
-    const algorithm = enums.read(enums.symmetric, await getPreferredAlgo('symmetric', encryptionKeys, date, userIDs, config));
-    const aeadAlgorithm = config.aeadProtect && await isAEADSupported(encryptionKeys, date, userIDs, config) ?
+    const algo = await getPreferredAlgo('symmetric', encryptionKeys, date, userIDs, config);
+    const algorithmName = enums.read(enums.symmetric, algo);
+    const aeadAlgorithmName = config.aeadProtect && await isAEADSupported(encryptionKeys, date, userIDs, config) ?
       enums.read(enums.aead, await getPreferredAlgo('aead', encryptionKeys, date, userIDs, config)) :
       undefined;
 
-    const sessionKeyData = await crypto.generateSessionKey(algorithm);
-    return { data: sessionKeyData, algorithm, aeadAlgorithm };
+    const sessionKeyData = await crypto.generateSessionKey(algo);
+    return { data: sessionKeyData, algorithm: algorithmName, aeadAlgorithm: aeadAlgorithmName };
   }
 
   /**
@@ -330,19 +335,20 @@ export class Message {
       throw new Error('No keys, passwords, or session key provided.');
     }
 
-    const { data: sessionKeyData, algorithm, aeadAlgorithm } = sessionKey;
+    const { data: sessionKeyData, algorithm: algorithmName, aeadAlgorithm: aeadAlgorithmName } = sessionKey;
 
-    const msg = await Message.encryptSessionKey(sessionKeyData, algorithm, aeadAlgorithm, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, userIDs, config);
+    const msg = await Message.encryptSessionKey(sessionKeyData, algorithmName, aeadAlgorithmName, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, userIDs, config);
 
     let symEncryptedPacket;
-    if (aeadAlgorithm) {
+    if (aeadAlgorithmName) {
       symEncryptedPacket = new AEADEncryptedDataPacket();
-      symEncryptedPacket.aeadAlgorithm = aeadAlgorithm;
+      symEncryptedPacket.aeadAlgorithm = enums.write(enums.aead, aeadAlgorithmName);
     } else {
       symEncryptedPacket = new SymEncryptedIntegrityProtectedDataPacket();
     }
     symEncryptedPacket.packets = this.packets;
 
+    const algorithm = enums.write(enums.symmetric, algorithmName);
     await symEncryptedPacket.encrypt(algorithm, sessionKeyData, config);
 
     msg.packets.push(symEncryptedPacket);
@@ -353,8 +359,8 @@ export class Message {
   /**
    * Encrypt a session key either with public keys, passwords, or both at once.
    * @param {Uint8Array} sessionKey - session key for encryption
-   * @param {String} algorithm - session key algorithm
-   * @param {String} [aeadAlgorithm] - AEAD algorithm, e.g. 'eax' or 'ocb'
+   * @param {String} algorithmName - session key algorithm
+   * @param {String} [aeadAlgorithmName] - AEAD algorithm, e.g. 'eax' or 'ocb'
    * @param {Array<PublicKey>} [encryptionKeys] - Public key(s) for message encryption
    * @param {Array<String>} [passwords] - For message encryption
    * @param {Boolean} [wildcard] - Use a key ID of 0 instead of the public key IDs
@@ -365,8 +371,10 @@ export class Message {
    * @returns {Promise<Message>} New message with encrypted content.
    * @async
    */
-  static async encryptSessionKey(sessionKey, algorithm, aeadAlgorithm, encryptionKeys, passwords, wildcard = false, encryptionKeyIDs = [], date = new Date(), userIDs = [], config = defaultConfig) {
+  static async encryptSessionKey(sessionKey, algorithmName, aeadAlgorithmName, encryptionKeys, passwords, wildcard = false, encryptionKeyIDs = [], date = new Date(), userIDs = [], config = defaultConfig) {
     const packetlist = new PacketList();
+    const algorithm = enums.write(enums.symmetric, algorithmName);
+    const aeadAlgorithm = aeadAlgorithmName && enums.write(enums.aead, aeadAlgorithmName);
 
     if (encryptionKeys) {
       const results = await Promise.all(encryptionKeys.map(async function(primaryKey, i) {

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -73,8 +73,8 @@ class AEADEncryptedDataPacket {
       if (version !== VERSION) { // The only currently defined value is 1.
         throw new UnsupportedError(`Version ${version} of the AEAD-encrypted data packet is not supported.`);
       }
-      this.cipherAlgorithm = enums.write(enums.symmetric, await reader.readByte());
-      this.aeadAlgorithm = enums.write(enums.aead, await reader.readByte());
+      this.cipherAlgorithm = await reader.readByte();
+      this.aeadAlgorithm = await reader.readByte();
       this.chunkSizeByte = await reader.readByte();
 
       const mode = crypto.getAEADMode(this.aeadAlgorithm);

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -134,9 +134,8 @@ class AEADEncryptedDataPacket {
    * @async
    */
   async crypt(fn, key, data) {
-    const cipherName = enums.read(enums.symmetric, this.cipherAlgorithm);
     const mode = crypto.mode[enums.read(enums.aead, this.aeadAlgorithm)];
-    const modeInstance = await mode(cipherName, key);
+    const modeInstance = await mode(this.cipherAlgorithm, key);
     const tagLengthIfDecrypting = fn === 'decrypt' ? mode.tagLength : 0;
     const tagLengthIfEncrypting = fn === 'encrypt' ? mode.tagLength : 0;
     const chunkSize = 2 ** (this.chunkSizeByte + 6) + tagLengthIfDecrypting; // ((uint64_t)1 << (c + 6))

--- a/src/packet/compressed_data.js
+++ b/src/packet/compressed_data.js
@@ -85,7 +85,7 @@ class CompressedDataPacket {
     await stream.parse(bytes, async reader => {
 
       // One octet that gives the algorithm used to compress the packet.
-      this.algorithm = enums.write(enums.compression, await reader.readByte());
+      this.algorithm = await reader.readByte();
 
       // Compressed data, which makes up the remainder of the packet.
       this.compressed = reader.remainder();

--- a/src/packet/literal_data.js
+++ b/src/packet/literal_data.js
@@ -35,7 +35,7 @@ class LiteralDataPacket {
    * @param {Date} date - The creation date of the literal package
    */
   constructor(date = new Date()) {
-    this.format = 'utf8'; // default format for literal data packets
+    this.format = enums.literal.utf8; // default format for literal data packets
     this.date = util.normalizeDate(date);
     this.text = null; // textual data representation
     this.data = null; // literal data representation
@@ -46,9 +46,9 @@ class LiteralDataPacket {
    * Set the packet data to a javascript native string, end of line
    * will be normalized to \r\n and by default text is converted to UTF8
    * @param {String | ReadableStream<String>} text - Any native javascript string
-   * @param {utf8|binary|text|mime} [format] - The format of the string of bytes
+   * @param {enums.literal} [format] - The format of the string of bytes
    */
-  setText(text, format = 'utf8') {
+  setText(text, format = enums.literal.utf8) {
     this.format = format;
     this.text = text;
     this.data = null;
@@ -70,7 +70,7 @@ class LiteralDataPacket {
   /**
    * Set the packet data to value represented by the provided string of bytes.
    * @param {Uint8Array | ReadableStream<Uint8Array>} bytes - The string of bytes
-   * @param {utf8|binary|text|mime} format - The format of the string of bytes
+   * @param {enums.literal} format - The format of the string of bytes
    */
   setBytes(bytes, format) {
     this.format = format;
@@ -123,7 +123,7 @@ class LiteralDataPacket {
   async read(bytes) {
     await stream.parse(bytes, async reader => {
       // - A one-octet field that describes how the data is formatted.
-      const format = enums.read(enums.literal, await reader.readByte());
+      const format = await reader.readByte(); // enums.literal
 
       const filename_len = await reader.readByte();
       this.filename = util.decodeUTF8(await reader.readBytes(filename_len));
@@ -145,7 +145,7 @@ class LiteralDataPacket {
     const filename = util.encodeUTF8(this.filename);
     const filename_length = new Uint8Array([filename.length]);
 
-    const format = new Uint8Array([enums.write(enums.literal, this.format)]);
+    const format = new Uint8Array([this.format]);
     const date = util.writeDate(this.date);
 
     return util.concatUint8Array([format, filename_length, filename, date]);

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -87,13 +87,13 @@ class OnePassSignaturePacket {
 
     // A one-octet signature type.  Signature types are described in
     //   Section 5.2.1.
-    this.signatureType = enums.write(enums.signature, bytes[mypos++]);
+    this.signatureType = bytes[mypos++];
 
     // A one-octet number describing the hash algorithm used.
-    this.hashAlgorithm = enums.write(enums.hash, bytes[mypos++]);
+    this.hashAlgorithm = bytes[mypos++];
 
     // A one-octet number describing the public-key algorithm used.
-    this.publicKeyAlgorithm = enums.write(enums.publicKey, bytes[mypos++]);
+    this.publicKeyAlgorithm = bytes[mypos++];
 
     // An eight-octet number holding the Key ID of the signing key.
     this.issuerKeyID = new KeyID();

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -46,16 +46,20 @@ class OnePassSignaturePacket {
      * A one-octet signature type.
      * Signature types are described in
      * {@link https://tools.ietf.org/html/rfc4880#section-5.2.1|RFC4880 Section 5.2.1}.
+     * @type {enums.signature}
+
      */
     this.signatureType = null;
     /**
      * A one-octet number describing the hash algorithm used.
      * @see {@link https://tools.ietf.org/html/rfc4880#section-9.4|RFC4880 9.4}
+     * @type {enums.hash}
      */
     this.hashAlgorithm = null;
     /**
      * A one-octet number describing the public-key algorithm used.
      * @see {@link https://tools.ietf.org/html/rfc4880#section-9.1|RFC4880 9.1}
+     * @type {enums.publicKey}
      */
     this.publicKeyAlgorithm = null;
     /** An eight-octet number holding the Key ID of the signing key. */
@@ -83,13 +87,13 @@ class OnePassSignaturePacket {
 
     // A one-octet signature type.  Signature types are described in
     //   Section 5.2.1.
-    this.signatureType = bytes[mypos++];
+    this.signatureType = enums.write(enums.signature, bytes[mypos++]);
 
     // A one-octet number describing the hash algorithm used.
-    this.hashAlgorithm = bytes[mypos++];
+    this.hashAlgorithm = enums.write(enums.hash, bytes[mypos++]);
 
     // A one-octet number describing the public-key algorithm used.
-    this.publicKeyAlgorithm = bytes[mypos++];
+    this.publicKeyAlgorithm = enums.write(enums.publicKey, bytes[mypos++]);
 
     // An eight-octet number holding the Key ID of the signing key.
     this.issuerKeyID = new KeyID();
@@ -109,9 +113,7 @@ class OnePassSignaturePacket {
    * @returns {Uint8Array} A Uint8Array representation of a one-pass signature packet.
    */
   write() {
-    const start = new Uint8Array([VERSION, enums.write(enums.signature, this.signatureType),
-      enums.write(enums.hash, this.hashAlgorithm),
-      enums.write(enums.publicKey, this.publicKeyAlgorithm)]);
+    const start = new Uint8Array([VERSION, this.signatureType, this.hashAlgorithm, this.publicKeyAlgorithm]);
 
     const end = new Uint8Array([this.flags]);
 

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -115,11 +115,7 @@ class PublicKeyPacket {
       pos += 4;
 
       // - A one-octet number denoting the public-key algorithm of this key.
-      try {
-        this.algorithm = enums.write(enums.publicKey, bytes[pos++]);
-      } catch (e) {
-        throw new Error('Error reading public key algorithm');
-      }
+      this.algorithm = bytes[pos++];
 
       if (this.version === 5) {
         // - A four-octet scalar octet count for the following key material.

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -72,7 +72,7 @@ class PublicKeyEncryptedSessionKeyPacket {
       throw new UnsupportedError(`Version ${this.version} of the PKESK packet is unsupported.`);
     }
     this.publicKeyID.read(bytes.subarray(1, bytes.length));
-    this.publicKeyAlgorithm = enums.write(enums.publicKey, bytes[9]);
+    this.publicKeyAlgorithm = bytes[9];
     this.encrypted = crypto.parseEncSessionKeyParams(this.publicKeyAlgorithm, bytes.subarray(10));
   }
 

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -68,7 +68,7 @@ class PublicKeyEncryptedSessionKeyPacket {
       throw new UnsupportedError(`Version ${this.version} of the PKESK packet is unsupported.`);
     }
     this.publicKeyID.read(bytes.subarray(1, bytes.length));
-    this.publicKeyAlgorithm = enums.read(enums.publicKey, bytes[9]);
+    this.publicKeyAlgorithm = enums.read(enums.publicKey, bytes[9]); // TODO use integer
 
     const algo = enums.write(enums.publicKey, this.publicKeyAlgorithm);
     this.encrypted = crypto.parseEncSessionKeyParams(algo, bytes.subarray(10));

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -49,7 +49,7 @@ class SecretKeyPacket extends PublicKeyPacket {
     this.isEncrypted = null;
     /**
      * S2K usage
-     * @type {Integer}
+     * @type {enums.symmetric}
      */
     this.s2kUsage = 0;
     /**
@@ -101,12 +101,12 @@ class SecretKeyPacket extends PublicKeyPacket {
     // - [Optional] If string-to-key usage octet was 255, 254, or 253, a
     //   one-octet symmetric encryption algorithm.
     if (this.s2kUsage === 255 || this.s2kUsage === 254 || this.s2kUsage === 253) {
-      this.symmetric = enums.write(enums.symmetric, bytes[i++]);
+      this.symmetric = bytes[i++];
 
       // - [Optional] If string-to-key usage octet was 253, a one-octet
       //   AEAD algorithm.
       if (this.s2kUsage === 253) {
-        this.aead = enums.write(enums.aead, bytes[i++]);
+        this.aead = bytes[i++];
       }
 
       // - [Optional] If string-to-key usage octet was 255, 254, or 253, a
@@ -119,7 +119,7 @@ class SecretKeyPacket extends PublicKeyPacket {
         return;
       }
     } else if (this.s2kUsage) {
-      this.symmetric = enums.write(enums.symmetric, this.s2kUsage);
+      this.symmetric = this.s2kUsage;
     }
 
     // - [Optional] If secret data is encrypted (string-to-key usage octet

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -301,7 +301,7 @@ class SecretKeyPacket extends PublicKeyPacket {
       this.keyMaterial = await modeInstance.encrypt(cleartext, this.iv.subarray(0, mode.ivLength), new Uint8Array());
     } else {
       this.s2kUsage = 254;
-      this.keyMaterial = await crypto.mode.cfb.encrypt(this.symmetric, key, util.concatUint8Array([
+      this.keyMaterial = await crypto.mode.cfb.encrypt(enums.write(enums.symmetric, this.symmetric), key, util.concatUint8Array([
         cleartext,
         await crypto.hash.sha1(cleartext, config)
       ]), this.iv, config);
@@ -348,7 +348,7 @@ class SecretKeyPacket extends PublicKeyPacket {
         throw err;
       }
     } else {
-      const cleartextWithHash = await crypto.mode.cfb.decrypt(this.symmetric, key, this.keyMaterial, this.iv);
+      const cleartextWithHash = await crypto.mode.cfb.decrypt(enums.write(enums.symmetric, this.symmetric), key, this.keyMaterial, this.iv);
 
       cleartext = cleartextWithHash.subarray(0, -20);
       const hash = await crypto.hash.sha1(cleartext);

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -61,7 +61,7 @@ class SecretKeyPacket extends PublicKeyPacket {
      * Symmetric algorithm
      * @type {String}
      */
-    this.symmetric = null;
+    this.symmetric = null; // TODO change
     /**
      * AEAD algorithm
      * @type {String}
@@ -297,7 +297,7 @@ class SecretKeyPacket extends PublicKeyPacket {
       this.s2kUsage = 253;
       this.aead = 'eax';
       const mode = crypto.mode[this.aead];
-      const modeInstance = await mode(this.symmetric, key);
+      const modeInstance = await mode(enums.write(enums.symmetric, this.symmetric), key);
       this.keyMaterial = await modeInstance.encrypt(cleartext, this.iv.subarray(0, mode.ivLength), new Uint8Array());
     } else {
       this.s2kUsage = 254;
@@ -339,7 +339,7 @@ class SecretKeyPacket extends PublicKeyPacket {
     if (this.s2kUsage === 253) {
       const mode = crypto.mode[this.aead];
       try {
-        const modeInstance = await mode(this.symmetric, key);
+        const modeInstance = await mode(enums.write(enums.symmetric, this.symmetric), key);
         cleartext = await modeInstance.decrypt(this.keyMaterial, this.iv.subarray(0, mode.ivLength), new Uint8Array());
       } catch (err) {
         if (err.message === 'Authentication tag mismatch') {

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -155,8 +155,7 @@ class SecretKeyPacket extends PublicKeyPacket {
         throw new Error('Key checksum mismatch');
       }
       try {
-        const algo = enums.write(enums.publicKey, this.algorithm);
-        const { privateParams } = crypto.parsePrivateKeyParams(algo, cleartext, this.publicParams);
+        const { privateParams } = crypto.parsePrivateKeyParams(this.algorithm, cleartext, this.publicParams);
         this.privateParams = privateParams;
       } catch (err) {
         throw new Error('Error reading MPIs');
@@ -205,8 +204,7 @@ class SecretKeyPacket extends PublicKeyPacket {
 
     if (!this.isDummy()) {
       if (!this.s2kUsage) {
-        const algo = enums.write(enums.publicKey, this.algorithm);
-        this.keyMaterial = crypto.serializeParams(algo, this.privateParams);
+        this.keyMaterial = crypto.serializeParams(this.algorithm, this.privateParams);
       }
 
       if (this.version === 5) {
@@ -289,8 +287,7 @@ class SecretKeyPacket extends PublicKeyPacket {
 
     this.s2k = new S2K(config);
     this.s2k.salt = await crypto.random.getRandomBytes(8);
-    const algo = enums.write(enums.publicKey, this.algorithm);
-    const cleartext = crypto.serializeParams(algo, this.privateParams);
+    const cleartext = crypto.serializeParams(this.algorithm, this.privateParams);
     this.symmetric = 'aes256';
     const key = await produceEncryptionKey(this.s2k, passphrase, this.symmetric);
     const blockLen = crypto.cipher[this.symmetric].blockSize;

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -111,9 +111,9 @@ class SignaturePacket {
       throw new UnsupportedError(`Version ${this.version} of the signature packet is unsupported.`);
     }
 
-    this.signatureType = bytes[i++];
-    this.publicKeyAlgorithm = bytes[i++];
-    this.hashAlgorithm = bytes[i++];
+    this.signatureType = enums.write(enums.signature, bytes[i++]);
+    this.publicKeyAlgorithm = enums.write(enums.publicKey, bytes[i++]);
+    this.hashAlgorithm = enums.write(enums.hash, bytes[i++]);
 
     // hashed subpackets
     i += this.readSubPackets(bytes.subarray(i, bytes.length), true);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -114,9 +114,9 @@ class SignaturePacket {
       throw new UnsupportedError(`Version ${this.version} of the signature packet is unsupported.`);
     }
 
-    this.signatureType = enums.write(enums.signature, bytes[i++]);
-    this.publicKeyAlgorithm = enums.write(enums.publicKey, bytes[i++]);
-    this.hashAlgorithm = enums.write(enums.hash, bytes[i++]);
+    this.signatureType = bytes[i++];
+    this.publicKeyAlgorithm = bytes[i++];
+    this.hashAlgorithm = bytes[i++];
 
     // hashed subpackets
     i += this.readSubPackets(bytes.subarray(i, bytes.length), true);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -50,8 +50,11 @@ class SignaturePacket {
 
   constructor() {
     this.version = null;
+    /** @type {enums.signature} */
     this.signatureType = null;
+    /** @type {enums.hash} */
     this.hashAlgorithm = null;
+    /** @type {enums.publicKey} */
     this.publicKeyAlgorithm = null;
 
     this.signatureData = null;
@@ -170,15 +173,12 @@ class SignaturePacket {
    * @async
    */
   async sign(key, data, date = new Date(), detached = false) {
-    const signatureType = enums.write(enums.signature, this.signatureType);
-    const hashAlgorithm = enums.write(enums.hash, this.hashAlgorithm);
-
     if (key.version === 5) {
       this.version = 5;
     } else {
       this.version = 4;
     }
-    const arr = [new Uint8Array([this.version, signatureType, this.publicKeyAlgorithm, hashAlgorithm])];
+    const arr = [new Uint8Array([this.version, this.signatureType, this.publicKeyAlgorithm, this.hashAlgorithm])];
 
     this.created = util.normalizeDate(date);
     this.issuerKeyVersion = key.version;
@@ -190,12 +190,12 @@ class SignaturePacket {
 
     this.signatureData = util.concat(arr);
 
-    const toHash = this.toHash(signatureType, data, detached);
-    const hash = await this.hash(signatureType, data, toHash, detached);
+    const toHash = this.toHash(this.signatureType, data, detached);
+    const hash = await this.hash(this.signatureType, data, toHash, detached);
 
     this.signedHashValue = stream.slice(stream.clone(hash), 0, 2);
     const signed = async () => crypto.signature.sign(
-      this.publicKeyAlgorithm, hashAlgorithm, key.publicParams, key.privateParams, toHash, await stream.readToEnd(hash)
+      this.publicKeyAlgorithm, this.hashAlgorithm, key.publicParams, key.privateParams, toHash, await stream.readToEnd(hash)
     );
     if (util.isStream(hash)) {
       this.params = signed();
@@ -643,9 +643,8 @@ class SignaturePacket {
   }
 
   async hash(signatureType, data, toHash, detached = false) {
-    const hashAlgorithm = enums.write(enums.hash, this.hashAlgorithm);
     if (!toHash) toHash = this.toHash(signatureType, data, detached);
-    return crypto.hash.digest(hashAlgorithm, toHash);
+    return crypto.hash.digest(this.hashAlgorithm, toHash);
   }
 
   /**
@@ -661,7 +660,6 @@ class SignaturePacket {
    * @async
    */
   async verify(key, signatureType, data, date = new Date(), detached = false, config = defaultConfig) {
-    const hashAlgorithm = enums.write(enums.hash, this.hashAlgorithm);
     if (!this.issuerKeyID.equals(key.getKeyID())) {
       throw new Error('Signature was not issued by the given public key');
     }
@@ -691,7 +689,7 @@ class SignaturePacket {
       this.params = await this.params;
 
       this[verified] = await crypto.signature.verify(
-        this.publicKeyAlgorithm, hashAlgorithm, this.params, key.publicParams,
+        this.publicKeyAlgorithm, this.hashAlgorithm, this.params, key.publicParams,
         toHash, hash
       );
 
@@ -707,12 +705,12 @@ class SignaturePacket {
     if (normDate && normDate >= this.getExpirationTime()) {
       throw new Error('Signature is expired');
     }
-    if (config.rejectHashAlgorithms.has(hashAlgorithm)) {
-      throw new Error('Insecure hash algorithm: ' + enums.read(enums.hash, hashAlgorithm).toUpperCase());
+    if (config.rejectHashAlgorithms.has(this.hashAlgorithm)) {
+      throw new Error('Insecure hash algorithm: ' + enums.read(enums.hash, this.hashAlgorithm).toUpperCase());
     }
-    if (config.rejectMessageHashAlgorithms.has(hashAlgorithm) &&
+    if (config.rejectMessageHashAlgorithms.has(this.hashAlgorithm) &&
       [enums.signature.binary, enums.signature.text].includes(this.signatureType)) {
-      throw new Error('Insecure message hash algorithm: ' + enums.read(enums.hash, hashAlgorithm).toUpperCase());
+      throw new Error('Insecure message hash algorithm: ' + enums.read(enums.hash, this.hashAlgorithm).toUpperCase());
     }
     this.rawNotations.forEach(({ name, critical }) => {
       if (critical && (config.knownNotations.indexOf(name) < 0)) {

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -88,8 +88,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @async
    */
   async encrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
-    const algorithmName = enums.read(enums.symmetric, sessionKeyAlgorithm);
-    const { blockSize } = crypto.cipher[algorithmName];
+    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
 
     let bytes = this.packets.write();
     if (stream.isArrayStream(bytes)) bytes = await stream.readToEnd(bytes);
@@ -114,8 +113,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @async
    */
   async decrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
-    const algorithmName = enums.read(enums.symmetric, sessionKeyAlgorithm);
-    const { blockSize } = crypto.cipher[algorithmName];
+    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
     let encrypted = stream.clone(this.encrypted);
     if (stream.isArrayStream(encrypted)) encrypted = await stream.readToEnd(encrypted);
     const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(blockSize));

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -100,7 +100,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
     const hash = await crypto.hash.sha1(stream.passiveClone(tohash));
     const plaintext = util.concat([tohash, hash]);
 
-    this.encrypted = await crypto.mode.cfb.encrypt(algorithmName, key, plaintext, new Uint8Array(blockSize), config);
+    this.encrypted = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(blockSize), config);
     return true;
   }
 
@@ -118,7 +118,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
     const { blockSize } = crypto.cipher[algorithmName];
     let encrypted = stream.clone(this.encrypted);
     if (stream.isArrayStream(encrypted)) encrypted = await stream.readToEnd(encrypted);
-    const decrypted = await crypto.mode.cfb.decrypt(algorithmName, key, encrypted, new Uint8Array(blockSize));
+    const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(blockSize));
 
     // there must be a modification detection code packet as the
     // last packet and everything gets hashed except the hash itself

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -80,13 +80,17 @@ class SymEncryptedIntegrityProtectedDataPacket {
 
   /**
    * Encrypt the payload in the packet.
-   * @param {String} sessionKeyAlgorithm - The selected symmetric encryption algorithm to be used e.g. 'aes128'
+   * @param {enums.symmetric} sessionKeyAlgorithm - The symmetric encryption algorithm to use
    * @param {Uint8Array} key - The key of cipher blocksize length to be used
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}
+   * @throws {Error} on encryption failure
    * @async
    */
   async encrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
+    const algorithmName = enums.read(enums.symmetric, sessionKeyAlgorithm);
+    const { blockSize } = crypto.cipher[algorithmName];
+
     let bytes = this.packets.write();
     if (stream.isArrayStream(bytes)) bytes = await stream.readToEnd(bytes);
     const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
@@ -96,22 +100,25 @@ class SymEncryptedIntegrityProtectedDataPacket {
     const hash = await crypto.hash.sha1(stream.passiveClone(tohash));
     const plaintext = util.concat([tohash, hash]);
 
-    this.encrypted = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize), config);
+    this.encrypted = await crypto.mode.cfb.encrypt(algorithmName, key, plaintext, new Uint8Array(blockSize), config);
     return true;
   }
 
   /**
    * Decrypts the encrypted data contained in the packet.
-   * @param {String} sessionKeyAlgorithm - The selected symmetric encryption algorithm to be used e.g. 'aes128'
+   * @param {enums.symmetric} sessionKeyAlgorithm - The selected symmetric encryption algorithm to be used
    * @param {Uint8Array} key - The key of cipher blocksize length to be used
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Boolean>}
+   * @throws {Error} on decryption failure
    * @async
    */
   async decrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
+    const algorithmName = enums.read(enums.symmetric, sessionKeyAlgorithm);
+    const { blockSize } = crypto.cipher[algorithmName];
     let encrypted = stream.clone(this.encrypted);
     if (stream.isArrayStream(encrypted)) encrypted = await stream.readToEnd(encrypted);
-    const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(crypto.cipher[sessionKeyAlgorithm].blockSize));
+    const decrypted = await crypto.mode.cfb.decrypt(algorithmName, key, encrypted, new Uint8Array(blockSize));
 
     // there must be a modification detection code packet as the
     // last packet and everything gets hashed except the hash itself
@@ -126,7 +133,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
       }
       return new Uint8Array();
     });
-    const bytes = stream.slice(tohash, crypto.cipher[sessionKeyAlgorithm].blockSize + 2); // Remove random prefix
+    const bytes = stream.slice(tohash, blockSize + 2); // Remove random prefix
     let packetbytes = stream.slice(bytes, 0, -2); // Remove MDC packet
     packetbytes = stream.concat([packetbytes, stream.fromAsync(() => verifyHash)]);
     if (!util.isStream(encrypted) || !config.allowUnauthenticatedStream) {

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -46,9 +46,21 @@ class SymEncryptedSessionKeyPacket {
   constructor(config = defaultConfig) {
     this.version = config.aeadProtect ? 5 : 4;
     this.sessionKey = null;
+    /**
+     * Algorithm to encrypt the session key with
+     * @type {enums.symmetric}
+     */
     this.sessionKeyEncryptionAlgorithm = null;
-    this.sessionKeyAlgorithm = 'aes256';
-    this.aeadAlgorithm = enums.read(enums.aead, config.preferredAEADAlgorithm);
+    /**
+     * Algorithm to encrypt the message with
+     * @type {enums.symmetric}
+     */
+    this.sessionKeyAlgorithm = enums.symmetric.aes256;
+    /**
+     * AEAD mode to encrypt the session key with (if AEAD protection is enabled)
+     * @type {enums.aead}
+     */
+    this.aeadAlgorithm = enums.write(enums.aead, config.preferredAEADAlgorithm);
     this.encrypted = null;
     this.s2k = null;
     this.iv = null;
@@ -69,11 +81,11 @@ class SymEncryptedSessionKeyPacket {
     }
 
     // A one-octet number describing the symmetric algorithm used.
-    const algo = enums.read(enums.symmetric, bytes[offset++]);
+    const algo = enums.write(enums.symmetric, bytes[offset++]);
 
     if (this.version === 5) {
       // A one-octet AEAD algorithm.
-      this.aeadAlgorithm = enums.read(enums.aead, bytes[offset++]);
+      this.aeadAlgorithm = enums.write(enums.aead, bytes[offset++]);
     }
 
     // A string-to-key (S2K) specifier, length as defined above.
@@ -81,7 +93,8 @@ class SymEncryptedSessionKeyPacket {
     offset += this.s2k.read(bytes.subarray(offset, bytes.length));
 
     if (this.version === 5) {
-      const mode = crypto.mode[this.aeadAlgorithm];
+      const aeadAlgoName = enums.read(enums.aead, this.aeadAlgorithm);
+      const mode = crypto.mode[aeadAlgoName];
 
       // A starting initialization vector of size specified by the AEAD
       // algorithm.
@@ -111,9 +124,9 @@ class SymEncryptedSessionKeyPacket {
     let bytes;
 
     if (this.version === 5) {
-      bytes = util.concatUint8Array([new Uint8Array([this.version, enums.write(enums.symmetric, algo), enums.write(enums.aead, this.aeadAlgorithm)]), this.s2k.write(), this.iv, this.encrypted]);
+      bytes = util.concatUint8Array([new Uint8Array([this.version, algo, this.aeadAlgorithm]), this.s2k.write(), this.iv, this.encrypted]);
     } else {
-      bytes = util.concatUint8Array([new Uint8Array([this.version, enums.write(enums.symmetric, algo)]), this.s2k.write()]);
+      bytes = util.concatUint8Array([new Uint8Array([this.version, algo]), this.s2k.write()]);
 
       if (this.encrypted !== null) {
         bytes = util.concatUint8Array([bytes, this.encrypted]);
@@ -124,7 +137,7 @@ class SymEncryptedSessionKeyPacket {
   }
 
   /**
-   * Decrypts the session key
+   * Decrypts the session key with the given passphrase
    * @param {String} passphrase - The passphrase in string form
    * @throws {Error} if decryption was not successful
    * @async
@@ -134,18 +147,22 @@ class SymEncryptedSessionKeyPacket {
       this.sessionKeyEncryptionAlgorithm :
       this.sessionKeyAlgorithm;
 
-    const length = crypto.cipher[algo].keySize;
+    const algoName = enums.read(enums.symmetric, algo);
+    const aeadAlgoName = enums.read(enums.aead, this.aeadAlgorithm)
+
+    const blockCipher = crypto.cipher[algoName];
+    const length = blockCipher.keySize;
     const key = await this.s2k.produceKey(passphrase, length);
 
     if (this.version === 5) {
-      const mode = crypto.mode[this.aeadAlgorithm];
-      const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-      const modeInstance = await mode(algo, key);
+      const mode = crypto.mode[aeadAlgoName];
+      const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
+      const modeInstance = await mode(algoName, key);
       this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
     } else if (this.encrypted !== null) {
-      const decrypted = await crypto.mode.cfb.decrypt(algo, key, this.encrypted, new Uint8Array(crypto.cipher[algo].blockSize));
+      const decrypted = await crypto.mode.cfb.decrypt(algoName, key, this.encrypted, new Uint8Array(blockCipher.blockSize)); // TODO pass integer
 
-      this.sessionKeyAlgorithm = enums.read(enums.symmetric, decrypted[0]);
+      this.sessionKeyAlgorithm = enums.write(enums.symmetric, decrypted[0]);
       this.sessionKey = decrypted.subarray(1, decrypted.length);
     } else {
       this.sessionKey = key;
@@ -153,7 +170,7 @@ class SymEncryptedSessionKeyPacket {
   }
 
   /**
-   * Encrypts the session key
+   * Encrypts the session key with the given passphrase
    * @param {String} passphrase - The passphrase in string form
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @throws {Error} if encryption was not successful
@@ -169,23 +186,28 @@ class SymEncryptedSessionKeyPacket {
     this.s2k = new S2K(config);
     this.s2k.salt = await crypto.random.getRandomBytes(8);
 
-    const length = crypto.cipher[algo].keySize;
-    const key = await this.s2k.produceKey(passphrase, length);
+    const algoName = enums.read(enums.symmetric, algo);
+    const blockCipher = crypto.cipher[algoName];
+    const length = blockCipher.keySize;
+    const encryptionKey = await this.s2k.produceKey(passphrase, length);
 
     if (this.sessionKey === null) {
       this.sessionKey = await crypto.generateSessionKey(this.sessionKeyAlgorithm);
     }
 
     if (this.version === 5) {
-      const mode = crypto.mode[this.aeadAlgorithm];
+      const aeadAlgoName = enums.read(enums.aead, this.aeadAlgorithm);
+      const mode = crypto.mode[aeadAlgoName];
       this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
-      const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-      const modeInstance = await mode(algo, key);
-      this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, adata);
+      const associatedData = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
+      const modeInstance = await mode(algoName, encryptionKey);
+      this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, associatedData);
     } else {
-      const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
-      const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
-      this.encrypted = await crypto.mode.cfb.encrypt(algo, key, private_key, new Uint8Array(crypto.cipher[algo].blockSize), config);
+      const toEncrypt = util.concatUint8Array([
+        new Uint8Array([this.sessionKeyAlgorithm]),
+        this.sessionKey
+      ]);
+      this.encrypted = await crypto.mode.cfb.encrypt(algoName, encryptionKey, toEncrypt, new Uint8Array(blockCipher.blockSize), config);
     }
   }
 }

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -157,7 +157,7 @@ class SymEncryptedSessionKeyPacket {
     if (this.version === 5) {
       const mode = crypto.mode[aeadAlgoName];
       const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
-      const modeInstance = await mode(algoName, key);
+      const modeInstance = await mode(algo, key);
       this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
     } else if (this.encrypted !== null) {
       const decrypted = await crypto.mode.cfb.decrypt(algoName, key, this.encrypted, new Uint8Array(blockCipher.blockSize)); // TODO pass integer
@@ -187,7 +187,7 @@ class SymEncryptedSessionKeyPacket {
     this.s2k.salt = await crypto.random.getRandomBytes(8);
 
     const algoName = enums.read(enums.symmetric, algo);
-    const blockCipher = crypto.cipher[algoName];
+    const blockCipher = crypto.cipher[algoName]; // TODO add crypto.getCipher()?
     const length = blockCipher.keySize;
     const encryptionKey = await this.s2k.produceKey(passphrase, length);
 
@@ -200,7 +200,7 @@ class SymEncryptedSessionKeyPacket {
       const mode = crypto.mode[aeadAlgoName];
       this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
       const associatedData = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
-      const modeInstance = await mode(algoName, encryptionKey);
+      const modeInstance = await mode(algo, encryptionKey);
       this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, associatedData);
     } else {
       const toEncrypt = util.concatUint8Array([

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -81,11 +81,11 @@ class SymEncryptedSessionKeyPacket {
     }
 
     // A one-octet number describing the symmetric algorithm used.
-    const algo = enums.write(enums.symmetric, bytes[offset++]);
+    const algo = bytes[offset++];
 
     if (this.version === 5) {
       // A one-octet AEAD algorithm.
-      this.aeadAlgorithm = enums.write(enums.aead, bytes[offset++]);
+      this.aeadAlgorithm = bytes[offset++];
     }
 
     // A string-to-key (S2K) specifier, length as defined above.

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -160,7 +160,7 @@ class SymEncryptedSessionKeyPacket {
       const modeInstance = await mode(algo, key);
       this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
     } else if (this.encrypted !== null) {
-      const decrypted = await crypto.mode.cfb.decrypt(algoName, key, this.encrypted, new Uint8Array(blockCipher.blockSize)); // TODO pass integer
+      const decrypted = await crypto.mode.cfb.decrypt(algo, key, this.encrypted, new Uint8Array(blockCipher.blockSize)); // TODO pass integer
 
       this.sessionKeyAlgorithm = enums.write(enums.symmetric, decrypted[0]);
       this.sessionKey = decrypted.subarray(1, decrypted.length);
@@ -207,7 +207,7 @@ class SymEncryptedSessionKeyPacket {
         new Uint8Array([this.sessionKeyAlgorithm]),
         this.sessionKey
       ]);
-      this.encrypted = await crypto.mode.cfb.encrypt(algoName, encryptionKey, toEncrypt, new Uint8Array(blockCipher.blockSize), config);
+      this.encrypted = await crypto.mode.cfb.encrypt(algo, encryptionKey, toEncrypt, new Uint8Array(blockCipher.blockSize), config);
     }
   }
 }

--- a/src/packet/symmetrically_encrypted_data.js
+++ b/src/packet/symmetrically_encrypted_data.js
@@ -85,9 +85,8 @@ class SymmetricallyEncryptedDataPacket {
     if (!config.allowUnauthenticatedMessages) {
       throw new Error('Message is not authenticated.');
     }
-    const algoName = enums.read(enums.symmetric, sessionKeyAlgorithm);
-    const { blockSize } = crypto.cipher[algoName];
 
+    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
     const encrypted = await stream.readToEnd(stream.clone(this.encrypted));
     const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key,
       encrypted.subarray(blockSize + 2),
@@ -108,8 +107,7 @@ class SymmetricallyEncryptedDataPacket {
    */
   async encrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
     const data = this.packets.write();
-    const algoName = enums.read(enums.symmetric, sessionKeyAlgorithm);
-    const { blockSize } = crypto.cipher[algoName];
+    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
 
     const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
     const FRE = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, prefix, new Uint8Array(blockSize), config);

--- a/src/packet/symmetrically_encrypted_data.js
+++ b/src/packet/symmetrically_encrypted_data.js
@@ -89,7 +89,7 @@ class SymmetricallyEncryptedDataPacket {
     const { blockSize } = crypto.cipher[algoName];
 
     const encrypted = await stream.readToEnd(stream.clone(this.encrypted));
-    const decrypted = await crypto.mode.cfb.decrypt(algoName, key,
+    const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key,
       encrypted.subarray(blockSize + 2),
       encrypted.subarray(2, blockSize + 2)
     );
@@ -112,8 +112,8 @@ class SymmetricallyEncryptedDataPacket {
     const { blockSize } = crypto.cipher[algoName];
 
     const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
-    const FRE = await crypto.mode.cfb.encrypt(algoName, key, prefix, new Uint8Array(blockSize), config);
-    const ciphertext = await crypto.mode.cfb.encrypt(algoName, key, data, FRE.subarray(2), config);
+    const FRE = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, prefix, new Uint8Array(blockSize), config);
+    const ciphertext = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, data, FRE.subarray(2), config);
     this.encrypted = util.concat([FRE, ciphertext]);
   }
 }

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -72,9 +72,6 @@ class S2K {
     let i = 0;
     this.type = enums.read(enums.s2k, bytes[i++]);
     this.algorithm = bytes[i++];
-    if (this.type !== 'gnu') {
-      this.algorithm = enums.write(enums.hash, this.algorithm);
-    }
 
     switch (this.type) {
       case 'simple':

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -39,13 +39,13 @@ class S2K {
    */
   constructor(config = defaultConfig) {
     /** @type {module:enums.hash} */
-    this.algorithm = 'sha256';
+    this.algorithm = enums.hash.sha256;
     /** @type {module:enums.s2k} */
     this.type = 'iterated';
     /** @type {Integer} */
     this.c = config.s2kIterationCountByte;
     /** Eight bytes of salt in a binary string.
-     * @type {String}
+     * @type {Uint8Array}
      */
     this.salt = null;
   }
@@ -59,7 +59,7 @@ class S2K {
 
   /**
    * Parsing function for a string-to-key specifier ({@link https://tools.ietf.org/html/rfc4880#section-3.7|RFC 4880 3.7}).
-   * @param {String} bytes - Payload of string-to-key specifier
+   * @param {Uint8Array} bytes - Payload of string-to-key specifier
    * @returns {Integer} Actual length of the object.
    */
   read(bytes) {
@@ -67,7 +67,7 @@ class S2K {
     this.type = enums.read(enums.s2k, bytes[i++]);
     this.algorithm = bytes[i++];
     if (this.type !== 'gnu') {
-      this.algorithm = enums.read(enums.hash, this.algorithm);
+      this.algorithm = enums.write(enums.hash, this.algorithm);
     }
 
     switch (this.type) {
@@ -117,8 +117,7 @@ class S2K {
     if (this.type === 'gnu-dummy') {
       return new Uint8Array([101, 0, ...util.stringToUint8Array('GNU'), 1]);
     }
-
-    const arr = [new Uint8Array([enums.write(enums.s2k, this.type), enums.write(enums.hash, this.algorithm)])];
+    const arr = [new Uint8Array([enums.write(enums.s2k, this.type), this.algorithm])];
 
     switch (this.type) {
       case 'simple':
@@ -149,7 +148,6 @@ class S2K {
    */
   async produceKey(passphrase, numBytes) {
     passphrase = util.encodeUTF8(passphrase);
-    const algorithm = enums.write(enums.hash, this.algorithm);
 
     const arr = [];
     let rlength = 0;
@@ -180,7 +178,7 @@ class S2K {
         default:
           throw new Error('Unknown s2k type.');
       }
-      const result = await crypto.hash.digest(algorithm, toHash);
+      const result = await crypto.hash.digest(this.algorithm, toHash);
       arr.push(result);
       rlength += result.length;
       prefixlen++;

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -38,9 +38,15 @@ class S2K {
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    */
   constructor(config = defaultConfig) {
-    /** @type {module:enums.hash} */
+    /**
+     * Hash function identifier, or 0 for gnu-dummy keys
+     * @type {module:enums.hash | 0}
+     */
     this.algorithm = enums.hash.sha256;
-    /** @type {module:enums.s2k} */
+    /**
+     * enums.s2k identifier or 'gnu-dummy'
+     * @type {String}
+     */
     this.type = 'iterated';
     /** @type {Integer} */
     this.c = config.s2kIterationCountByte;

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -242,8 +242,8 @@ module.exports = () => describe('API functional testing', function() {
         const algo = openpgp.enums.write(openpgp.enums.symmetric, algoName);
         const symmKey = await crypto.generateSessionKey(algo);
         const IV = new Uint8Array(crypto.cipher[algoName].blockSize);
-        const symmencData = await crypto.mode.cfb.encrypt(algoName, symmKey, util.stringToUint8Array(plaintext), IV, openpgp.config);
-        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algoName, symmKey, symmencData, new Uint8Array(crypto.cipher[algoName].blockSize)));
+        const symmencData = await crypto.mode.cfb.encrypt(algo, symmKey, util.stringToUint8Array(plaintext), IV, openpgp.config);
+        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algo, symmKey, symmencData, new Uint8Array(crypto.cipher[algoName].blockSize)));
         expect(text).to.equal(plaintext);
       }));
     }

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -233,17 +233,17 @@ module.exports = () => describe('API functional testing', function() {
   });
 
   describe('Encrypt and decrypt', function () {
-    let symmAlgos = Object.keys(openpgp.enums.symmetric);
-    symmAlgos = symmAlgos.filter(function(algo) {
-      return algo !== 'idea' && algo !== 'plaintext';
-    });
+    const symmAlgoNames = Object.keys(openpgp.enums.symmetric).filter(
+      algo => algo !== 'idea' && algo !== 'plaintext'
+    );
 
     async function testCFB(plaintext) {
-      await Promise.all(symmAlgos.map(async function(algo) {
+      await Promise.all(symmAlgoNames.map(async function(algoName) {
+        const algo = openpgp.enums.write(openpgp.enums.symmetric, algoName);
         const symmKey = await crypto.generateSessionKey(algo);
-        const IV = new Uint8Array(crypto.cipher[algo].blockSize);
-        const symmencData = await crypto.mode.cfb.encrypt(algo, symmKey, util.stringToUint8Array(plaintext), IV, openpgp.config);
-        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algo, symmKey, symmencData, new Uint8Array(crypto.cipher[algo].blockSize)));
+        const IV = new Uint8Array(crypto.cipher[algoName].blockSize);
+        const symmencData = await crypto.mode.cfb.encrypt(algoName, symmKey, util.stringToUint8Array(plaintext), IV, openpgp.config);
+        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algoName, symmKey, symmencData, new Uint8Array(crypto.cipher[algoName].blockSize)));
         expect(text).to.equal(plaintext);
       }));
     }
@@ -255,7 +255,7 @@ module.exports = () => describe('API functional testing', function() {
     });
 
     it('Asymmetric using RSA with eme_pkcs1 padding', async function () {
-      const symmKey = await crypto.generateSessionKey('aes256');
+      const symmKey = await crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
       return crypto.publicKeyEncrypt(algoRSA, RSAPublicParams, symmKey).then(RSAEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoRSA, RSAPublicParams, RSAPrivateParams, RSAEncryptedData
@@ -266,7 +266,7 @@ module.exports = () => describe('API functional testing', function() {
     });
 
     it('Asymmetric using Elgamal with eme_pkcs1 padding', async function () {
-      const symmKey = await crypto.generateSessionKey('aes256');
+      const symmKey = await crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
       return crypto.publicKeyEncrypt(algoElGamal, elGamalPublicParams, symmKey).then(ElgamalEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoElGamal, elGamalPublicParams, elGamalPrivateParams, ElgamalEncryptedData

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -240,10 +240,11 @@ module.exports = () => describe('API functional testing', function() {
     async function testCFB(plaintext) {
       await Promise.all(symmAlgoNames.map(async function(algoName) {
         const algo = openpgp.enums.write(openpgp.enums.symmetric, algoName);
+        const { blockSize } = crypto.getCipher(algo);
         const symmKey = await crypto.generateSessionKey(algo);
-        const IV = new Uint8Array(crypto.cipher[algoName].blockSize);
+        const IV = new Uint8Array(blockSize);
         const symmencData = await crypto.mode.cfb.encrypt(algo, symmKey, util.stringToUint8Array(plaintext), IV, openpgp.config);
-        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algo, symmKey, symmencData, new Uint8Array(crypto.cipher[algoName].blockSize)));
+        const text = util.uint8ArrayToString(await crypto.mode.cfb.decrypt(algo, symmKey, symmencData, new Uint8Array(blockSize)));
         expect(text).to.equal(plaintext);
       }));
     }

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -1,7 +1,7 @@
 // Modified by ProtonTech AG
 
 // Adapted from https://github.com/artjomb/cryptojs-extension/blob/8c61d159/test/eax.js
-
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const EAX = require('../../src/crypto/mode/eax');
 const util = require('../../src/util');
 
@@ -87,7 +87,7 @@ function testAESEAX() {
       }
     ];
 
-    const cipher = 'aes128';
+    const cipher = openpgp.enums.symmetric.aes128;
 
     await Promise.all(vectors.map(async vec => {
       const keyBytes = util.hexToUint8Array(vec.key);

--- a/test/crypto/gcm.js
+++ b/test/crypto/gcm.js
@@ -35,7 +35,7 @@ module.exports = () => describe('Symmetric AES-GCM (experimental)', function() {
 
   function testAESGCM(plaintext, nativeEncrypt, nativeDecrypt) {
     const aesAlgoNames = Object.keys(openpgp.enums.symmetric).filter(
-      algo => algo.substr(0,3) === 'aes'
+      algoName => algoName.substr(0,3) === 'aes'
     );
     aesAlgoNames.forEach(function(algoName) {
       it(algoName, async function() {

--- a/test/crypto/gcm.js
+++ b/test/crypto/gcm.js
@@ -52,12 +52,12 @@ module.exports = () => describe('Symmetric AES-GCM (experimental)', function() {
         const nativeDecryptSpy = webCrypto ? sinonSandbox.spy(webCrypto, 'decrypt') : sinonSandbox.spy(nodeCrypto, 'createDecipheriv');
 
         nativeEncrypt || disableNative();
-        let modeInstance = await crypto.mode.gcm(algoName, key);
+        let modeInstance = await crypto.mode.gcm(algo, key);
         const ciphertext = await modeInstance.encrypt(util.stringToUint8Array(plaintext), iv);
         enableNative();
 
         nativeDecrypt || disableNative();
-        modeInstance = await crypto.mode.gcm(algoName, key);
+        modeInstance = await crypto.mode.gcm(algo, key);
         const decrypted = await modeInstance.decrypt(util.stringToUint8Array(util.uint8ArrayToString(ciphertext)), iv);
         enableNative();
 

--- a/test/crypto/ocb.js
+++ b/test/crypto/ocb.js
@@ -1,7 +1,7 @@
 // Modified by ProtonTech AG
 
 // Adapted from https://github.com/artjomb/cryptojs-extension/blob/8c61d159/test/eax.js
-
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../..');
 const OCB = require('../../src/crypto/mode/ocb');
 const util = require('../../src/util');
 
@@ -115,7 +115,7 @@ module.exports = () => describe('Symmetric AES-OCB', function() {
       }
     ];
 
-    const cipher = 'aes128';
+    const cipher = openpgp.enums.symmetric.aes128;
 
     await Promise.all(vectors.map(async vec => {
       const msgBytes = util.hexToUint8Array(vec.P);
@@ -163,7 +163,8 @@ module.exports = () => describe('Symmetric AES-OCB', function() {
       const k = new Uint8Array(keylen / 8);
       k[k.length - 1] = taglen;
 
-      const ocb = await OCB('aes' + keylen, k);
+      const algo = openpgp.enums.write(openpgp.enums.symmetric, 'aes' + keylen);
+      const ocb = await OCB(algo, k);
 
       const c = [];
       let n;

--- a/test/crypto/rsa.js
+++ b/test/crypto/rsa.js
@@ -79,7 +79,7 @@ module.exports = () => describe('basic RSA cryptography', function () {
     const bits = 1024;
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);
     const { n, e, d, p, q, u } = { ...publicParams, ...privateParams };
-    const message = await crypto.generateSessionKey('aes256');
+    const message = await crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
     const encrypted = await crypto.publicKey.rsa.encrypt(message, n, e);
     const decrypted = await crypto.publicKey.rsa.decrypt(encrypted, n, e, d, p, q, u);
     expect(decrypted).to.deep.equal(message);
@@ -92,7 +92,7 @@ module.exports = () => describe('basic RSA cryptography', function () {
     const bits = 1024;
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);
     const { n, e, d, p, q, u } = { ...publicParams, ...privateParams };
-    const message = await crypto.generateSessionKey('aes256');
+    const message = await crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
     disableNative();
     const encryptedBn = await crypto.publicKey.rsa.encrypt(message, n, e);
     enableNative();

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -223,7 +223,7 @@ vAFM3jjrAQDgJPXsv8PqCrLGDuMa/2r6SgzYd03aw/xt1WM6hgUvhQD+J54Z
       expect(encData2.constructor.tag).to.equal(openpgp.enums.packet.aeadEncryptedData);
       const { packets: [compressed] } = await encrypted2.decrypt(null, passwords, null, encrypted2.fromStream, openpgp.config);
       expect(compressed.constructor.tag).to.equal(openpgp.enums.packet.compressedData);
-      expect(compressed.algorithm).to.equal('zip');
+      expect(compressed.algorithm).to.equal(openpgp.enums.compression.zip);
 
       const userIDs = { name: 'Test User', email: 'text2@example.com' };
       const { privateKey: key } = await openpgp.generateKey({ userIDs, format: 'object' });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -3481,7 +3481,7 @@ aOU=
         }).then(async function (message) {
           const literals = message.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
-          expect(literals[0].format).to.equal('binary');
+          expect(literals[0].format).to.equal(openpgp.enums.literal.binary);
           expect(+literals[0].date).to.equal(+future);
           const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
           expect(await stream.readToEnd(message.getLiteralData())).to.deep.equal(data);
@@ -3510,7 +3510,7 @@ aOU=
         }).then(async function (message) {
           const literals = message.packets.filterByTag(openpgp.enums.packet.literalData);
           expect(literals.length).to.equal(1);
-          expect(literals[0].format).to.equal('mime');
+          expect(literals[0].format).to.equal(openpgp.enums.literal.mime);
           expect(+literals[0].date).to.equal(+future);
           const signatures = await message.verify([publicKey_2038_2045], future, undefined, openpgp.config);
           expect(await stream.readToEnd(message.getLiteralData())).to.deep.equal(data);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2307,7 +2307,7 @@ aOU=
 
         it('should encrypt using custom session key and decrypt using session key', async function () {
           const sessionKey = {
-            data: await crypto.generateSessionKey('aes256'),
+            data: await crypto.generateSessionKey(openpgp.enums.symmetric.aes256),
             algorithm: 'aes256'
           };
           const encOpt = {
@@ -2330,7 +2330,7 @@ aOU=
 
         it('should encrypt using custom session key and decrypt using private key', async function () {
           const sessionKey = {
-            data: await crypto.generateSessionKey('aes128'),
+            data: await crypto.generateSessionKey(openpgp.enums.symmetric.aes128),
             algorithm: 'aes128'
           };
           const encOpt = {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -834,7 +834,7 @@ Be4ubVrj5KjhX2PVNEJd3XZRzaXZE2aAMQ==
 -----END PGP PUBLIC KEY BLOCK-----`;
 
 function withCompression(tests) {
-  const compressionTypes = Object.keys(openpgp.enums.compression).map(k => openpgp.enums.compression[k]);
+  const compressionTypes = Object.values(openpgp.enums.compression);
 
   compressionTypes.forEach(function (compression) {
     const compressionName = openpgp.enums.read(openpgp.enums.compression, compression);
@@ -870,9 +870,9 @@ function withCompression(tests) {
           }
 
           expect(compressSpy.called).to.be.true;
-          expect(compressSpy.thisValues[0].algorithm).to.equal(compressionName);
+          expect(compressSpy.thisValues[0].algorithm).to.equal(compression);
           expect(decompressSpy.called).to.be.true;
-          expect(decompressSpy.thisValues[0].algorithm).to.equal(compressionName);
+          expect(decompressSpy.thisValues[0].algorithm).to.equal(compression);
         }
       );
     });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -840,7 +840,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
     const secretKeyPacket = new openpgp.SecretKeyPacket();
     secretKeyPacket.privateParams = privateParams;
     secretKeyPacket.publicParams = publicParams;
-    secretKeyPacket.algorithm = 'rsaSign';
+    secretKeyPacket.algorithm = openpgp.enums.publicKey.rsaSign;
     secretKeyPacket.isEncrypted = false;
     await secretKeyPacket.encrypt('hello', { ...openpgp.config, aeadProtect: true });
     expect(secretKeyPacket.s2kUsage).to.equal(253);
@@ -864,7 +864,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
       packet.privateParams = { key: new Uint8Array([1, 2, 3]) };
       packet.publicParams = { pubKey: new Uint8Array([4, 5, 6]) };
-      packet.algorithm = 'rsaSign';
+      packet.algorithm = openpgp.enums.publicKey.rsaSign;
       packet.isEncrypted = false;
       packet.s2kUsage = 0;
 
@@ -896,7 +896,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
     const secretKeyPacket = new openpgp.SecretKeyPacket();
     secretKeyPacket.privateParams = privateParams;
     secretKeyPacket.publicParams = publicParams;
-    secretKeyPacket.algorithm = 'rsaSign';
+    secretKeyPacket.algorithm = openpgp.enums.publicKey.rsaSign;
     secretKeyPacket.isEncrypted = false;
     await secretKeyPacket.encrypt('hello', { ...openpgp.config, aeadProtect: false });
     expect(secretKeyPacket.s2kUsage).to.equal(254);
@@ -917,7 +917,7 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
 
       key.publicParams = publicParams;
       key.privateParams = privateParams;
-      key.algorithm = 'rsaSign';
+      key.algorithm = openpgp.enums.publicKey.rsaSign;
       await key.computeFingerprintAndKeyID();
 
       const signed = new openpgp.PacketList();

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -68,7 +68,7 @@ import {
 
   // Encrypt text message (armored)
   const text = 'hello';
-  const textMessage = await createMessage({ text: 'hello' });
+  const textMessage = await createMessage({ text: 'hello', format: 'text' });
   const encryptedArmor: string = await encrypt({ encryptionKeys: publicKeys, message: textMessage });
   expect(encryptedArmor).to.include('-----BEGIN PGP MESSAGE-----');
 


### PR DESCRIPTION
In several packet classes, we used to store string identifiers for public-key, aead, cipher or hash algorithms. To make the code consistent and to avoid having to convert to/from string values, we now always store integer values instead, e.g. `enums.symmetric.aes128` is used instead of `'aes128'`.

This is not expected to be a breaking change for most library users. Note that the type of `Key.getAlgorithmInfo()` and of the session key objects returned and accepted by top-level functions remain unchanged.

Affected classes (type changes for some properties and method's arguments):
- `PublicKeyPacket`, `PublicSubkeyPacket`, `SecretKeyPacket`, `SecretSubkeyPacket`
- `SymEncryptedIntegrityProtectedDataPacket`, `AEADEncryptedDataPacket`, `SymmetricallyEncryptedDataPacket`
- `LiteralDataPacket`, `CompressedDataPacket`
- `PublicKeyEncryptedSessionKey`, `SymEncryptedSessionKeyPacket`
- `SignaturePacket`

Other potentially breaking changes:
- Removed property `AEADEncryptedDataPacket.aeadAlgo`, since it was redudant given `.aeadAlgorithm`.
- Renamed `AEADEncryptedDataPacket.cipherAlgo` -> `.cipherAlgorithm`

TODO:
- [x] TS