### PR TITLE
Add `config.allowInsecureVerificationWithReformattedKeys`

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -130,6 +130,15 @@ export default {
    * @property {Boolean} allowInsecureDecryptionWithSigningKeys
    */
   allowInsecureDecryptionWithSigningKeys: false,
+  /**
+   * Allow verification of message signatures with keys whose validity at the time of signing cannot be determined.
+   * Instead, a verification key will also be consider valid as long as it is valid at the current time.
+   * This setting is potentially insecure, but it is needed to verify messages signed with keys that were later reformatted,
+   * and have self-signature's creation date that does not match the primary key creation date.
+   * @memberof module:config
+   * @property {Boolean} allowInsecureDecryptionWithSigningKeys
+   */
+  allowInsecureVerificationWithReformattedKeys: false,
 
   /**
    * @memberof module:config

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -88,7 +88,8 @@ export async function generateKey({ userIDs = [], passphrase = '', type = 'ecc',
  * @param {Object|Array<Object>} options.userIDs - User IDs as objects: `{ name: 'Jo Doe', email: 'info@jo.com' }`
  * @param {String} [options.passphrase=(not protected)] - The passphrase used to encrypt the reformatted private key. If omitted, the key won't be encrypted.
  * @param {Number} [options.keyExpirationTime=0 (never expires)] - Number of seconds from the key creation time after which the key expires
- * @param {Date}   [options.date] - Override the creation date of the key signatures
+ * @param {Date}   [options.date] - Override the creation date of the key signatures. If the key was previously used to sign messages, it is recommended
+ *                                  to set the same date as the key creation time to ensure that old message signatures will still be verifiable using the reformatted key.
  * @param {'armored'|'binary'|'object'} [options.format='armored'] - format of the output keys
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<Object>} The generated key object in the form:


### PR DESCRIPTION
Using `openpgp.reformatKey` using the default `date` option would render messages signed with the original key unverifiable by OpenPGP.js v5 (not v4), since the signing key would not be considered valid at the time of signing (due to its self-certification signature being in the future, compared to the message signature creation time).

This PR adds `config.allowInsecureVerificationWithReformattedKeys` (false by default) to make it possible to still verify such messages with the reformatted key provided the key is valid at the `date` specified for verification (which defaults to the current time).

To avoid this type of issue with message verification, we recommend to pass the key creation time as `date` when using `reformatKey`.