### PR TITLE
TS: Rely on new `web-stream-tools` types, fix `SignOptions`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,13 +261,20 @@
       "dev": true
     },
     "@openpgp/web-stream-tools": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.9.tgz",
-      "integrity": "sha512-GEKuXpQRshUqgKH4sMcwYbHolxaUSHIowcIMd02EsnLv4q5acP0z9pRUy3kjV0ZyRPgyD0vXAy60Rf0MPKoCMw==",
+      "version": "github:larabr/web-stream-tools#494806ee715f07f2ae3704024541f071e066a516",
+      "from": "github:larabr/web-stream-tools#ts-definitions",
       "dev": true,
       "requires": {
         "@mattiasbuelens/web-streams-adapter": "~0.1.0",
         "web-streams-polyfill": "~3.0.3"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+          "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-commonjs": {
@@ -5137,9 +5144,9 @@
       "dev": true
     },
     "web-streams-polyfill": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-      "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@openpgp/pako": "^1.0.12",
     "@openpgp/seek-bzip": "^1.0.5-git",
     "@openpgp/tweetnacl": "^1.0.3",
-    "@openpgp/web-stream-tools": "0.0.9",
+    "@openpgp/web-stream-tools": "github:larabr/web-stream-tools#ts-definitions",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",
@@ -87,7 +87,8 @@
     "rollup": "^2.38.5",
     "rollup-plugin-terser": "^7.0.2",
     "sinon": "^4.3.0",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "web-streams-polyfill": "^3.2.0"
   },
   "dependencies": {
     "asn1.js": "^5.0.0"

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -5,6 +5,8 @@
  *  - if it fails to build, edit the file to match type definitions
  *  - if it fails to run, edit this file to match the actual library API, then edit the definitions file (openpgp.d.ts) accordingly.
  */
+import { ReadableStream as WebReadableStream } from 'web-streams-polyfill';
+import { createReadStream } from 'fs';
 
 import { expect } from 'chai';
 import {
@@ -12,7 +14,8 @@ import {
   readMessage, createMessage, Message, createCleartextMessage,
   encrypt, decrypt, sign, verify, config, enums,
   generateSessionKey, encryptSessionKey, decryptSessionKeys,
-  LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket, CleartextMessage
+  LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket, CleartextMessage,
+  WebStream, NodeStream,
 } from '../..';
 
 (async () => {
@@ -100,8 +103,10 @@ import {
   // Get session keys from encrypted message
   const sessionKeys = await decryptSessionKeys({ message: await readMessage({ binaryMessage: encryptedBinary }), decryptionKeys: privateKeys });
   expect(sessionKeys).to.have.length(1);
-  const encryptedSessionKeys: string = await encryptSessionKey({ ...sessionKeys[0], passwords: 'pass', algorithm: 'aes128', aeadAlgorithm: 'eax' });
-  expect(encryptedSessionKeys).to.include('-----BEGIN PGP MESSAGE-----');
+  const armoredEncryptedSessionKeys: string = await encryptSessionKey({ ...sessionKeys[0], passwords: 'pass', algorithm: 'aes128', aeadAlgorithm: 'eax' });
+  expect(armoredEncryptedSessionKeys).to.include('-----BEGIN PGP MESSAGE-----');
+  const encryptedSessionKeys: Message<any> = await encryptSessionKey({ ...sessionKeys[0], passwords: 'pass', algorithm: 'aes128', aeadAlgorithm: 'eax', format: 'object' });
+  expect(encryptedSessionKeys).to.be.instanceOf(Message);
   const newSessionKey = await generateSessionKey({ encryptionKeys: privateKey.toPublic() });
   expect(newSessionKey.data).to.exist;
   expect(newSessionKey.algorithm).to.exist;
@@ -180,19 +185,25 @@ import {
   // const signed = await sign({ privateKeys, message, detached: true, format: 'binary' });
   // console.log(signed); // Uint8Array
 
-  // // Streaming - encrypt text message on Node.js (armored)
-  // const data = fs.createReadStream(filename, { encoding: 'utf8' });
-  // const message = await createMessage({ text: data });
-  // const encrypted = await encrypt({ publicKeys, message });
-  // encrypted.on('data', chunk => {
-  //   console.log(chunk); // String
-  // });
+  // Streaming - encrypt text message (armored output)
+  try {
+    const nodeTextStream = createReadStream('non-existent-file', { encoding: 'utf8' });
+    const messageFromNodeTextStream = await createMessage({ text: nodeTextStream });
+    (await encrypt({ message: messageFromNodeTextStream, passwords: 'password', format: 'armored' })) as NodeStream<string>;
+  } catch (err) {}
+  const webTextStream = new WebReadableStream<string>();
+  const messageFromWebTextStream = await createMessage({ text: webTextStream });
+  (await encrypt({ message: messageFromWebTextStream, passwords: 'password', format: 'armored' })) as WebStream<string>;
 
-  // // Streaming - encrypt binary message on Node.js (unarmored)
-  // const data = fs.createReadStream(filename);
-  // const message = await createMessage({ binary: data });
-  // const encrypted = await encrypt({ publicKeys, message, format: 'binary' });
-  // encrypted.pipe(targetStream);
+  // Streaming - encrypt binary message (binary output)
+  try {
+    const nodeBinaryStream = createReadStream('non-existent-file');
+    const messageFromNodeBinaryStream = await createMessage({ binary: nodeBinaryStream });
+    (await encrypt({ message: messageFromNodeBinaryStream, passwords: 'password', format: 'binary' })) as NodeStream<Uint8Array>;
+  } catch (err) {}
+  const webBinaryStream = new WebReadableStream<Uint8Array>();
+  const messageFromWebBinaryStream = await createMessage({ binary: webBinaryStream });
+  (await encrypt({ message: messageFromWebBinaryStream, passwords: 'password', format: 'binary' })) as WebStream<Uint8Array>;
 
   console.log('TypeScript definitions are correct');
 })().catch(e => {


### PR DESCRIPTION
Also, add `EncryptSessionKeyOptions` to make it easier to declare wrapper functions of `encryptSessionKey`.

TODO:
- [ ] point to released web-stream-tools version