### PR TITLE
Do not include checksum values in error messages when armor integrity check fails

### DIFF
--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -328,8 +328,7 @@ export function unarmor(input, config = defaultConfig) {
         try {
           const checksumVerifiedString = (await checksumVerified).replace('\n', '');
           if (checksum !== checksumVerifiedString && (checksum || config.checksumRequired)) {
-            throw new Error("Ascii armor integrity check on message failed: '" + checksum + "' should be '" +
-                    checksumVerifiedString + "'");
+            throw new Error('Ascii armor integrity check failed');
           }
           await writer.ready;
           await writer.close();

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -170,11 +170,11 @@ module.exports = () => describe('ASCII armor', function() {
     ].join('\n');
 
     // try with default config
-    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check failed/);
 
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check failed/);
 
     // back to default
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
@@ -234,7 +234,7 @@ module.exports = () => describe('ASCII armor', function() {
 
     // try with default config
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check failed/);
     } else {
       await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
     }
@@ -242,7 +242,7 @@ module.exports = () => describe('ASCII armor', function() {
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check failed/);
     } else {
       await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
     }
@@ -274,7 +274,7 @@ module.exports = () => describe('ASCII armor', function() {
 
     // try with default config
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check failed/);
     } else {
       await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
     }
@@ -282,7 +282,7 @@ module.exports = () => describe('ASCII armor', function() {
     // try opposite config
     openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
     if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check on message failed/);
+      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check failed/);
     } else {
       await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
     }

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2795,7 +2795,7 @@ aOU=
                     stepReached = 2;
                     await stream.readToEnd(decrypted);
                   } catch (e) {
-                    expect(e.message).to.match(/Ascii armor integrity check on message failed/);
+                    expect(e.message).to.match(/Ascii armor integrity check failed/);
                     expect(stepReached).to.equal(
                       j === 0 ? 0 :
                         (openpgp.config.aeadChunkSizeByte === 0 && (j === 2 || util.detectNode() || util.getHardwareConcurrency() < 8)) || (!openpgp.config.aeadProtect && openpgp.config.allowUnauthenticatedStream) ? 2 :
@@ -2803,7 +2803,7 @@ aOU=
                     );
                     return;
                   }
-                  throw new Error(`Expected "Ascii armor integrity check on message failed" error in subtest ${i}.${j}`);
+                  throw new Error(`Expected "Ascii armor integrity check failed" error in subtest ${i}.${j}`);
                 }));
               }));
             }

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -479,7 +479,7 @@ function tests() {
       const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
       dataArrived();
-      await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
+      await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check failed');
       expect(decrypted.signatures).to.exist.and.have.length(1);
     } finally {
       openpgp.config.allowUnauthenticatedStream = allowUnauthenticatedStreamValue;
@@ -515,7 +515,7 @@ function tests() {
       const reader = stream.getReader(decrypted.data);
       expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
       dataArrived();
-      await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
+      await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check failed');
       expect(decrypted.signatures).to.exist.and.have.length(1);
       await expect(decrypted.signatures[0].verified).to.be.eventually.rejectedWith(/Could not find signing key/);
     } finally {
@@ -549,7 +549,7 @@ function tests() {
     const reader = stream.getReader(verified.data);
     expect(await reader.peekBytes(1024)).not.to.deep.equal(plaintext[0]);
     dataArrived();
-    await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check on message failed');
+    await expect(reader.readToEnd()).to.be.rejectedWith('Ascii armor integrity check failed');
     expect(verified.signatures).to.exist.and.have.length(1);
   });
 


### PR DESCRIPTION
This PR removes the expected and actual checksum values from the error message thrown when parsing armored data whose integrity cannot be verified.
This is because we do not want error messages to leak information about the content of potentially sensitive data.