### PR TITLE
Check existence of `navigator` before using it

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -430,7 +430,8 @@ const util = {
       return os.cpus().length;
     }
 
-    return navigator.hardwareConcurrency || 1;
+    // eslint-disable-next-line no-mixed-operators
+    return typeof navigator !== 'undefined' && navigator.hardwareConcurrency || 1;
   },
 
   isEmailAddress: function(data) {

--- a/src/util.js
+++ b/src/util.js
@@ -430,8 +430,7 @@ const util = {
       return os.cpus().length;
     }
 
-    // eslint-disable-next-line no-mixed-operators
-    return typeof navigator !== 'undefined' && navigator.hardwareConcurrency || 1;
+    return (typeof navigator !== 'undefined' && navigator.hardwareConcurrency) || 1;
   },
 
   isEmailAddress: function(data) {


### PR DESCRIPTION
Fix #1464. Depends on #1474.