### PR TITLE
TypeScript: Added selfCertification property to PrimaryUser interface definition

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -58,7 +58,7 @@ export abstract class Key {
   public signAllUsers(privateKeys: PrivateKey[], date?: Date, config?: Config): Promise<this>
   public verifyPrimaryKey(date?: Date, userID?: UserID, config?: Config): Promise<void>; // throws on error
   public verifyPrimaryUser(publicKeys: PublicKey[], date?: Date, userIDs?: UserID, config?: Config): Promise<{ keyID: KeyID, valid: boolean | null }[]>;
-  public verifyAllUsers(publicKeys: PublicKey[], date?: Date, config?: Config): Promise<{ userID: string, keyID: KeyID, valid: boolean | null }[]>;
+  public verifyAllUsers(publicKeys?: PublicKey[], date?: Date, config?: Config): Promise<{ userID: string, keyID: KeyID, valid: boolean | null }[]>;
   public isRevoked(signature?: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public getRevocationCertificate(date?: Date, config?: Config): Promise<MaybeStream<string> | undefined>;
   public getEncryptionKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -111,6 +111,7 @@ export interface User {
 export interface PrimaryUser {
   index: number;
   user: User;
+  selfCertification: SignaturePacket;
 }
 
 type AlgorithmInfo = {


### PR DESCRIPTION
It's useful to be able to extract additional data from the signature, e.g. key usage flags

Also changed type definition for `Key.verifyAllUsers`