### PR TITLE
Prevent adding subkeys that use blacklisted curves

### DIFF
--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -230,6 +230,7 @@ class PrivateKey extends PublicKey {
     defaultOptions.curve = defaultOptions.curve || 'curve25519';
     options = helper.sanitizeKeyOptions(options, defaultOptions);
     const keyPacket = await helper.generateSecretSubkey(options);
+    helper.checkKeyRequirements(keyPacket, config);
     const bindingSignature = await helper.createBindingSignature(keyPacket, secretKeyPacket, options, config);
     const packetList = this.toPacketList();
     packetList.push(keyPacket, bindingSignature);


### PR DESCRIPTION
Breaking change:
when generating new subkeys through `key.addSubkey()`, we now check `config.rejectCurves` and prevent adding subkeys using the corresponding curves.
By default, `config.rejectCurves` includes the brainpool curves (`brainpoolP256r1`, `brainpoolP384r1`, `brainpoolP512r1`) and the Bitcoin curve (`secp256k1`).

This is a follow up to #1395 , which introduced the same check to `openpgp.generateKey`.
