### PR TITLE
Remove line terminators from randomly generated test messages

### DIFF
--- a/test/general/testInputs.js
+++ b/test/general/testInputs.js
@@ -9,7 +9,7 @@ function createSomeMessage(){
   for (let i = 0; i < 10; i++) {
     arr.push(0x1F600 + Math.floor(Math.random() * (0x1F64F - 0x1F600)) + 1);
   }
-  return '  \t' + String.fromCodePoint(...arr).replace(/\r/g, '\n') + '  \t\n한국어/조선말';
+  return '  \t' + String.fromCodePoint(...arr).replace(/[\r\u2028\u2029]/g, '\n') + '  \t\n한국어/조선말';
 }
 
 module.exports = {


### PR DESCRIPTION
Remove line separators (U+2028) and paragraph separators (U+2029) from randomly generated test messages. These messages cause the test to fail due to the difference in handling them between multiline regexes and OpenPGP.js-internal functions.