### PR TITLE
Add support for creating Notation Data subpackets when signing or encrypting messages

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -166,7 +166,7 @@ export class CleartextMessage {
    *
    *  @param privateKeys private keys with decrypted secret key data for signing
    */
-  sign(privateKeys: PrivateKey[], signature?: Signature, signingKeyIDs?: KeyID[], date?: Date, userIDs?: UserID[], config?: Config): void;
+  sign(privateKeys: PrivateKey[], signature?: Signature, signingKeyIDs?: KeyID[], date?: Date, userIDs?: UserID[], notations?: RawNotation[], config?: Config): void;
 
   /** Verify signatures of cleartext signed message
    *  @param keys array of keys to verify signatures
@@ -285,7 +285,7 @@ export class Message<T extends MaybeStream<Data>> {
   /** Sign the message (the literal data packet of the message)
       @param signingKeys private keys with decrypted secret key data for signing
   */
-  public sign(signingKeys: PrivateKey[], signature?: Signature, signingKeyIDs?: KeyID[], date?: Date, userIDs?: UserID[], config?: Config): Promise<Message<T>>;
+  public sign(signingKeys: PrivateKey[], signature?: Signature, signingKeyIDs?: KeyID[], date?: Date, userIDs?: UserID[], notations?: RawNotation[], config?: Config): Promise<Message<T>>;
 
   /** Unwrap compressed message
    */
@@ -604,6 +604,8 @@ interface EncryptOptions {
   signingUserIDs?: MaybeArray<UserID>;
   /** (optional) array of user IDs to encrypt for, e.g. { name:'Robert Receiver', email:'robert@openpgp.org' } */
   encryptionUserIDs?: MaybeArray<UserID>;
+  /** (optional) array of notations to add to the signatures, e.g. { name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true } */
+  signatureNotations?: MaybeArray<RawNotation>;
   config?: PartialConfig;
 }
 
@@ -637,6 +639,7 @@ interface SignOptions {
   signingKeyIDs?: MaybeArray<KeyID>;
   date?: Date;
   signingUserIDs?: MaybeArray<UserID>;
+  signatureNotations?: MaybeArray<RawNotation>;
   config?: PartialConfig;
 }
 

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -64,14 +64,15 @@ export class CleartextMessage {
    * @param {Array<module:type/keyid~KeyID>} [signingKeyIDs] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to privateKeys[i]
    * @param {Date} [date] - The creation time of the signature that should be created
    * @param {Array} [userIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param {Array} [notations] - Notation Data to add to the signatures, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true }]
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<CleartextMessage>} New cleartext message with signed content.
    * @async
    */
-  async sign(privateKeys, signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], config = defaultConfig) {
+  async sign(privateKeys, signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], notations = [], config = defaultConfig) {
     const literalDataPacket = new LiteralDataPacket();
     literalDataPacket.setText(this.text);
-    const newSignature = new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, signingKeyIDs, date, userIDs, true, config));
+    const newSignature = new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, signingKeyIDs, date, userIDs, notations, true, config));
     return new CleartextMessage(this.text, newSignature);
   }
 

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -249,7 +249,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
     signatureType: enums.signature.keyRevocation,
     reasonForRevocationFlag: enums.reasonForRevocation.noReason,
     reasonForRevocationString: ''
-  }, options.date, undefined, undefined, config));
+  }, options.date, undefined, undefined, undefined, config));
 
   if (options.passphrase) {
     secretKeyPacket.clearPrivateParams();

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -96,7 +96,7 @@ export async function createBindingSignature(subkey, primaryKey, options, config
     subkeySignaturePacket.keyFlags = [enums.keyFlags.signData];
     subkeySignaturePacket.embeddedSignature = await createSignaturePacket(dataToSign, null, subkey, {
       signatureType: enums.signature.keyBinding
-    }, options.date, undefined, undefined, config);
+    }, options.date, undefined, undefined, undefined, config);
   } else {
     subkeySignaturePacket.keyFlags = [enums.keyFlags.encryptCommunication | enums.keyFlags.encryptStorage];
   }
@@ -192,11 +192,12 @@ export async function getPreferredAlgo(type, keys = [], date = new Date(), userI
  * @param {Object} [signatureProperties] - Properties to write on the signature packet before signing
  * @param {Date} [date] - Override the creationtime of the signature
  * @param {Object} [userID] - User ID
+ * @param {Array} [notations] - Notation Data to add to the signature, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true }]
  * @param {Object} [detached] - Whether to create a detached signature packet
  * @param {Object} config - full configuration
  * @returns {Promise<SignaturePacket>} Signature packet.
  */
-export async function createSignaturePacket(dataToSign, privateKey, signingKeyPacket, signatureProperties, date, userID, detached = false, config) {
+export async function createSignaturePacket(dataToSign, privateKey, signingKeyPacket, signatureProperties, date, userID, notations = [], detached = false, config) {
   if (signingKeyPacket.isDummy()) {
     throw new Error('Cannot sign with a gnu-dummy key.');
   }
@@ -207,6 +208,7 @@ export async function createSignaturePacket(dataToSign, privateKey, signingKeyPa
   Object.assign(signaturePacket, signatureProperties);
   signaturePacket.publicKeyAlgorithm = signingKeyPacket.algorithm;
   signaturePacket.hashAlgorithm = await getPreferredHashAlgo(privateKey, signingKeyPacket, date, userID, config);
+  signaturePacket.rawNotations = notations;
   await signaturePacket.sign(signingKeyPacket, dataToSign, date, detached);
   return signaturePacket;
 }

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -191,7 +191,7 @@ class PrivateKey extends PublicKey {
       signatureType: enums.signature.keyRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString
-    }, date, undefined, undefined, config));
+    }, date, undefined, undefined, undefined, config));
     return key;
   }
 

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -190,7 +190,7 @@ class Subkey {
       signatureType: enums.signature.subkeyRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString
-    }, date, undefined, false, config));
+    }, date, undefined, undefined, false, config));
     await subkey.update(this);
     return subkey;
   }

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -77,7 +77,7 @@ class User {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,
         keyFlags: [enums.keyFlags.certifyKeys | enums.keyFlags.signData]
-      }, date, undefined, undefined, config);
+      }, date, undefined, undefined, undefined, config);
     }));
     await user.update(this, date, config);
     return user;
@@ -265,7 +265,7 @@ class User {
       signatureType: enums.signature.certRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString
-    }, date, undefined, false, config));
+    }, date, undefined, undefined, false, config));
     await user.update(this);
     return user;
   }

--- a/src/message.js
+++ b/src/message.js
@@ -476,11 +476,12 @@ export class Message {
    * @param {Array<module:type/keyid~KeyID>} [signingKeyIDs] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
    * @param {Date} [date] - Override the creation time of the signature
    * @param {Array} [userIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param {Array} [notations] - Notation Data to add to the signatures, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true }]
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Message>} New message with signed content.
    * @async
    */
-  async sign(signingKeys = [], signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], config = defaultConfig) {
+  async sign(signingKeys = [], signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], notations = [], config = defaultConfig) {
     const packetlist = new PacketList();
 
     const literalDataPacket = this.packets.findPacket(enums.packet.literalData);
@@ -530,7 +531,7 @@ export class Message {
     });
 
     packetlist.push(literalDataPacket);
-    packetlist.push(...(await createSignaturePackets(literalDataPacket, signingKeys, signature, signingKeyIDs, date, userIDs, false, config)));
+    packetlist.push(...(await createSignaturePackets(literalDataPacket, signingKeys, signature, signingKeyIDs, date, userIDs, notations, false, config)));
 
     return new Message(packetlist);
   }
@@ -563,16 +564,17 @@ export class Message {
    * @param {Array<module:type/keyid~KeyID>} [signingKeyIDs] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
    * @param {Date} [date] - Override the creation time of the signature
    * @param {Array} [userIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param {Array} [notations] - Notation Data to add to the signatures, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true }]
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Signature>} New detached signature of message content.
    * @async
    */
-  async signDetached(signingKeys = [], signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], config = defaultConfig) {
+  async signDetached(signingKeys = [], signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], notations = [], config = defaultConfig) {
     const literalDataPacket = this.packets.findPacket(enums.packet.literalData);
     if (!literalDataPacket) {
       throw new Error('No literal data packet to sign.');
     }
-    return new Signature(await createSignaturePackets(literalDataPacket, signingKeys, signature, signingKeyIDs, date, userIDs, true, config));
+    return new Signature(await createSignaturePackets(literalDataPacket, signingKeys, signature, signingKeyIDs, date, userIDs, notations, true, config));
   }
 
   /**
@@ -705,13 +707,14 @@ export class Message {
  * @param {Array<module:type/keyid~KeyID>} [signingKeyIDs] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
  * @param {Date} [date] - Override the creationtime of the signature
  * @param {Array} [userIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+ * @param {Array} [notations] - Notation Data to add to the signatures, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true }]
  * @param {Boolean} [detached] - Whether to create detached signature packets
  * @param {Object} [config] - Full configuration, defaults to openpgp.config
  * @returns {Promise<PacketList>} List of signature packets.
  * @async
  * @private
  */
-export async function createSignaturePackets(literalDataPacket, signingKeys, signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], detached = false, config = defaultConfig) {
+export async function createSignaturePackets(literalDataPacket, signingKeys, signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], notations = [], detached = false, config = defaultConfig) {
   const packetlist = new PacketList();
 
   // If data packet was created from Uint8Array, use binary, otherwise use text
@@ -724,7 +727,7 @@ export async function createSignaturePackets(literalDataPacket, signingKeys, sig
       throw new Error('Need private key for signing');
     }
     const signingKey = await primaryKey.getSigningKey(signingKeyIDs[i], date, userID, config);
-    return createSignaturePacket(literalDataPacket, primaryKey, signingKey.keyPacket, { signatureType }, date, userID, detached, config);
+    return createSignaturePacket(literalDataPacket, primaryKey, signingKey.keyPacket, { signatureType }, date, userID, notations, detached, config);
   })).then(signatureList => {
     packetlist.push(...signatureList);
   });

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -260,7 +260,7 @@ class SignaturePacket {
       // MUST NOT be included in the signature.
       arr.push(writeSubPacket(sub.issuer, this.issuerKeyID.write()));
     }
-    this.rawNotations.forEach(([{ name, value, humanReadable }]) => {
+    this.rawNotations.forEach(({ name, value, humanReadable }) => {
       bytes = [new Uint8Array([humanReadable ? 0x80 : 0, 0, 0, 0])];
       // 2 octets of name length
       bytes.push(util.writeNumber(name.length, 2));

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -354,7 +354,7 @@ class SignaturePacket {
     let mypos = 0;
 
     // The leftmost bit denotes a "critical" packet
-    const critical = bytes[mypos] & 0x80;
+    const critical = !!(bytes[mypos] & 0x80);
     const type = bytes[mypos] & 0x7F;
 
     if (!hashed) {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1154,6 +1154,11 @@ eSvSZutLuKKbidSYMLhWROPlwKc2GU2ws6PrLZAyCAel/lU=
           name: 'test@example.com',
           value: new TextEncoder().encode('test'),
           humanReadable: true
+        },
+        {
+          name: 'séparation-de-domaine@proton.ch',
+          value: new Uint8Array([0, 1, 2, 3]),
+          humanReadable: false
         }
       ],
       config
@@ -1164,11 +1169,15 @@ eSvSZutLuKKbidSYMLhWROPlwKc2GU2ws6PrLZAyCAel/lU=
       verificationKeys: privKey
     });
     const { packets: [{ rawNotations: notations }] } = await sig.signature;
-    expect(notations).to.have.length(1);
+    expect(notations).to.have.length(2);
     expect(notations[0].name).to.equal('test@example.com');
     expect(notations[0].value).to.deep.equal(new Uint8Array([116, 101, 115, 116]));
     expect(notations[0].humanReadable).to.be.true;
     expect(notations[0].critical).to.be.false;
+    expect(notations[1].name).to.equal('séparation-de-domaine@proton.ch');
+    expect(notations[1].value).to.deep.equal(new Uint8Array([0, 1, 2, 3]));
+    expect(notations[1].humanReadable).to.be.false;
+    expect(notations[1].critical).to.be.false;
   });
 
   it('Verify cleartext signed message with two signatures with openpgp.verify', async function() {

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1138,6 +1138,39 @@ eSvSZutLuKKbidSYMLhWROPlwKc2GU2ws6PrLZAyCAel/lU=
     expect(await sig.verified).to.be.true;
   });
 
+  it('Can create notations', async function() {
+    const privKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readKey({ armoredKey: priv_key_arm2 }),
+      passphrase: 'hello world'
+    });
+
+    const config = { minRSABits: 1024 };
+    const message_with_notation = await openpgp.encrypt({
+      message: await openpgp.createMessage({ text: 'test' }),
+      encryptionKeys: privKey,
+      signingKeys: privKey,
+      signatureNotations: [
+        {
+          name: 'test@example.com',
+          value: new TextEncoder().encode('test'),
+          humanReadable: true
+        }
+      ],
+      config
+    });
+    const { signatures: [sig] } = await openpgp.decrypt({
+      message: await openpgp.readMessage({ armoredMessage: message_with_notation }),
+      decryptionKeys: privKey,
+      verificationKeys: privKey
+    });
+    const { packets: [{ rawNotations: notations }] } = await sig.signature;
+    expect(notations).to.have.length(1);
+    expect(notations[0].name).to.equal('test@example.com');
+    expect(notations[0].value).to.deep.equal(new Uint8Array([116, 101, 115, 116]));
+    expect(notations[0].humanReadable).to.be.true;
+    expect(notations[0].critical).to.be.false;
+  });
+
   it('Verify cleartext signed message with two signatures with openpgp.verify', async function() {
     const cleartextMessage =
       ['-----BEGIN PGP SIGNED MESSAGE-----',

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -134,6 +134,14 @@ import {
   const textSignedObject: Message<string> = await sign({ signingKeys: privateKeys, message: textMessage, format: 'object' });
   expect(textSignedObject).to.be.instanceOf(Message);
 
+  // Sign text message (armored)
+  const textSignedWithNotations: string = await sign({ signingKeys: privateKeys, message: textMessage, signatureNotations: [{
+    name: 'test@example.org',
+    value: new TextEncoder().encode('test'),
+    humanReadable: true
+  }] });
+  expect(textSignedWithNotations).to.include('-----BEGIN PGP MESSAGE-----');
+
   // Verify signed text message (armored)
   const signedMessage = await readMessage({ armoredMessage: textSignedArmor });
   const verifiedText = await verify({ verificationKeys: publicKeys, message: signedMessage });


### PR DESCRIPTION
Add a `signatureNotations` option to `sign()` and `encrypt()`, of the type `[{ name: String, value: Uint8Array, humanReadable: bool }]`, to allow adding Notation Data subpackets when signing messages.

Also, make `signaturePacket.rawNotations[*].critical` a boolean instead of a number.

