### PR TITLE
`printDebug`: add label to identify source of the log

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -289,7 +289,7 @@ const util = {
    */
   printDebug: function (str) {
     if (debugMode) {
-      console.log(str);
+      console.log('[OpenPGP.js debug]', str);
     }
   },
 
@@ -300,7 +300,7 @@ const util = {
    */
   printDebugError: function (error) {
     if (debugMode) {
-      console.error(error);
+      console.error('[OpenPGP.js debug]', error);
     }
   },
 


### PR DESCRIPTION
Errors logged in debug mode are hard to distinguish from other errors thrown in the library.