### PR TITLE
Fix SignaturePacket.verify() Typescript definition

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -522,7 +522,7 @@ export class SignaturePacket extends BasePacket {
   public preferredAEADAlgorithms: enums.aead[] | null;
   public revoked: null | boolean;
   public sign(key: AnySecretKeyPacket, data: Uint8Array, date?: Date, detached?: boolean): Promise<void>;
-  public verify(key: AnyKeyPacket, signatureType: enums.signature, data: Uint8Array, date?: Date, detached?: boolean, config?: Config): Promise<void>; // throws on error
+  public verify(key: AnyKeyPacket, signatureType: enums.signature, data: string | object, date?: Date, detached?: boolean, config?: Config): Promise<void>; // throws on error
   public isExpired(date?: Date): boolean;
   public getExpirationTime(): Date | typeof Infinity;
 }

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -522,7 +522,7 @@ export class SignaturePacket extends BasePacket {
   public preferredAEADAlgorithms: enums.aead[] | null;
   public revoked: null | boolean;
   public sign(key: AnySecretKeyPacket, data: Uint8Array, date?: Date, detached?: boolean): Promise<void>;
-  public verify(key: AnyKeyPacket, signatureType: enums.signature, data: string | object, date?: Date, detached?: boolean, config?: Config): Promise<void>; // throws on error
+  public verify(key: AnyKeyPacket, signatureType: enums.signature, data: Uint8Array | object, date?: Date, detached?: boolean, config?: Config): Promise<void>; // throws on error
   public isExpired(date?: Date): boolean;
   public getExpirationTime(): Date | typeof Infinity;
 }

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -652,7 +652,7 @@ class SignaturePacket {
    * @param {PublicSubkeyPacket|PublicKeyPacket|
    *         SecretSubkeyPacket|SecretKeyPacket} key - the public key to verify the signature
    * @param {module:enums.signature} signatureType - Expected signature type
-   * @param {String|Object} data - Data which on the signature applies
+   * @param {Uint8Array|Object} data - Data which on the signature applies
    * @param {Date} [date] - Use the given date instead of the current time to check for signature validity and expiration
    * @param {Boolean} [detached] - Whether to verify a detached signature
    * @param {Object} [config] - Full configuration, defaults to openpgp.config


### PR DESCRIPTION
According to doc comment in signature.js:
```javascript
  /**
   * verifies the signature packet. Note: not all signature types are implemented
   * ...
   * @param {String|Object} data - Data which on the signature applies
   * ...
   */
```
But it is `Uint8Array` currently in the openpgp.d.ts.
 