### PR TITLE
docs: add typescript setup notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ import * as openpgp from './openpgp.min.mjs';
 
 To offload cryptographic operations off the main thread, you can implement a Web Worker in your application and load OpenPGP.js from there. For an example Worker implementation, see `test/worker/worker_example.js`.
 
+#### TypeScript
+
+For typescript support you have to add `@openpgp/web-stream-tools` to your dependencies as well.
+
+```sh
+npm install --save openpgp
+npm install --save-dev @openpgp/web-stream-tools
+```
+
+We are relying on types from the `web-stream-tools` package but do not want to put TypeScript only dependencies into our dependencies.
+
 ### Examples
 
 Here are some examples of how to use OpenPGP.js v5. For more elaborate examples and working code, please check out the [public API unit tests](https://github.com/openpgpjs/openpgpjs/blob/main/test/general/openpgp.js). If you're upgrading from v4 it might help to check out the [changelog](https://github.com/openpgpjs/openpgpjs/wiki/V5-Changelog) and [documentation](https://github.com/openpgpjs/openpgpjs#documentation).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Since TS is not fully integrated in the library, TS-only dependencies are curren
 npm install --save-dev @openpgp/web-stream-tools
 ```
 
-We are relying on types from the `web-stream-tools` package but do not want to put TypeScript only dependencies into our dependencies.
+If you notice missing or incorrect type definitions, feel free to open a PR.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,9 @@ To offload cryptographic operations off the main thread, you can implement a Web
 
 #### TypeScript
 
-For typescript support you have to add `@openpgp/web-stream-tools` to your dependencies as well.
+Since TS is not fully integrated in the library, TS-only dependencies are currently listed as `devDependencies`, so to compile the project you’ll need to add `@openpgp/web-stream-tools` manually:
 
 ```sh
-npm install --save openpgp
 npm install --save-dev @openpgp/web-stream-tools
 ```
 


### PR DESCRIPTION
Mention that `openpgpjs` does needs types from `@openpgp/web-stream-tools`.

---
Reference: https://github.com/openpgpjs/openpgpjs/pull/1502#issuecomment-1406366038
