### PR TITLE
Throw `UnsupportedError` on unknown algorithm in keys, signatures and encrypted session keys

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -74,11 +74,11 @@ export abstract class Key {
 
 type AllowedKeyPackets = PublicKeyPacket | PublicSubkeyPacket | SecretKeyPacket | SecretSubkeyPacket | UserIDPacket | UserAttributePacket | SignaturePacket;
 export class PublicKey extends Key {
-  constructor(packetlist: PacketList<AnyKeyPacket>);
+  constructor(packetlist: PacketList<AnyPacket>);
 }
 
 export class PrivateKey extends PublicKey {
-  constructor(packetlist: PacketList<AnyKeyPacket>);
+  constructor(packetlist: PacketList<AnyPacket>);
   public revoke(reason?: ReasonForRevocation, date?: Date, config?: Config): Promise<PrivateKey>;
   public isDecrypted(): boolean;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
@@ -527,7 +527,12 @@ export class TrustPacket extends BasePacket {
   static readonly tag: enums.packet.trust;
 }
 
-export type AnyPacket = BasePacket;
+export class UnparsablePacket {
+  tag: enums.packet;
+  write: () => Uint8Array;
+}
+
+export type AnyPacket = BasePacket | UnparsablePacket;
 export type AnySecretKeyPacket = SecretKeyPacket | SecretSubkeyPacket;
 export type AnyKeyPacket = BasePublicKeyPacket;
 

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -527,12 +527,12 @@ export class TrustPacket extends BasePacket {
   static readonly tag: enums.packet.trust;
 }
 
-export class UnparsablePacket {
+export class UnparseablePacket {
   tag: enums.packet;
   write: () => Uint8Array;
 }
 
-export type AnyPacket = BasePacket | UnparsablePacket;
+export type AnyPacket = BasePacket | UnparseablePacket;
 export type AnySecretKeyPacket = SecretKeyPacket | SecretSubkeyPacket;
 export type AnyKeyPacket = BasePublicKeyPacket;
 

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -106,7 +106,7 @@ export async function publicKeyDecrypt(algo, publicKeyParams, privateKeyParams, 
         oid, kdfParams, V, C.data, Q, d, fingerprint);
     }
     default:
-      throw new Error('Invalid public key encryption algorithm.');
+      throw new Error('Unknown public key encryption algorithm.');
   }
 }
 
@@ -157,7 +157,7 @@ export function parsePublicKeyParams(algo, bytes) {
       return { read: read, publicParams: { oid, Q, kdfParams } };
     }
     default:
-      throw new UnsupportedError('Invalid public key encryption algorithm.');
+      throw new UnsupportedError('Unknown public key encryption algorithm.');
   }
 }
 
@@ -198,7 +198,7 @@ export function parsePrivateKeyParams(algo, bytes, publicParams) {
       return { read, privateParams: { seed } };
     }
     default:
-      throw new UnsupportedError('Invalid public key encryption algorithm.');
+      throw new UnsupportedError('Unknown public key encryption algorithm.');
   }
 }
 
@@ -235,7 +235,7 @@ export function parseEncSessionKeyParams(algo, bytes) {
       return { V, C };
     }
     default:
-      throw new Error('Invalid public key encryption algorithm.');
+      throw new Error('Unknown public key encryption algorithm.');
   }
 }
 
@@ -294,7 +294,7 @@ export function generateParams(algo, bits, oid) {
     case enums.publicKey.elgamal:
       throw new Error('Unsupported algorithm for key generation.');
     default:
-      throw new Error('Invalid public key algorithm.');
+      throw new Error('Unknown public key algorithm.');
   }
 }
 
@@ -341,7 +341,7 @@ export async function validateParams(algo, publicParams, privateParams) {
       return publicKey.elliptic.eddsa.validateParams(oid, Q, seed);
     }
     default:
-      throw new Error('Invalid public key algorithm.');
+      throw new Error('Unknown public key algorithm.');
   }
 }
 

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -34,6 +34,7 @@ import enums from '../enums';
 import util from '../util';
 import OID from '../type/oid';
 import { Curve } from './public_key/elliptic/curves';
+import { UnsupportedError } from '../packet/packet';
 
 /**
  * Encrypts data using specified algorithm and public key parameters.
@@ -156,7 +157,7 @@ export function parsePublicKeyParams(algo, bytes) {
       return { read: read, publicParams: { oid, Q, kdfParams } };
     }
     default:
-      throw new Error('Invalid public key encryption algorithm.');
+      throw new UnsupportedError('Invalid public key encryption algorithm.');
   }
 }
 
@@ -197,7 +198,7 @@ export function parsePrivateKeyParams(algo, bytes, publicParams) {
       return { read, privateParams: { seed } };
     }
     default:
-      throw new Error('Invalid public key encryption algorithm.');
+      throw new UnsupportedError('Invalid public key encryption algorithm.');
   }
 }
 

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -235,7 +235,7 @@ export function parseEncSessionKeyParams(algo, bytes) {
       return { V, C };
     }
     default:
-      throw new Error('Unknown public key encryption algorithm.');
+      throw new UnsupportedError('Unknown public key encryption algorithm.');
   }
 }
 

--- a/src/crypto/public_key/elliptic/curves.js
+++ b/src/crypto/public_key/elliptic/curves.js
@@ -28,6 +28,7 @@ import util from '../../../util';
 import { uint8ArrayToB64, b64ToUint8Array } from '../../../encoding/base64';
 import OID from '../../../type/oid';
 import { keyFromPublic, keyFromPrivate, getIndutnyCurve } from './indutnyKey';
+import { UnsupportedError } from '../../../packet/packet';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -145,7 +146,7 @@ class Curve {
       // by curve name or oid string
       this.name = enums.write(enums.curve, oidOrName);
     } catch (err) {
-      throw new Error('Not valid curve');
+      throw new UnsupportedError('Unknown curve');
     }
     params = params || curves[this.name];
 

--- a/src/crypto/signature.js
+++ b/src/crypto/signature.js
@@ -56,7 +56,7 @@ export function parseSignatureParams(algo, signature) {
       return { r, s };
     }
     default:
-      throw new UnsupportedError('Invalid signature algorithm.');
+      throw new UnsupportedError('Unknown signature algorithm.');
   }
 }
 
@@ -102,7 +102,7 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
       return publicKey.elliptic.eddsa.verify(oid, hashAlgo, signature, data, Q, hashed);
     }
     default:
-      throw new Error('Invalid signature algorithm.');
+      throw new Error('Unknown signature algorithm.');
   }
 }
 
@@ -152,6 +152,6 @@ export async function sign(algo, hashAlgo, publicKeyParams, privateKeyParams, da
       return publicKey.elliptic.eddsa.sign(oid, hashAlgo, data, Q, seed, hashed);
     }
     default:
-      throw new Error('Invalid signature algorithm.');
+      throw new Error('Unknown signature algorithm.');
   }
 }

--- a/src/crypto/signature.js
+++ b/src/crypto/signature.js
@@ -7,6 +7,7 @@
 import publicKey from './public_key';
 import enums from '../enums';
 import util from '../util';
+import { UnsupportedError } from '../packet/packet';
 
 /**
  * Parse signature in binary form to get the parameters.
@@ -55,7 +56,7 @@ export function parseSignatureParams(algo, signature) {
       return { r, s };
     }
     default:
-      throw new Error('Invalid signature algorithm.');
+      throw new UnsupportedError('Invalid signature algorithm.');
   }
 }
 

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -340,7 +340,7 @@ export function sanitizeKeyOptions(options, subkeyDefaults = {}) {
       try {
         options.curve = enums.write(enums.curve, options.curve);
       } catch (e) {
-        throw new Error('Invalid curve');
+        throw new Error('Unknown curve');
       }
       if (options.curve === enums.curve.ed25519 || options.curve === enums.curve.curve25519) {
         options.curve = options.sign ? enums.curve.ed25519 : enums.curve.curve25519;

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -28,7 +28,7 @@ import Subkey from './subkey';
 import * as helper from './helper';
 import PrivateKey from './private_key';
 import PublicKey from './public_key';
-import { UnparsablePacket } from '../packet/packet';
+import { UnparseablePacket } from '../packet/packet';
 
 // A key revocation certificate can contain the following packets
 const allowedRevocationPackets = /*#__PURE__*/ util.constructAllowedPackets([SignaturePacket]);
@@ -61,10 +61,10 @@ class Key {
 
     for (const packet of packetlist) {
 
-      if (packet instanceof UnparsablePacket) {
-        const isUnparsableKeyPacket = keyPacketTags.has(packet.tag);
-        if (isUnparsableKeyPacket && !ignoreUntil){
-          // Since non-key packets apply to the preceding key packet, if a (sub)key is unparsable we must
+      if (packet instanceof UnparseablePacket) {
+        const isUnparseableKeyPacket = keyPacketTags.has(packet.tag);
+        if (isUnparseableKeyPacket && !ignoreUntil){
+          // Since non-key packets apply to the preceding key packet, if a (sub)key is Unparseable we must
           // discard all non-key packets that follow, until another (sub)key packet is found.
           if (mainKeyPacketTags.has(packet.tag)) {
             ignoreUntil = mainKeyPacketTags;

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -28,9 +28,15 @@ import Subkey from './subkey';
 import * as helper from './helper';
 import PrivateKey from './private_key';
 import PublicKey from './public_key';
+import { UnparsablePacket } from '../packet/packet';
 
 // A key revocation certificate can contain the following packets
 const allowedRevocationPackets = /*#__PURE__*/ util.constructAllowedPackets([SignaturePacket]);
+const mainKeyPacketTags = new Set([enums.packet.publicKey, enums.packet.privateKey]);
+const keyPacketTags = new Set([
+  enums.packet.publicKey, enums.packet.privateKey,
+  enums.packet.publicSubkey, enums.packet.privateSubkey
+]);
 
 /**
  * Abstract class that represents an OpenPGP key. Must contain a primary key.
@@ -51,8 +57,29 @@ class Key {
     let user;
     let primaryKeyID;
     let subkey;
+    let ignoreUntil;
+
     for (const packet of packetlist) {
+
+      if (packet instanceof UnparsablePacket) {
+        const isUnparsableKeyPacket = keyPacketTags.has(packet.tag);
+        if (isUnparsableKeyPacket && !ignoreUntil){
+          // Since non-key packets apply to the preceding key packet, if a (sub)key is unparsable we must
+          // discard all non-key packets that follow, until another (sub)key packet is found.
+          if (mainKeyPacketTags.has(packet.tag)) {
+            ignoreUntil = mainKeyPacketTags;
+          } else {
+            ignoreUntil = keyPacketTags;
+          }
+        }
+        continue;
+      }
+
       const tag = packet.constructor.tag;
+      if (ignoreUntil) {
+        if (!ignoreUntil.has(tag)) continue;
+        ignoreUntil = null;
+      }
       if (disallowedPackets.has(tag)) {
         throw new Error(`Unexpected packet type: ${tag}`);
       }

--- a/src/packet/index.js
+++ b/src/packet/index.js
@@ -1,2 +1,3 @@
 export * from './all_packets';
 export { default as PacketList } from './packetlist';
+export { UnparsablePacket } from './packet';

--- a/src/packet/index.js
+++ b/src/packet/index.js
@@ -1,3 +1,3 @@
 export * from './all_packets';
 export { default as PacketList } from './packetlist';
-export { UnparsablePacket } from './packet';
+export { UnparseablePacket } from './packet';

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -309,3 +309,13 @@ export class UnsupportedError extends Error {
   }
 }
 
+export class UnparsablePacket {
+  constructor(tag, rawContent) {
+    this.tag = tag;
+    this.rawContent = rawContent;
+  }
+
+  write() {
+    return this.rawContent;
+  }
+}

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -309,7 +309,7 @@ export class UnsupportedError extends Error {
   }
 }
 
-export class UnparsablePacket {
+export class UnparseablePacket {
   constructor(tag, rawContent) {
     this.tag = tag;
     this.rawContent = rawContent;

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -3,7 +3,7 @@ import {
   readPackets, supportsStreaming,
   writeTag, writeHeader,
   writePartialLength, writeSimpleLength,
-  UnparsablePacket,
+  UnparseablePacket,
   UnsupportedError
 } from './packet';
 import util from '../util';
@@ -91,7 +91,7 @@ class PacketList extends Array {
                 // (since we likely cannot process the message without these packets anyway).
                 await writer.abort(e);
               } else {
-                const unparsedPacket = new UnparsablePacket(parsed.tag, parsed.packet);
+                const unparsedPacket = new UnparseablePacket(parsed.tag, parsed.packet);
                 await writer.write(unparsedPacket);
               }
               util.printDebugError(e);
@@ -133,7 +133,7 @@ class PacketList extends Array {
     const arr = [];
 
     for (let i = 0; i < this.length; i++) {
-      const tag = this[i] instanceof UnparsablePacket ? this[i].tag : this[i].constructor.tag;
+      const tag = this[i] instanceof UnparseablePacket ? this[i].tag : this[i].constructor.tag;
       const packetbytes = this[i].write();
       if (util.isStream(packetbytes) && supportsStreaming(this[i].constructor.tag)) {
         let buffer = [];

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -3,6 +3,7 @@ import {
   readPackets, supportsStreaming,
   writeTag, writeHeader,
   writePartialLength, writeSimpleLength,
+  UnparsablePacket,
   UnsupportedError
 } from './packet';
 import util from '../util';
@@ -89,6 +90,9 @@ class PacketList extends Array {
                 // Those are also the ones we want to be more strict about and throw on parse errors
                 // (since we likely cannot process the message without these packets anyway).
                 await writer.abort(e);
+              } else {
+                const unparsedPacket = new UnparsablePacket(parsed.tag, parsed.packet);
+                await writer.write(unparsedPacket);
               }
               util.printDebugError(e);
             }
@@ -129,12 +133,13 @@ class PacketList extends Array {
     const arr = [];
 
     for (let i = 0; i < this.length; i++) {
+      const tag = this[i] instanceof UnparsablePacket ? this[i].tag : this[i].constructor.tag;
       const packetbytes = this[i].write();
       if (util.isStream(packetbytes) && supportsStreaming(this[i].constructor.tag)) {
         let buffer = [];
         let bufferLength = 0;
         const minLength = 512;
-        arr.push(writeTag(this[i].constructor.tag));
+        arr.push(writeTag(tag));
         arr.push(stream.transform(packetbytes, value => {
           buffer.push(value);
           bufferLength += value.length;
@@ -152,9 +157,9 @@ class PacketList extends Array {
           let length = 0;
           arr.push(stream.transform(stream.clone(packetbytes), value => {
             length += value.length;
-          }, () => writeHeader(this[i].constructor.tag, length)));
+          }, () => writeHeader(tag, length)));
         } else {
-          arr.push(writeHeader(this[i].constructor.tag, packetbytes.length));
+          arr.push(writeHeader(tag, packetbytes.length));
         }
         arr.push(packetbytes);
       }

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -123,14 +123,9 @@ class PublicKeyPacket {
       }
 
       // - A series of values comprising the key material.
-      try {
-        const { read, publicParams } = crypto.parsePublicKeyParams(this.algorithm, bytes.subarray(pos));
-        this.publicParams = publicParams;
-        pos += read;
-      } catch (err) {
-        if (err instanceof UnsupportedError) throw err;
-        throw new Error('Error reading MPIs');
-      }
+      const { read, publicParams } = crypto.parsePublicKeyParams(this.algorithm, bytes.subarray(pos));
+      this.publicParams = publicParams;
+      pos += read;
 
       // we set the fingerprint and keyID already to make it possible to put together the key packets directly in the Key constructor
       await this.computeFingerprintAndKeyID();

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -128,6 +128,7 @@ class PublicKeyPacket {
         this.publicParams = publicParams;
         pos += read;
       } catch (err) {
+        if (err instanceof UnsupportedError) throw err;
         throw new Error('Error reading MPIs');
       }
 

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -21,6 +21,7 @@ import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
 import defaultConfig from '../config';
+import { UnsupportedError } from './packet';
 
 /**
  * A Secret-Key packet contains all the information that is found in a
@@ -155,6 +156,8 @@ class SecretKeyPacket extends PublicKeyPacket {
         const { privateParams } = crypto.parsePrivateKeyParams(this.algorithm, cleartext, this.publicParams);
         this.privateParams = privateParams;
       } catch (err) {
+        if (err instanceof UnsupportedError) throw err;
+        // avoid throwing potentially sensitive errors
         throw new Error('Error reading MPIs');
       }
     }

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -69,7 +69,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   it('Invalid curve oid', function (done) {
     expect(decrypt_message(
       '', 2, 7, [], [], [], [], []
-    )).to.be.rejectedWith(Error, /Not valid curve/).notify(done);
+    )).to.be.rejectedWith(Error, /Unknown curve/).notify(done);
   });
   it('Invalid ephemeral key', function (done) {
     if (!openpgp.config.useIndutnyElliptic && !util.getNodeCrypto()) {

--- a/test/crypto/elliptic.js
+++ b/test/crypto/elliptic.js
@@ -167,10 +167,10 @@ module.exports = () => describe('Elliptic Curve Cryptography @lightweight', func
       return Promise.all([
         expect(verify_signature(
           'invalid oid', 8, [], [], [], []
-        )).to.be.rejectedWith(Error, /Not valid curve/),
+        )).to.be.rejectedWith(Error, /Unknown curve/),
         expect(verify_signature(
           '\x00', 8, [], [], [], []
-        )).to.be.rejectedWith(Error, /Not valid curve/)
+        )).to.be.rejectedWith(Error, /Unknown curve/)
       ]);
     });
     it('Invalid public key', async function () {

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -969,7 +969,8 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
       packets.push(signaturePacket);
       const bytes = packets.write();
       const parsed = await openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true });
-      expect(parsed.length).to.equal(0);
+      expect(parsed.length).to.equal(1);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.signature);
     });
 
     it('Throws on unknown packet version with `config.ignoreUnsupportedPackets` disabled', async function() {
@@ -1011,7 +1012,8 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
         openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, maxUserIDLength: 2, ignoreMalformedPackets: false })
       ).to.be.rejectedWith(/User ID string is too long/);
       const parsed = await openpgp.PacketList.fromBinary(bytes, allAllowedPackets, { ...openpgp.config, maxUserIDLength: 2, ignoreMalformedPackets: true });
-      expect(parsed.length).to.equal(0);
+      expect(parsed.length).to.equal(1);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.userID);
     });
   });
 });

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -1022,6 +1022,20 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
       ).to.be.rejectedWith(/Unknown public key encryption algorithm/);
     });
 
+    it('Ignores unknown PKESK algorithm only with `config.ignoreUnsupportedPackets` enabled', async function() {
+      const binaryMessage = util.hexToUint8Array('c15e03c6a6737124ef0f5e63010740282956b4db64ea79e1b4b8e5c528241b5e1cf40b2f5df2a619692755d532353d30a8e044e7c96f51741c73e6c5c8f73db08daf66e49240afe90c9b50705d51e71ec2e7630c5bd86b002e1f6dbd638f61e2d23501830d9bb3711c66963363a6e5f8d9294210a0cd194174c3caa3f29865d33c6be4c09b437f906ca8d35e666f3ef53fd22e0d8ceade');
+
+      const parsed = await openpgp.PacketList.fromBinary(binaryMessage, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true });
+      expect(parsed.length).to.equal(2);
+      expect(parsed[0]).instanceOf(openpgp.UnparseablePacket);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.publicKeyEncryptedSessionKey);
+
+      await expect(
+        openpgp.PacketList.fromBinary(binaryMessage, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false })
+      ).to.be.rejectedWith(/Unknown public key encryption algorithm/);
+    });
+
+
     it('Throws on disallowed packet even with tolerant mode enabled', async function() {
       const packets = new openpgp.PacketList();
       packets.push(new openpgp.LiteralDataPacket());

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -996,6 +996,32 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
       ).to.be.rejectedWith(/Version 1 of the signature packet is unsupported/);
     });
 
+    it('Ignores unknown signature algorithm only with `config.ignoreUnsupportedPackets` enabled', async function() {
+      const binarySignature = util.hexToUint8Array('c2750401630a00060502628b8e2200210910f30ddfc2310b3560162104b9b0045c1930f842cb245566f30ddfc2310b35602ded0100bd69fe6a9f52499cd8b2fd2493dae91c997979890df4467cf31b197901590ff10100ead4c671487535b718a8428c8e6099e3873a41610aad9fcdaa06f6df5f404002');
+
+      const parsed = await openpgp.PacketList.fromBinary(binarySignature, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true });
+      expect(parsed.length).to.equal(1);
+      expect(parsed[0]).instanceOf(openpgp.UnparseablePacket);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.signature);
+
+      await expect(
+        openpgp.PacketList.fromBinary(binarySignature, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false })
+      ).to.be.rejectedWith(/Invalid signature algorithm/);
+    });
+
+    it('Ignores unknown key algorithm only with `config.ignoreUnsupportedPackets` enabled', async function() {
+      const binaryKey = util.hexToUint8Array('c55804628b944e63092b06010401da470f01010740d01ab8619b6dc6a36da5bff62ff416a974900f5a8c74d1bd1760d717d0aad8d50000ff516f8e3190aa5b394597655d7c32e16392e638da0e2a869fb7b1f429d9de263d1062cd0f3c7465737440746573742e636f6d3ec28c0410160a001d0502628b944e040b0907080315080a0416000201021901021b03021e01002109104803e40df201fa5b16210496dc42e91cc585e2f5e331644803e40df201fa5b340b0100812c47b60fa509e12e329fc37cc9c437cc6a6500915caa03ad8703db849846f900ff571b9a0d9e1dcc087d9fae04ec2906e60ef40ca02a387eb07ce1c37bedeecd0a');
+
+      const parsed = await openpgp.PacketList.fromBinary(binaryKey, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true });
+      expect(parsed.length).to.equal(3);
+      expect(parsed[0]).instanceOf(openpgp.UnparseablePacket);
+      expect(parsed[0].tag).to.equal(openpgp.enums.packet.secretKey);
+
+      await expect(
+        openpgp.PacketList.fromBinary(binaryKey, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false })
+      ).to.be.rejectedWith(/Invalid public key encryption algorithm/);
+    });
+
     it('Throws on disallowed packet even with tolerant mode enabled', async function() {
       const packets = new openpgp.PacketList();
       packets.push(new openpgp.LiteralDataPacket());

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -1006,7 +1006,7 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
 
       await expect(
         openpgp.PacketList.fromBinary(binarySignature, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false })
-      ).to.be.rejectedWith(/Invalid signature algorithm/);
+      ).to.be.rejectedWith(/Unknown signature algorithm/);
     });
 
     it('Ignores unknown key algorithm only with `config.ignoreUnsupportedPackets` enabled', async function() {
@@ -1019,7 +1019,7 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
 
       await expect(
         openpgp.PacketList.fromBinary(binaryKey, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false })
-      ).to.be.rejectedWith(/Invalid public key encryption algorithm/);
+      ).to.be.rejectedWith(/Unknown public key encryption algorithm/);
     });
 
     it('Throws on disallowed packet even with tolerant mode enabled', async function() {


### PR DESCRIPTION
With this change, the relevant packets will be considered unsupported instead of malformed.

To merge after #1522 .