### PR TITLE
Add `UnparsablePacket` to properly deal with key blocks that include malformed/unsupported packets

### DIFF
--- a/src/key/key.js
+++ b/src/key/key.js
@@ -28,9 +28,15 @@ import Subkey from './subkey';
 import * as helper from './helper';
 import PrivateKey from './private_key';
 import PublicKey from './public_key';
+import { UnparsablePacket } from '../packet/packet';
 
 // A key revocation certificate can contain the following packets
 const allowedRevocationPackets = /*#__PURE__*/ util.constructAllowedPackets([SignaturePacket]);
+const mainKeyPacketTags = new Set([enums.packet.publicKey, enums.packet.privateKey]);
+const keyPacketTags = new Set([
+  enums.packet.publicKey, enums.packet.privateKey,
+  enums.packet.publicSubkey, enums.packet.privateSubkey
+]);
 
 /**
  * Abstract class that represents an OpenPGP key. Must contain a primary key.
@@ -51,8 +57,29 @@ class Key {
     let user;
     let primaryKeyID;
     let subkey;
+    let ignoreUntil;
+
     for (const packet of packetlist) {
+
+      if (packet instanceof UnparsablePacket) {
+        const isUnparsableKeyPacket = keyPacketTags.has(packet.tag);
+        if (isUnparsableKeyPacket && !ignoreUntil){
+          // Since non-key packets apply to the preceding key packet, if a (sub)key is unparsable we must
+          // discard all non-key packets that follow, until another (sub)key packet is found.
+          if (mainKeyPacketTags.has(packet.tag)) {
+            ignoreUntil = mainKeyPacketTags;
+          } else {
+            ignoreUntil = keyPacketTags;
+          }
+        }
+        continue;
+      }
+
       const tag = packet.constructor.tag;
+      if (ignoreUntil) {
+        if (!ignoreUntil.has(tag)) continue;
+        ignoreUntil = null;
+      }
       if (disallowedPackets.has(tag)) {
         throw new Error(`Unexpected packet type: ${tag}`);
       }

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -309,3 +309,13 @@ export class UnsupportedError extends Error {
   }
 }
 
+export class UnparsablePacket {
+  constructor(tag, rawContent) {
+    this.tag = tag;
+    this.rawContent = rawContent;
+  }
+
+  write() {
+    return this.rawContent;
+  }
+}

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -3,6 +3,7 @@ import {
   readPackets, supportsStreaming,
   writeTag, writeHeader,
   writePartialLength, writeSimpleLength,
+  UnparsablePacket,
   UnsupportedError
 } from './packet';
 import util from '../util';
@@ -89,6 +90,9 @@ class PacketList extends Array {
                 // Those are also the ones we want to be more strict about and throw on parse errors
                 // (since we likely cannot process the message without these packets anyway).
                 await writer.abort(e);
+              } else {
+                const unparsedPacket = new UnparsablePacket(parsed.tag, parsed.packet);
+                await writer.write(unparsedPacket);
               }
               util.printDebugError(e);
             }
@@ -129,12 +133,13 @@ class PacketList extends Array {
     const arr = [];
 
     for (let i = 0; i < this.length; i++) {
+      const tag = this[i] instanceof UnparsablePacket ? this[i].tag : this[i].constructor.tag;
       const packetbytes = this[i].write();
       if (util.isStream(packetbytes) && supportsStreaming(this[i].constructor.tag)) {
         let buffer = [];
         let bufferLength = 0;
         const minLength = 512;
-        arr.push(writeTag(this[i].constructor.tag));
+        arr.push(writeTag(tag));
         arr.push(stream.transform(packetbytes, value => {
           buffer.push(value);
           bufferLength += value.length;
@@ -152,9 +157,9 @@ class PacketList extends Array {
           let length = 0;
           arr.push(stream.transform(stream.clone(packetbytes), value => {
             length += value.length;
-          }, () => writeHeader(this[i].constructor.tag, length)));
+          }, () => writeHeader(tag, length)));
         } else {
-          arr.push(writeHeader(this[i].constructor.tag, packetbytes.length));
+          arr.push(writeHeader(tag, packetbytes.length));
         }
         arr.push(packetbytes);
       }

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -969,7 +969,8 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
       packets.push(signaturePacket);
       const bytes = packets.write();
       const parsed = await openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true });
-      expect(parsed.length).to.equal(0);
+      expect(parsed.length).to.equal(1);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.signature);
     });
 
     it('Throws on unknown packet version with `config.ignoreUnsupportedPackets` disabled', async function() {
@@ -1011,7 +1012,8 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
         openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, maxUserIDLength: 2, ignoreMalformedPackets: false })
       ).to.be.rejectedWith(/User ID string is too long/);
       const parsed = await openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, maxUserIDLength: 2, ignoreMalformedPackets: true });
-      expect(parsed.length).to.equal(0);
+      expect(parsed.length).to.equal(1);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.userID);
     });
   });
 });


### PR DESCRIPTION
Fix #1420 : when parsing errors are being ignored, packets that fail to parse are now included in the resulting packet list as `UnparsablePacket`s . This way, when parsing keys that contain unparsable (sub)key, we avoid associating the following non-key packets to the wrong key entity.

On serialization, `UnparsablePacket`s are also included by writing their raw packet body as it was read.