### PR TITLE
TypeScript: fix signature of armor function (again)

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -721,7 +721,7 @@ interface VerifyMessageResult {
 /**
  * Armor an OpenPGP binary packet block
  */
-export function armor(messagetype: enums.armor, body: object, partindex?: number, parttotal?: number, config?: Config): string;
+export function armor(messagetype: enums.armor, body: object, partindex?: number, parttotal?: number, customComment?: string, config?: Config): string;
 
 /**
  * DeArmor an OpenPGP armored message; verify the checksum and return the encoded bytes


### PR DESCRIPTION
This commit updates the openpgp.d.ts file to match what I observed in the actual implementaion.