### PR TITLE
CI: move away from Node.js v12

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,17 +11,15 @@ jobs:
 
     steps:
       # check out pull request branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: pr
       # check out main branch (to compare performance)
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
           path: main
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '15'
+      - uses: actions/setup-node@v2
 
       - name: Run pull request time benchmark
         run: cd pr && npm install && npm run --silent benchmark-time > benchmarks.txt && cat benchmarks.txt

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: softprops/turnstyle@v1
       with:
         poll-interval-seconds: 30
         abort-after-seconds: 900
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: npm ci
     - run: npm run build-test
     - run: npm run browserstack
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: softprops/turnstyle@v1
       with:
         poll-interval-seconds: 30
         abort-after-seconds: 900
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: npm ci
     - run: npm run build-test --lightweight
     - run: npm run browserstack

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v2
     - run: npm ci
     - run: npm run docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v2
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,12 +17,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/test-type-definitions.yml
+++ b/.github/workflows/test-type-definitions.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '15'
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v2
     - run: npm ci
     - run: npm run test-type-definitions


### PR DESCRIPTION
Github is deprecating it in Actions, and it's already past EOL.