### PR TITLE
Throw in `encryptSessionKey` if no keys or passwords are provided

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -555,7 +555,7 @@ export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryp
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.encryptSessionKey, pass `encryptionKeys` instead');
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
-  if ((!encryptionKeys || !encryptionKeys.length === 0) && (!passwords || passwords.length === 0)) {
+  if ((!encryptionKeys || encryptionKeys.length === 0) && (!passwords || passwords.length === 0)) {
     throw new Error('No encryption keys or passwords provided.');
   }
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -240,7 +240,7 @@ export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
 
 
 /**
- * Encrypts a message using public keys, passwords or both at once. At least one of `encryptionKeys` or `passwords`
+ * Encrypts a message using public keys, passwords or both at once. At least one of `encryptionKeys`, `passwords` or `sessionKeys`
  *   must be specified. If signing keys are specified, those will be used to sign the message.
  * @param {Object} options
  * @param {Message} options.message - Message to be encrypted as created by {@link createMessage}
@@ -554,6 +554,10 @@ export async function encryptSessionKey({ data, algorithm, aeadAlgorithm, encryp
   encryptionKeys = toArray(encryptionKeys); passwords = toArray(passwords); encryptionKeyIDs = toArray(encryptionKeyIDs); encryptionUserIDs = toArray(encryptionUserIDs);
   if (rest.publicKeys) throw new Error('The `publicKeys` option has been removed from openpgp.encryptSessionKey, pass `encryptionKeys` instead');
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
+
+  if ((!encryptionKeys || !encryptionKeys.length === 0) && (!passwords || passwords.length === 0)) {
+    throw new Error('No encryption keys or passwords provided.');
+  }
 
   try {
     const message = await Message.encryptSessionKey(data, algorithm, aeadAlgorithm, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2015,6 +2015,13 @@ aOU=
       const [decryptedSessionKey] = await openpgp.decryptSessionKeys({ message: objectMessage, passwords });
       expect(decryptedSessionKey).to.deep.equal(sessionKey);
     });
+
+    it('passing no encryption keys or passwords leads to exception', async function() {
+      await expect(openpgp.encryptSessionKey({
+        algorithm: 'aes256',
+        data: util.hexToUint8Array('3e99c1bb485e70a1fcef09a7ad8d38d171015243bbdd853e1a2b0e334d122ff3')
+      })).to.be.rejectedWith(/No encryption keys or passwords provided/);
+    });
   });
 
   describe('encrypt, decrypt, sign, verify - integration tests', function() {


### PR DESCRIPTION
Currently, if no passwords or keys are given, the operation returns an empty message.