### PR TITLE
Decryption of Large Files/Streams - Update documentation and Guard Test case

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -93,16 +93,10 @@ export default {
   allowUnauthenticatedMessages: false,
   /**
    * Allow streaming unauthenticated data before its integrity has been checked. This would allow the application to
-   * process very large streams by deferring the checksum integrity check to be only verified at the end of the stream.
+   * process large streams while limiting memory usage by releasing the decrypted chunks as soon as possible
+   * and deferring checking their integrity until the decrypted stream has been read in full.
    *
    * This setting is **insecure** if the partially decrypted message is processed further or displayed to the user.
-   *
-   * Therefore, the client application is advised to implement at least one of the following strategies when processing
-   * very large streams.
-   * - Perform a two-phase commit -- process the data in a staged area, and when the stream finalizes, commit if no error
-   *   occurs.
-   * - Read the stream twice -- read the contents to the end of the stream, and if the data is verified to be correct,
-   *   then perform a second pass on the stream to perform the real work.
    * @memberof module:config
    * @property {Boolean} allowUnauthenticatedStream
    */

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -92,8 +92,17 @@ export default {
    */
   allowUnauthenticatedMessages: false,
   /**
-   * Allow streaming unauthenticated data before its integrity has been checked.
+   * Allow streaming unauthenticated data before its integrity has been checked. This would allow the application to
+   * process very large streams by deferring the checksum integrity check to be only verified at the end of the stream.
+   *
    * This setting is **insecure** if the partially decrypted message is processed further or displayed to the user.
+   *
+   * Therefore, the client application is advised to implement at least one of the following strategies when processing
+   * very large streams.
+   * - Perform a two-phase commit -- process the data in a staged area, and when the stream finalizes, commit if no error
+   *   occurs.
+   * - Read the stream twice -- read the contents to the end of the stream, and if the data is verified to be correct,
+   *   then perform a second pass on the stream to perform the real work.
    * @memberof module:config
    * @property {Boolean} allowUnauthenticatedStream
    */

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -109,7 +109,7 @@ class MemoryBenchamrkSuite {
   suite.add('empty test (baseline)', () => {});
 
   suite.add('openpgp.encrypt/decrypt (CFB, binary)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
     const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(ONE_MEGABYTE) });
@@ -121,7 +121,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
     const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(ONE_MEGABYTE / 2) }); // two bytes per character
@@ -133,7 +133,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, binary)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
     const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(ONE_MEGABYTE) });
@@ -145,7 +145,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
     const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(ONE_MEGABYTE / 2) }); // two bytes per character
@@ -158,7 +158,7 @@ class MemoryBenchamrkSuite {
 
   // streaming tests
   suite.add('openpgp.encrypt/decrypt (CFB, binary, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -183,7 +183,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -208,7 +208,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, binary, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -233,7 +233,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -258,7 +258,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -283,7 +283,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with unauthenticated streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
@@ -312,7 +312,7 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text @ 100MB, with streaming)', async () => {
-    const ONE_MEGABYTE = 1024 * 1024;
+    const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -257,7 +257,7 @@ class MemoryBenchamrkSuite {
     });
   });
 
-  suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with streaming)', async () => {
+  suite.add('openpgp.encrypt/decrypt (CFB, text @ 10MB, with streaming)', async () => {
     const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
@@ -267,7 +267,7 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE / 2), numberOfChunks: 20 }));
     const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
@@ -282,7 +282,7 @@ class MemoryBenchamrkSuite {
     });
   });
 
-  suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with unauthenticated streaming)', async () => {
+  suite.add('openpgp.encrypt/decrypt (CFB, text @ 10MB, with unauthenticated streaming)', async () => {
     const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
@@ -292,7 +292,7 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE / 2), numberOfChunks: 20 }));
     const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
@@ -311,7 +311,7 @@ class MemoryBenchamrkSuite {
     });
   });
 
-  suite.add('openpgp.encrypt/decrypt (AEAD, text @ 100MB, with streaming)', async () => {
+  suite.add('openpgp.encrypt/decrypt (AEAD, text @ 10MB, with streaming)', async () => {
     const ONE_MEGABYTE = 1000000;
     function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
@@ -321,7 +321,7 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE / 2), numberOfChunks: 20 }));
     const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -213,7 +213,7 @@ class MemoryBenchamrkSuite {
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
-  suite.add('openpgp.encrypt/decrypt (PGP, text @ 100MB, with streaming)', async () => {
+  suite.add('openpgp.encrypt/decrypt (PGP, text @ 6000MB, with streaming)', async () => {
     await stream.loadStreamsPonyfill();
 
     const userID = { name: 'test', email: 'a@b.com' };
@@ -223,7 +223,7 @@ class MemoryBenchamrkSuite {
 
     function* largeDataGenerator() {
       const chunkSize = 1024 * 1024; /*1MB*/
-      const numberOfChunks = 100;
+      const numberOfChunks = 6000;
 
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield 'a'.repeat(chunkSize);
@@ -242,7 +242,11 @@ class MemoryBenchamrkSuite {
       privateKey: await openpgp.readKey({ armoredKey: rawPrivateKey }),
       passphrase
     });
-    await openpgp.decrypt({ message: encryptedMessage, decryptionKeys: privateKey });
+    await openpgp.decrypt({
+      message: encryptedMessage,
+      decryptionKeys: privateKey,
+      config: { allowUnauthenticatedStream: true }
+    });
   });
 
   const stats = await suite.run();

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -109,9 +109,10 @@ class MemoryBenchamrkSuite {
   suite.add('empty test (baseline)', () => {});
 
   suite.add('openpgp.encrypt/decrypt (CFB, binary)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(1000000).fill(1) });
+    const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(ONE_MEGABYTE) });
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
@@ -120,9 +121,10 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(10000000 / 2) }); // two bytes per character
+    const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(ONE_MEGABYTE / 2) }); // two bytes per character
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
@@ -131,9 +133,10 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, binary)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(1000000).fill(1) });
+    const plaintextMessage = await openpgp.createMessage({ binary: new Uint8Array(ONE_MEGABYTE) });
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
@@ -142,9 +145,10 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(10000000 / 2) }); // two bytes per character
+    const plaintextMessage = await openpgp.createMessage({ text: 'a'.repeat(ONE_MEGABYTE / 2) }); // two bytes per character
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
@@ -154,9 +158,17 @@ class MemoryBenchamrkSuite {
 
   // streaming tests
   suite.add('openpgp.encrypt/decrypt (CFB, binary, with streaming)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
+      for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
+        yield chunk;
+      }
+    }
+
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ binary: require('stream').Readable.from([new Uint8Array(1000000).fill(1)]) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: new Uint8Array(ONE_MEGABYTE), numberOfChunks: 1 }));
+    const plaintextMessage = await openpgp.createMessage({ binary: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -171,9 +183,17 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text, with streaming)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
+      for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
+        yield chunk;
+      }
+    }
+
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: require('stream').Readable.from(['a'.repeat(10000000 / 2)]) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE / 2), numberOfChunks: 1 }));
+    const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -188,9 +208,17 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, binary, with streaming)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
+      for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
+        yield chunk;
+      }
+    }
+
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ binary: require('stream').Readable.from([new Uint8Array(1000000).fill(1)]) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: new Uint8Array(ONE_MEGABYTE), numberOfChunks: 1 }));
+    const plaintextMessage = await openpgp.createMessage({ binary:inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -205,9 +233,17 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text, with streaming)', async () => {
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
+      for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
+        yield chunk;
+      }
+    }
+
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: require('stream').Readable.from(['a'.repeat(10000000 / 2)]) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE / 2), numberOfChunks: 1 }));
+    const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -222,11 +258,8 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with streaming)', async () => {
-    function* largeTextDataGenerator() {
-      const chunkSize = 1024 * 1024; // 1MB
-      const numberOfChunks = 100;
-
-      const chunk = 'a'.repeat(chunkSize);
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
       }
@@ -234,7 +267,8 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: require('stream').Readable.from(largeTextDataGenerator()) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -249,11 +283,8 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (CFB, text @ 100MB, with unauthenticated streaming)', async () => {
-    function* largeTextDataGenerator() {
-      const chunkSize = 1024 * 1024; // 1MB
-      const numberOfChunks = 100;
-
-      const chunk = 'a'.repeat(chunkSize);
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
       }
@@ -261,7 +292,8 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: false, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: require('stream').Readable.from(largeTextDataGenerator()) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
@@ -280,11 +312,8 @@ class MemoryBenchamrkSuite {
   });
 
   suite.add('openpgp.encrypt/decrypt (AEAD, text @ 100MB, with streaming)', async () => {
-    function* largeTextDataGenerator() {
-      const chunkSize = 1024 * 1024; // 1MB
-      const numberOfChunks = 100;
-
-      const chunk = 'a'.repeat(chunkSize);
+    const ONE_MEGABYTE = 1024 * 1024;
+    function* largeDataGenerator({ chunk, numberOfChunks }) {
       for (let chunkNumber = 0; chunkNumber < numberOfChunks; chunkNumber++) {
         yield chunk;
       }
@@ -292,7 +321,8 @@ class MemoryBenchamrkSuite {
 
     const passwords = 'password';
     const config = { aeadProtect: true, preferredCompressionAlgorithm: openpgp.enums.compression.uncompressed };
-    const plaintextMessage = await openpgp.createMessage({ text: require('stream').Readable.from(largeTextDataGenerator()) });
+    const inputStream = require('stream').Readable.from(largeDataGenerator({ chunk: 'a'.repeat(ONE_MEGABYTE), numberOfChunks: 100 }));
+    const plaintextMessage = await openpgp.createMessage({ text: inputStream });
     assert(plaintextMessage.fromStream);
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -213,7 +213,7 @@ class MemoryBenchamrkSuite {
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
-  suite.add('openpgp.encrypt/decrypt (PGP, text @ 6000MB, with streaming)', async () => {
+  suite.add('openpgp.encrypt/decrypt (MDC, text @ 6000MB, with streaming)', async () => {
     await stream.loadStreamsPonyfill();
 
     const userID = { name: 'test', email: 'a@b.com' };


### PR DESCRIPTION
# Introduction

We are working on larger files which result in the process crashing with the following stack trace, and reproduced with the following commit: https://github.com/justin-lovell/openpgpjs/commit/68c7c29bd140202591550c20d895af426d769e07
```
node:buffer:602
    slice: (buf, start, end) => buf.ucs2Slice(start, end),
                                    ^

Error: Failed to allocate memory
    at Object.slice (node:buffer:602:37)
    at Uint8Array.toString (node:buffer:811:14)
    at TextDecoder.decode (node:internal/encoding:431:18)
    at r (C:\src\card-data-importer-poc\node_modules\openpgp\dist\node\openpgp.min.js:2:14559)
    at C:\src\card-data-importer-poc\node_modules\openpgp\dist\node\openpgp.min.js:2:6762
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 'ERR_MEMORY_ALLOCATION_FAILED'
```

This has been a long standing issue as per the following issues:
* https://github.com/openpgpjs/openpgpjs/issues/1012
* https://github.com/openpgpjs/openpgpjs/issues/1449

# Solution

The reason why memory allocations grow is due to the eager loading of the stream to perform integrity checks on the checksum. The key lines are the following:

https://github.com/openpgpjs/openpgpjs/blob/6da1c53de7852000fd63bacf1809b7e1ea17cf11/src/packet/sym_encrypted_integrity_protected_data.js#L137-L139

There is an `option` which may be set for `allowUnauthenticatedStream` -- this is largely undocumented and not mentioned. This PR would advise on the option and provide an assertion that the client should perform a double stream pass to ensure the integrity check had the opportunity to verify the packet.

# Additional Test Case

An additional test case was added to guard against an accidental regression for processing large files. 