### PR TITLE
TypeScript: fix signature of armor function

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -721,7 +721,7 @@ interface VerifyMessageResult {
 /**
  * Armor an OpenPGP binary packet block
  */
-export function armor(messagetype: enums.armor, body: object, partindex: number, parttotal: number, config?: Config): string;
+export function armor(messagetype: enums.armor, body: object, partindex?: number, parttotal?: number, config?: Config): string;
 
 /**
  * DeArmor an OpenPGP armored message; verify the checksum and return the encoded bytes


### PR DESCRIPTION
In the [JSDoc](https://github.com/openpgpjs/openpgpjs/blob/main/src/encoding/armor.js#L357-L358) the partIndex and partTotal params of the `armor` function are marked as optional. Also when reading the function it appears that it will still work if they are not passed. This commit updates the openpgp.d.ts file to match what I observed in the actual implementaion.