### PR TITLE
Add support for constant-time decryption of PKCS#1 v1.5-encoded session keys

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -326,6 +326,8 @@ interface Config {
   versionString: string;
   commentString: string;
   allowInsecureDecryptionWithSigningKeys: boolean;
+  constantTimePKCS1Decryption: boolean;
+  constantTimePKCS1DecryptionSupportedSymmetricAlgorithms: Set<enums.symmetric>;
   v5Keys: boolean;
   preferredAEADAlgorithm: enums.aead;
   aeadChunkSizeByte: number;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -140,6 +140,9 @@ export default {
    */
   allowInsecureVerificationWithReformattedKeys: false,
 
+  constantTimePKCS1Decryption: false,
+  // TODO add option to specify ciphers to decrypt with (default to AES ones)
+
   /**
    * @memberof module:config
    * @property {Integer} minBytesForWebCrypto The minimum amount of bytes for which to use native WebCrypto APIs when available

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -140,8 +140,24 @@ export default {
    */
   allowInsecureVerificationWithReformattedKeys: false,
 
+  /**
+   * Enable constant-time decryption of RSA- and ElGamal-encrypted session keys, to hinder Bleichenbacher-like attacks (https://link.springer.com/chapter/10.1007/BFb0055716).
+   * This setting has measurable performance impact and it is only helpful in application scenarios where both of the following conditions apply:
+   * - new/incoming messages are automatically decrypted (without user interaction);
+   * - an attacker can determine how long it takes to decrypt each message (e.g. due to decryption errors being logged remotely).
+   * See also `constantTimePKCS1DecryptionSupportedSymmetricAlgorithms`.
+   * @memberof module:config
+   * @property {Boolean} constantTimePKCS1Decryption
+   */
   constantTimePKCS1Decryption: false,
-  // TODO add option to specify ciphers to decrypt with (default to AES ones)
+  /**
+   * This setting is only meaningful if `constantTimePKCS1Decryption` is enabled.
+   * Decryption of RSA- and ElGamal-encrypted session keys of symmetric algorithms different from the ones specified here will fail.
+   * However, the more algorithms are added, the slower the decryption procedure becomes.
+   * @memberof module:config
+   * @property {Set<Integer>} constantTimePKCS1DecryptionSupportedSymmetricAlgorithms {@link module:enums.symmetric}
+   */
+  constantTimePKCS1DecryptionSupportedSymmetricAlgorithms: new Set([enums.symmetric.aes128, enums.symmetric.aes192, enums.symmetric.aes256]),
 
   /**
    * @memberof module:config

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -76,23 +76,26 @@ export async function publicKeyEncrypt(algo, publicParams, data, fingerprint) {
  * @param {Object} privateKeyParams - Algorithm-specific private key parameters
  * @param {Object} sessionKeyParams - Encrypted session key parameters
  * @param {Uint8Array} fingerprint - Recipient fingerprint
+ * @param {Uint8Array} [randomPayload] - Data to return on decryption error, instead of throwing
+ *                                    (needed for constant-time processing in RSA and ElGamal)
  * @returns {Promise<Uint8Array>} Decrypted data.
+ * @throws {Error} on sensitive decryption error, unless `randomPayload` is given
  * @async
  */
-export async function publicKeyDecrypt(algo, publicKeyParams, privateKeyParams, sessionKeyParams, fingerprint) {
+export async function publicKeyDecrypt(algo, publicKeyParams, privateKeyParams, sessionKeyParams, fingerprint, randomPayload) {
   switch (algo) {
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaEncrypt: {
       const { c } = sessionKeyParams;
       const { n, e } = publicKeyParams;
       const { d, p, q, u } = privateKeyParams;
-      return publicKey.rsa.decrypt(c, n, e, d, p, q, u);
+      return publicKey.rsa.decrypt(c, n, e, d, p, q, u, randomPayload);
     }
     case enums.publicKey.elgamal: {
       const { c1, c2 } = sessionKeyParams;
       const p = publicKeyParams.p;
       const x = privateKeyParams.x;
-      return publicKey.elgamal.decrypt(c1, c2, p, x);
+      return publicKey.elgamal.decrypt(c1, c2, p, x, randomPayload);
     }
     case enums.publicKey.ecdh: {
       const { oid, Q, kdfParams } = publicKeyParams;

--- a/src/crypto/pkcs1.js
+++ b/src/crypto/pkcs1.js
@@ -26,6 +26,7 @@
 
 import { getRandomBytes } from './random';
 import hash from './hash';
+import util from '../util';
 
 /**
  * ASN1 object identifiers for hashes
@@ -116,7 +117,7 @@ export function emeDecode(encoded, randomPayload) {
   const isValidPadding = encoded[0] === 0 & encoded[1] === 2 & psLen >= 8 & !separatorNotFound;
 
   if (randomPayload) {
-    return isValidPadding ? payload : randomPayload;
+    return util.selectUint8Array(isValidPadding, payload, randomPayload);
   }
 
   if (isValidPadding) {

--- a/src/crypto/pkcs1.js
+++ b/src/crypto/pkcs1.js
@@ -113,7 +113,7 @@ export function emeDecode(encoded, randomPayload) {
   }
 
   const psLen = offset - 2;
-  const payload = encoded.subarray(offset + 1); // discar the 0x00 separator
+  const payload = encoded.subarray(offset + 1); // discard the 0x00 separator
   const isValidPadding = encoded[0] === 0 & encoded[1] === 2 & psLen >= 8 & !separatorNotFound;
 
   if (randomPayload) {

--- a/src/crypto/public_key/elgamal.js
+++ b/src/crypto/public_key/elgamal.js
@@ -59,10 +59,13 @@ export async function encrypt(data, p, g, y) {
  * @param {Uint8Array} c2
  * @param {Uint8Array} p
  * @param {Uint8Array} x
+ * @param {Uint8Array} randomPayload - Data to return on unpadding error, instead of throwing
+ *                                     (needed for constant-time processing)
  * @returns {Promise<Uint8Array>} Unpadded message.
+ * @throws {Error} on decryption error, unless `randomPayload` is given
  * @async
  */
-export async function decrypt(c1, c2, p, x) {
+export async function decrypt(c1, c2, p, x, randomPayload) {
   const BigInteger = await util.getBigInteger();
   c1 = new BigInteger(c1);
   c2 = new BigInteger(c2);
@@ -70,7 +73,7 @@ export async function decrypt(c1, c2, p, x) {
   x = new BigInteger(x);
 
   const padded = c1.modExp(x, p).modInv(p).imul(c2).imod(p);
-  return emeDecode(padded.toUint8Array('be', p.byteLength()));
+  return emeDecode(padded.toUint8Array('be', p.byteLength()), randomPayload);
 }
 
 /**

--- a/src/message.js
+++ b/src/message.js
@@ -107,7 +107,7 @@ export class Message {
    * @async
    */
   async decrypt(decryptionKeys, passwords, sessionKeys, date = new Date(), config = defaultConfig) {
-    const sessionKeyObjs = sessionKeys || await this.decryptSessionKeys(decryptionKeys, passwords, date, config);
+    const sessionKeyObjects = sessionKeys || await this.decryptSessionKeys(decryptionKeys, passwords, date, config);
 
     const symEncryptedPacketlist = this.packets.filterByTag(
       enums.packet.symmetricallyEncryptedData,
@@ -121,7 +121,7 @@ export class Message {
 
     const symEncryptedPacket = symEncryptedPacketlist[0];
     let exception = null;
-    const decryptedPromise = Promise.all(sessionKeyObjs.map(async ({ algorithm: algorithmName, data }) => {
+    const decryptedPromise = Promise.all(sessionKeyObjects.map(async ({ algorithm: algorithmName, data }) => {
       if (!util.isUint8Array(data) || !util.isString(algorithmName)) {
         throw new Error('Invalid session key for decryption.');
       }
@@ -162,36 +162,36 @@ export class Message {
    * @async
    */
   async decryptSessionKeys(decryptionKeys, passwords, date = new Date(), config = defaultConfig) {
-    let keyPackets = [];
+    let decryptedSessionKeyPackets = [];
 
     let exception;
     if (passwords) {
-      const symESKeyPacketlist = this.packets.filterByTag(enums.packet.symEncryptedSessionKey);
-      if (symESKeyPacketlist.length === 0) {
+      const skeskPackets = this.packets.filterByTag(enums.packet.symEncryptedSessionKey);
+      if (skeskPackets.length === 0) {
         throw new Error('No symmetrically encrypted session key packet found.');
       }
       await Promise.all(passwords.map(async function(password, i) {
         let packets;
         if (i) {
-          packets = await PacketList.fromBinary(symESKeyPacketlist.write(), allowedSymSessionKeyPackets, config);
+          packets = await PacketList.fromBinary(skeskPackets.write(), allowedSymSessionKeyPackets, config);
         } else {
-          packets = symESKeyPacketlist;
+          packets = skeskPackets;
         }
-        await Promise.all(packets.map(async function(keyPacket) {
+        await Promise.all(packets.map(async function(skeskPacket) {
           try {
-            await keyPacket.decrypt(password);
-            keyPackets.push(keyPacket);
+            await skeskPacket.decrypt(password);
+            decryptedSessionKeyPackets.push(skeskPacket);
           } catch (err) {
             util.printDebugError(err);
           }
         }));
       }));
     } else if (decryptionKeys) {
-      const pkESKeyPacketlist = this.packets.filterByTag(enums.packet.publicKeyEncryptedSessionKey);
-      if (pkESKeyPacketlist.length === 0) {
+      const pkeskPackets = this.packets.filterByTag(enums.packet.publicKeyEncryptedSessionKey);
+      if (pkeskPackets.length === 0) {
         throw new Error('No public key encrypted session key packet found.');
       }
-      await Promise.all(pkESKeyPacketlist.map(async function(keyPacket) {
+      await Promise.all(pkeskPackets.map(async function(pkeskPacket) {
         await Promise.all(decryptionKeys.map(async function(decryptionKey) {
           let algos = [
             enums.symmetric.aes256, // Old OpenPGP.js default fallback
@@ -207,7 +207,7 @@ export class Message {
           } catch (e) {}
 
           // do not check key expiration to allow decryption of old messages
-          const decryptionKeyPackets = (await decryptionKey.getDecryptionKeys(keyPacket.publicKeyID, null, undefined, config)).map(key => key.keyPacket);
+          const decryptionKeyPackets = (await decryptionKey.getDecryptionKeys(pkeskPacket.publicKeyID, null, undefined, config)).map(key => key.keyPacket);
           await Promise.all(decryptionKeyPackets.map(async function(decryptionKeyPacket) {
             if (!decryptionKeyPacket || decryptionKeyPacket.isDummy()) {
               return;
@@ -215,30 +215,78 @@ export class Message {
             if (!decryptionKeyPacket.isDecrypted()) {
               throw new Error('Decryption key is not decrypted.');
             }
-            try {
-              await keyPacket.decrypt(decryptionKeyPacket);
-              if (!algos.includes(keyPacket.sessionKeyAlgorithm)) {
-                throw new Error('A non-preferred symmetric algorithm was used.');
+
+            // To hinder CCA attacks against RSA PKCS1, we carry out a constant-time decryption flow if the `constantTimePKCS1Decryption` config option is set.
+            const doConstantTimeDecryption = config.constantTimePKCS1Decryption && (
+              pkeskPacket.publicKeyAlgorithm === enums.publicKey.rsaEncrypt ||
+              pkeskPacket.publicKeyAlgorithm === enums.publicKey.rsaEncryptSign ||
+              pkeskPacket.publicKeyAlgorithm === enums.publicKey.rsaSign
+            );
+
+            if (doConstantTimeDecryption) {
+              // The goal is to not reveal whether PKESK decryption failed, hence, we always proceed to decrypt the message, either with the successfully decrypted session key,
+              // or with a randomly generated one of the same type.
+              // Since the SEIP/AEAD's symmetric algorithm and key size are stored in the encrypted portion of the PKESK, and the execution flow cannot depend on
+              // the decrypted payload, we always assume the message to be AES-encrypted, and try to decrypt the message using all possible AES key sizes (i.e. 128, 192, 256):
+              // - If the PKESK decryption succeeds, and the session key cipher is AES, then we try to decrypt the data with the decrypted session key as well as the
+              // randomly generated keys of the two remaining key sizes.
+              // - If the PKESK decryptions fails, or if it succeeds but the cipher is not AES, then we discard the session key and try to decrypt the data using only the randomly
+              // generated session keys.
+              //
+              // NB: if the data is encrypted with a non-AES cipher, decryption will always fail. The code could be extended to support additional non-AES ciphers,
+              // but that would considerably slow down decryption.
+              const sessionKeysOfEachAlgo = await Promise.all(['aes128', 'aes192', 'aes256'].map(async algoName => {
+                const randomPKESK = new PublicKeyEncryptedSessionKeyPacket();
+                randomPKESK.publicKeyAlgorithm = pkeskPacket.publicKeyAlgorithm;
+                randomPKESK.sessionKeyAlgorithm = enums.write(enums.symmetric, algoName);
+                randomPKESK.sessionKey = await crypto.generateSessionKey(algoName);
+                return randomPKESK;
+              }));
+
+              try {
+                // PKESK decryption is not constant time and  it will throw on failure, but the time variability is small enough
+                await pkeskPacket.decrypt(decryptionKeyPacket);
+                if (!algos.includes(enums.write(enums.symmetric, pkeskPacket.sessionKeyAlgorithm))) {
+                  throw new Error('A non-preferred symmetric algorithm was used.');
+                }
+                // If the successfully decrypted session key is AES, use it instead of the randomly generated AES key of the same size.
+                // If it is non-AES, discard it and proceed with only the randomly generated session keys.
+
+                // TODO this can be simplified with pkesk.decrypt being aware of constant timeness:
+                // - clone pkesk and have it decrypted with each random key passed as `randomSessionKey`
+                // - use the result as-is, unless errors are thrown, then discard the pkesk (as already done)
+                const algoIndex = sessionKeysOfEachAlgo.findIndex(({ sessionKeyAlgorithm }) => sessionKeyAlgorithm === pkeskPacket.sessionKeyAlgorithm);
+                sessionKeysOfEachAlgo[algoIndex] = (algoIndex >= 0) ? pkeskPacket : sessionKeysOfEachAlgo[algoIndex];
+              } finally {
+                decryptedSessionKeyPackets.push(...sessionKeysOfEachAlgo);
               }
-              keyPackets.push(keyPacket);
-            } catch (err) {
-              util.printDebugError(err);
-              exception = err;
+
+            } else {
+              try {
+                await pkeskPacket.decrypt(decryptionKeyPacket);
+                if (!algos.includes(enums.write(enums.symmetric, pkeskPacket.sessionKeyAlgorithm))) {
+                  throw new Error('A non-preferred symmetric algorithm was used.');
+                }
+                decryptedSessionKeyPackets.push(pkeskPacket);
+              } catch (err) {
+                util.printDebugError(err);
+                exception = err;
+              }
             }
           }));
         }));
-        stream.cancel(keyPacket.encrypted); // Don't keep copy of encrypted data in memory.
-        keyPacket.encrypted = null;
+        stream.cancel(pkeskPacket.encrypted); // Don't keep copy of encrypted data in memory.
+        pkeskPacket.encrypted = null;
       }));
     } else {
       throw new Error('No key or password specified.');
     }
 
-    if (keyPackets.length) {
+    if (decryptedSessionKeyPackets.length > 0) {
       // Return only unique session keys
-      if (keyPackets.length > 1) {
+      if (decryptedSessionKeyPackets.length > 1) {
         const seen = new Set();
-        keyPackets = keyPackets.filter(item => {
+        decryptedSessionKeyPackets = decryptedSessionKeyPackets.filter(item => {
           const k = item.sessionKeyAlgorithm + util.uint8ArrayToString(item.sessionKey);
           if (seen.has(k)) {
             return false;
@@ -248,7 +296,7 @@ export class Message {
         });
       }
 
-      return keyPackets.map(packet => ({
+      return decryptedSessionKeyPackets.map(packet => ({
         data: packet.sessionKey,
         algorithm: enums.read(enums.symmetric, packet.sessionKeyAlgorithm)
       }));

--- a/src/message.js
+++ b/src/message.js
@@ -226,10 +226,10 @@ export class Message {
 
             if (doConstantTimeDecryption) {
               // The goal is to not reveal whether PKESK decryption (specifically the PKCS1 decoding step) failed, hence, we always proceed to decrypt the message,
-              // either with the successfully decrypted session key, or with a randomly generated one of the same type.
+              // either with the successfully decrypted session key, or with a randomly generated one.
               // Since the SEIP/AEAD's symmetric algorithm and key size are stored in the encrypted portion of the PKESK, and the execution flow cannot depend on
               // the decrypted payload, we always assume the message to be encrypted with one of the symmetric algorithms specified in `config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms`:
-              // - If the PKESK decryption succeeds, and the session key cipher is in the supported set, then we try to decrypt the data with the decrypted session key as well as the
+              // - If the PKESK decryption succeeds, and the session key cipher is in the supported set, then we try to decrypt the data with the decrypted session key as well as with the
               // randomly generated keys of the remaining key types.
               // - If the PKESK decryptions fails, or if it succeeds but support for the cipher is not enabled, then we discard the session key and try to decrypt the data using only the randomly
               // generated session keys.

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -138,8 +138,8 @@ class PublicKeyEncryptedSessionKeyPacket {
       // We must not leak info about the validity of the decrypted checksum or cipher algo.
       // The decrypted session key must be of the same algo and size as the random session key, otherwise we discard it and use the random data.
       const isValidPayload = isValidChecksum & symmetricAlgoByte === randomSessionKey.sessionKeyAlgorithm & sessionKey.length === randomSessionKey.sessionKey.length;
-      this.sessionKey = isValidPayload ? sessionKey : randomSessionKey.sessionKey;
-      this.sessionKeyAlgorithm = isValidPayload ? symmetricAlgoByte : randomSessionKey.sessionKeyAlgorithm;
+      this.sessionKeyAlgorithm = util.selectUint8(isValidPayload, symmetricAlgoByte, randomSessionKey.sessionKeyAlgorithm);
+      this.sessionKey = util.selectUint8Array(isValidPayload, sessionKey, randomSessionKey.sessionKey);
 
     } else {
       const isValidPayload = isValidChecksum && enums.read(enums.symmetric, symmetricAlgoByte);

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -131,9 +131,9 @@ class PublicKeyEncryptedSessionKeyPacket {
     const decoded = await crypto.publicKeyDecrypt(this.publicKeyAlgorithm, key.publicParams, key.privateParams, this.encrypted, key.getFingerprintBytes(), randomPayload);
     const symmetricAlgoByte = decoded[0];
     const sessionKey = decoded.subarray(1, decoded.length - 2);
-    const expectedChecksum = decoded.subarray(decoded.length - 2);
-    const actualChecksum = util.writeChecksum(sessionKey);
-    const isValidChecksum = actualChecksum[0] === expectedChecksum[0] & actualChecksum[1] === expectedChecksum[1];
+    const checksum = decoded.subarray(decoded.length - 2);
+    const computedChecksum = util.writeChecksum(sessionKey);
+    const isValidChecksum = computedChecksum[0] === checksum[0] & computedChecksum[1] === checksum[1];
 
     if (randomSessionKey) {
       // We must not leak info about the validity of the decrypted checksum or cipher algo.

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -129,10 +129,11 @@ class PublicKeyEncryptedSessionKeyPacket {
       util.writeChecksum(randomSessionKey.sessionKey)
     ]) : null;
     const decoded = await crypto.publicKeyDecrypt(this.publicKeyAlgorithm, key.publicParams, key.privateParams, this.encrypted, key.getFingerprintBytes(), randomPayload);
-    const checksum = decoded.subarray(decoded.length - 2);
-    const sessionKey = decoded.subarray(1, decoded.length - 2);
     const symmetricAlgoByte = decoded[0];
-    const isValidChecksum = util.equalsUint8Array(checksum, util.writeChecksum(sessionKey));
+    const sessionKey = decoded.subarray(1, decoded.length - 2);
+    const expectedChecksum = decoded.subarray(decoded.length - 2);
+    const actualChecksum = util.writeChecksum(sessionKey);
+    const isValidChecksum = actualChecksum[0] === expectedChecksum[0] & actualChecksum[1] === expectedChecksum[1];
 
     if (randomSessionKey) {
       // We must not leak info about the validity of the decrypted checksum or cipher algo.

--- a/src/util.js
+++ b/src/util.js
@@ -588,6 +588,35 @@ const util = {
       }));
       reject(exception);
     });
+  },
+
+  /**
+   * Return either `a` or `b` based on `cond`, in algorithmic constant time.
+   * @param {Boolean} cond
+   * @param {Uint8Array} a
+   * @param {Uint8Array} b
+   * @returns `a` if `cond` is true, `b` otherwise
+   */
+  selectUint8Array: function(cond, a, b) {
+    const length = Math.max(a.length, b.length);
+    const result = new Uint8Array(length);
+    let end = 0;
+    for (let i = 0; i < result.length; i++) {
+      result[i] = (a[i] & (256 - cond)) | (b[i] & (255 + cond));
+      end += (cond & i < a.length) | ((1 - cond) & i < b.length);
+    }
+    return result.subarray(0, end);
+  },
+  /**
+   * Return either `a` or `b` based on `cond`, in algorithmic constant time.
+   * NB: it only supports `a, b` with values between 0-255.
+   * @param {Boolean} cond
+   * @param {Uint8} a
+   * @param {Uint8} b
+   * @returns `a` if `cond` is true, `b` otherwise
+   */
+  selectUint8: function(cond, a, b) {
+    return (a & (256 - cond)) | (b & (255 + cond));
   }
 };
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1537,17 +1537,21 @@ aOU=
         encryptionKeys: [publicKeyRSA, privateKeyECC]
       });
 
+      const config = {
+        constantTimePKCS1Decryption: true,
+        constantTimePKCS1DecryptionSupportedSymmetricAlgorithms: new Set()
+      };
       // decryption using RSA key should fail
       await expect(openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         decryptionKeys: privateKeyRSA,
-        config: { constantTimePKCS1Decryption: true, constantTimePKCS1DecryptionSupportedSymmetricAlgorithms: new Set() }
+        config
       })).to.be.rejectedWith(/Session key decryption failed/);
       // decryption using ECC key should succeed (PKCS1 is not used, so constant time countermeasures are not applied)
       const { data } = await openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         decryptionKeys: privateKeyECC,
-        config: { constantTimePKCS1Decryption: true }
+        config
       });
       expect(data).to.equal(plaintext);
     });

--- a/test/general/util.js
+++ b/test/general/util.js
@@ -141,6 +141,33 @@ module.exports = () => describe('Util unit tests', function() {
     });
   });
 
+  describe('constant time select', function() {
+    it('selectUint8Array should work for arrays of equal length', function () {
+      const size = 10;
+      const a = new Uint8Array(size).fill(1);
+      const b = new Uint8Array(size).fill(2);
+      expect(util.selectUint8Array(true, a, b)).to.deep.equal(a);
+      expect(util.selectUint8Array(false, a, b)).to.deep.equal(b);
+    });
+
+    it('selectUint8Array should work for arrays of different length', function () {
+      const size = 10;
+      const a = new Uint8Array(size).fill(1);
+      const b = new Uint8Array(2 * size).fill(2);
+      expect(util.selectUint8Array(true, a, b)).to.deep.equal(a);
+      expect(util.selectUint8Array(false, a, b)).to.deep.equal(b);
+      expect(util.selectUint8Array(true, b, a)).to.deep.equal(b);
+      expect(util.selectUint8Array(false, b, a)).to.deep.equal(a);
+    });
+
+    it('selectUint8 should return the expected value based on condition', function () {
+      const a = 1;
+      const b = 2;
+      expect(util.selectUint8(true, a, b)).to.equal(a);
+      expect(util.selectUint8(false, a, b)).to.equal(b);
+    });
+  });
+
   describe('Misc.', function() {
     it('util.readNumber should not overflow until full range of uint32', function () {
       const ints = [2 ** 20, 2 ** 25, 2 ** 30, 2 ** 32 - 1];


### PR DESCRIPTION
Implement optional constant-time decryption flow to hinder Bleichenbacher-like attacks against RSA- and ElGamal public-key encrypted session keys.

Changes:
- Add `config.constantTimePKCS1Decryption` to enable the constant-time processing (defaults to `false`). The constant-time option is off by default since it has measurable performance impact on message decryption, and it is only helpful in specific application scenarios (more info below).
- Add `config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms` (defaults to the AES algorithms). The set of supported ciphers is restricted by default since the number of algorithms negatively affects performance.

Bleichenbacher-like attacks are of concern for applications where both of the following conditions are met:
   1. new/incoming messages are automatically decrypted (without user interaction);
   2. an attacker can determine how long it takes to decrypt each message (e.g. due to decryption errors being logged remotely).

