### PR TITLE
Moved functionality to check for Edge browser to shimmable function in util object

### DIFF
--- a/src/crypto/hash/index.js
+++ b/src/crypto/hash/index.js
@@ -77,7 +77,7 @@ if (nodeCrypto) { // Use Node native crypto for all hash functions
 } else { // Use JS fallbacks
   hashFunctions = {
     md5: md5,
-    sha1: asmcryptoHash(Sha1, (!navigator.userAgent || navigator.userAgent.indexOf('Edge') === -1) && 'SHA-1'),
+    sha1: asmcryptoHash(Sha1, !util.isEdge() && 'SHA-1'),
     sha224: hashjsHash(sha224),
     sha256: asmcryptoHash(Sha256, 'SHA-256'),
     sha384: hashjsHash(sha384, 'SHA-384'),

--- a/src/crypto/mode/eax.js
+++ b/src/crypto/mode/eax.js
@@ -51,7 +51,7 @@ async function CTR(key) {
   if (
     util.getWebCrypto() &&
     key.length !== 24 && // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
-    (!navigator.userAgent || navigator.userAgent.indexOf('Edge') === -1)
+    (!util.isEdge())
   ) {
     key = await webCrypto.importKey('raw', key, { name: 'AES-CTR', length: key.length * 8 }, false, ['encrypt']);
     return async function(pt, iv) {

--- a/src/crypto/mode/gcm.js
+++ b/src/crypto/mode/gcm.js
@@ -56,7 +56,7 @@ async function GCM(cipher, key) {
           !pt.length ||
           // iOS does not support GCM-en/decrypting empty messages
           // Also, synchronous en/decryption might be faster in this case.
-          (!adata.length && navigator.userAgent && navigator.userAgent.indexOf('Edge') !== -1)
+          (!adata.length && util.isEdge())
           // Edge does not support GCM-en/decrypting without ADATA
         ) {
           return AES_GCM.encrypt(pt, key, iv, adata);
@@ -70,7 +70,7 @@ async function GCM(cipher, key) {
           ct.length === tagLength ||
           // iOS does not support GCM-en/decrypting empty messages
           // Also, synchronous en/decryption might be faster in this case.
-          (!adata.length && navigator.userAgent && navigator.userAgent.indexOf('Edge') !== -1)
+          (!adata.length && util.isEdge())
           // Edge does not support GCM-en/decrypting without ADATA
         ) {
           return AES_GCM.decrypt(ct, key, iv, adata);

--- a/src/util.js
+++ b/src/util.js
@@ -617,7 +617,20 @@ const util = {
    */
   selectUint8: function(cond, a, b) {
     return (a & (256 - cond)) | (b & (255 + cond));
-  }
+  },
+  /**
+   * @returns true if running on the Edge browser, false otherwise.
+   */
+  isEdge: (function() {
+    // we only need to compute this value once, so cache it first time we look
+    let _isEdge = undefined;
+    return function() {
+      if (_isEdge === undefined) {
+        _isEdge = !!(navigator.userAgent && navigator.userAgent.indexOf('Edge') !== -1)
+      }
+      return _isEdge;
+    }
+  })(),
 };
 
 export default util;


### PR DESCRIPTION
Moved functionality to check for Edge browser to util object.
Cache value to avoid computing it several times.
This makes the function shimmable as well
(so it can be replaced in non-browser environments).