### PR TITLE
Remove default known notations

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -210,7 +210,7 @@ export default {
    * @memberof module:config
    * @property {Array} knownNotations
    */
-  knownNotations: ['preferred-email-encoding@pgp.com', 'pka-address@gnupg.org'],
+  knownNotations: [],
   /**
    * Whether to use the indutny/elliptic library for curves (other than Curve25519) that are not supported by the available native crypto API.
    * When false, certain standard curves will not be supported (depending on the platform).


### PR DESCRIPTION
Since we don't interpret these notations, it is up to the caller to handle them, and thus also to decide whether they are "known". If they are marked as critical, and aren't handled by the caller, we should consider the signature unverified.

Though these notations don't seem super security-critical, it's not up to us to decide, the signer shouldn't mark them as critical if they don't want the signature to fail if we don't interpret them.

Cc @wiktor-k, let me know if you disagree, since you originally added this, but I think it was based on my suggestion, that I now think was mistaken :)