### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Using the private key:
 
 ### Documentation
 
-The full documentation is available at [openpgpjs.org](https://openpgpjs.org/openpgpjs/).
+The full documentation is available at [openpgpjs.org](https://docs.openpgpjs.org/).
 
 ### Security Audit
 


### PR DESCRIPTION
Current documentation link in the readme (https://openpgpjs.org/openpgpjs/) 404s. This PR updates the link to the new documentation URL (https://docs.openpgpjs.org/))