### PR TITLE
Remove stream from type definitions

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -562,15 +562,6 @@ interface NodeStream<T extends Data> extends BaseStream<T> { // copied+simplifie
 type Stream<T extends Data> = WebStream<T> | NodeStream<T>;
 type MaybeStream<T extends Data> = T | Stream<T>;
 
-export namespace stream {
-  function readToEnd<T extends Data>(input: MaybeStream<T>, concat?: (list: T[]) => T): Promise<T>;
-  // concat
-  // slice
-  // clone
-  // webToNode
-  // nodeToWeb
-}
-
 /* ############## v5 GENERAL #################### */
 type MaybeArray<T> = T | Array<T>;
 


### PR DESCRIPTION
As stated in #1291, `stream` namespace have been unexported from openpgpjs.

#1363 described the problem with typings: although unexported, the type still exists in the type definition file.


Note: for those needing `stream.readToEnd`, a workaround is described in #1365.