### PR TITLE
Fix CleartextMessage signature generation over text with trailing whitespace and \r\n line endings

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -36,7 +36,7 @@ export class CleartextMessage {
    * @param {Signature} signature - The detached signature or an empty signature for unsigned messages
    */
   constructor(text, signature) {
-    // normalize EOL to canonical form <CR><LF>
+    // remove trailing whitespace and normalize EOL to canonical form <CR><LF>
     this.text = util.removeTrailingSpaces(text).replace(/\r?\n/g, '\r\n');
     if (signature && !(signature instanceof Signature)) {
       throw new Error('Invalid signature input');

--- a/src/util.js
+++ b/src/util.js
@@ -520,12 +520,12 @@ const util = {
   },
 
   /**
-   * Remove trailing spaces and tabs from each line
+   * Remove trailing spaces, carriage returns and tabs from each line
    */
   removeTrailingSpaces: function(text) {
     return text.split('\n').map(line => {
       let i = line.length - 1;
-      for (; i >= 0 && (line[i] === ' ' || line[i] === '\t'); i--);
+      for (; i >= 0 && (line[i] === ' ' || line[i] === '\t' || line[i] === '\r'); i--);
       return line.substr(0, i + 1);
     }).join('\n');
   },


### PR DESCRIPTION
Signing a `CleartextMessage` containing trailing whitespace and \r\n line endings (as opposed to \n) would result in an unverifiable signature. The issue seems to have been present since v3.0.9 (https://github.com/openpgpjs/openpgpjs/commit/ebeedd3443ceda323d0fbe7a62c2c7c41d2c0809). Note that these broken signatures were unverifiable even in the OpenPGP.js version(s) that generated them.

The problem is that the data was incorrectly normalised before being signed, as trailing whitespace preceding \r\n would not be stripped (but still correctly normalised on verification).

Example of data that would be incorrectly signed: 
```
'this text    \r\nused to be incorrectly normalised'
```

If you have access to the original data that was signed (with whitespaces preserved), it's possible to verify an affected cleartext signature as a detached signature, by manually normalising the input message data as follows:
```js
function removeTrailingSpaces(text) {
    return text.split('\n').map(line => {
      let i = line.length - 1;
      for (; i >= 0 && (line[i] === ' ' || line[i] === '\t'); i--);
      return line.substr(0, i + 1);
    }).join('\n');
}

// To verify:
// -----BEGIN PGP SIGNED MESSAGE-----
// Hash: SHA256
//
// this text    
// used to be incorrectly normalised
//
// -----BEGIN PGP SIGNATURE-----
// Version: OpenPGP.js v5.3.1
//
// wrMEAQEIAAYFAmLjqsQAIQkQ4IT3RGwgLJcWIQTX0bHexsqUZwA0RcXghPdE
// bCAsl2TvBADLOHYXevDSc3LtLRYR1HteijL/MssCCoZIfuGihd5AzJpD2h2j
// L8UuxlfERJn15RlFsDzlkMNMefJp5ltC8kKcf+HTuBUi+xf2t2nvlf8CrdjY
// vcEqswjkODDxxZ842h0sC0ZtbzWuMXIvODEdzZxBjhlmZmv9VKQ5uyb0oD/5
// WQ==
// =o2gq
// -----END PGP SIGNATURE-----

const message = await openpgp.createMessage({
    // manually normalise original input (with whitespaces preserved)
    text: removeTrailingSpaces('this text   \r\nused to be incorrectly normalised')
});

const signature = await openpgp.readSignature({ armoredSignature: `
-----BEGIN PGP SIGNATURE-----
Version: OpenPGP.js v5.3.1

wrMEAQEIAAYFAmLjqsQAIQkQ4IT3RGwgLJcWIQTX0bHexsqUZwA0RcXghPdE
bCAsl2TvBADLOHYXevDSc3LtLRYR1HteijL/MssCCoZIfuGihd5AzJpD2h2j
L8UuxlfERJn15RlFsDzlkMNMefJp5ltC8kKcf+HTuBUi+xf2t2nvlf8CrdjY
vcEqswjkODDxxZ842h0sC0ZtbzWuMXIvODEdzZxBjhlmZmv9VKQ5uyb0oD/5
WQ==
=o2gq
-----END PGP SIGNATURE-----
` })

const result = await openpgp.verify({
      message,
      signature,
      verificationKeys
});
```
