### PR TITLE
Docs: mark global `generateSessionKeys`'s `encryptionKeys` as optional

### DIFF
--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -505,9 +505,9 @@ export async function verify({ message, verificationKeys, expectSigned = false, 
 ///////////////////////////////////////////////
 
 /**
- * Generate a new session key object, taking the algorithm preferences of the passed public keys into account.
+ * Generate a new session key object, taking the algorithm preferences of the passed public keys into account, if any.
  * @param {Object} options
- * @param {PublicKey|PublicKey[]} options.encryptionKeys - Array of public keys or single key used to select algorithm preferences for
+ * @param {PublicKey|PublicKey[]} [options.encryptionKeys] - Array of public keys or single key used to select algorithm preferences for. If no keys are given, the algorithm will be [config.preferredSymmetricAlgorithm]{@link module:config.preferredSymmetricAlgorithm}
  * @param {Date} [options.date=current date] - Date to select algorithm preferences at
  * @param {Object|Object[]} [options.encryptionUserIDs=primary user IDs] - User IDs to select algorithm preferences for
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}


### PR DESCRIPTION
`generateSessionKeys` calls `Message.generateSessionKeys`, which calls `helper.js`'s `getPreferredAlgo`, which returns `config.preferredSymmetricAlgorithm` when the `encryptionKeys` array is empty.
`encryptionKeys` also defaults to an empty array, and `Message.generateSessionkeys`'s `encryptionKeys` is properly marked as optional, so this seems to just be an oversight from the doc.

I'm not familiar with the code or jsdoc or if there's a particular doc style, so feel free to edit!

In any case, it looks like it renders correctly: 
![Screenshot of the updated doc for generateSessionkey](https://user-images.githubusercontent.com/61185219/218417934-fe878a84-afb5-4ae9-82a6-5788f453391d.png)