### PR TITLE
Fix AES encryption error in browsers for messages larger than 3MB

### DIFF
--- a/src/crypto/mode/cfb.js
+++ b/src/crypto/mode/cfb.js
@@ -23,8 +23,8 @@
  */
 
 import { AES_CFB } from '@openpgp/asmcrypto.js/dist_es8/aes/cfb';
-
 import * as stream from '@openpgp/web-stream-tools';
+import { getCipher } from '../crypto';
 import * as cipher from '../cipher';
 import util from '../../util';
 import enums from '../../enums';
@@ -160,7 +160,7 @@ function xorMut(a, b) {
 async function webEncrypt(algo, key, pt, iv) {
   const ALGO = 'AES-CBC';
   const _key = await webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt']);
-  const { blockSize } = crypto.getCipher(algo);
+  const { blockSize } = getCipher(algo);
   const cbc_pt = util.concatUint8Array([new Uint8Array(blockSize), pt]);
   const ct = new Uint8Array(await webCrypto.encrypt({ name: ALGO, iv }, _key, cbc_pt)).subarray(0, pt.length);
   xorMut(ct, pt);


### PR DESCRIPTION
In browsers, encryption of messages larger than 3MB (or other custom value based on `config.minBytesForWebCrypto`) would throw the error `Error encrypting message: 'crypto.getCipher' is not a function` due to a missing import statement. This wasn't caught by the linter since the module name (`crypto`) is the same as the global browser variable.

[Issue reported by @panchiniak](https://gitter.im/openpgpjs/openpgpjs?at=622dd6940909252318214c4d).