### PR TITLE
Leave unhashed subpackets as-is when re-serializing signatures

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -188,7 +188,7 @@ class SignaturePacket {
     // Add hashed subpackets
     arr.push(this.writeHashedSubPackets());
 
-    // Reserialize allowed unhashed subpackets
+    // Set unhashed subpackets for serialization
     this.unhashedSubpackets = this.createUnhashedSubPackets();
 
     this.signatureData = util.concat(arr);
@@ -318,7 +318,7 @@ class SignaturePacket {
   }
 
   /**
-   * Pushes the Issuer and Embedded Signature subpackets to the unhashedSubpackets
+   * Returns the Issuer, Issuer Fingperprint, and Embedded Signature subpacket bodies
    * @returns {Array<Uint8Array>} Subpackets.
    */
   createUnhashedSubPackets() {
@@ -343,7 +343,7 @@ class SignaturePacket {
   }
 
   /**
-   * Writes an Uint8Array of bytes of allowedUnhashedSubpackets and unhashedSubpackets
+   * Creates an Uint8Array containing the unhashed subpackets
    * @returns {Uint8Array} Subpacket data.
    */
   writeUnhashedSubPackets() {

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -58,7 +58,6 @@ class SignaturePacket {
     this.publicKeyAlgorithm = null;
 
     this.signatureData = null;
-    this.allowedUnhashedSubpackets = [];
     this.unhashedSubpackets = [];
     this.signedHashValue = null;
 
@@ -190,7 +189,7 @@ class SignaturePacket {
     arr.push(this.writeHashedSubPackets());
 
     // Reserialize allowed unhashed subpackets
-    this.allowedUnhashedSubpackets = this.createUnhashedSubPackets();
+    this.unhashedSubpackets = this.createUnhashedSubPackets();
 
     this.signatureData = util.concat(arr);
 
@@ -349,11 +348,6 @@ class SignaturePacket {
    */
   writeUnhashedSubPackets() {
     const arr = [];
-    this.allowedUnhashedSubpackets.forEach(data => {
-      arr.push(writeSimpleLength(data.length));
-      arr.push(data);
-    });
-
     this.unhashedSubpackets.forEach(data => {
       arr.push(writeSimpleLength(data.length));
       arr.push(data);
@@ -374,11 +368,10 @@ class SignaturePacket {
     const type = bytes[mypos] & 0x7F;
 
     if (!hashed) {
+      this.unhashedSubpackets.push(bytes.subarray(mypos, bytes.length));
       if (!allowedUnhashedSubpackets.has(type)) {
-        this.unhashedSubpackets.push(bytes.subarray(mypos, bytes.length));
         return;
       }
-      this.allowedUnhashedSubpackets.push(bytes.subarray(mypos, bytes.length));
     }
 
     mypos++;


### PR DESCRIPTION
When an embedded signature is already present in the hashed part it will be serialized twice when exporting an already signed public key.