### PR TITLE
Add additionalAllowedPackets config option

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -178,6 +178,14 @@ export default {
    */
   ignoreMalformedPackets: false,
   /**
+   * Parsing of packets is normally restricted to a predefined set of packets. For example a Sym. Encrypted Integrity Protected Data Packet can only
+   * contain a certain set of packets including LiteralDataPacket. With this setting we can allow additional packets, which is probably not advisable
+   * as a global config setting, but can be used for specific function calls (e.g. decrypt method of Message).
+   * @memberof module:config
+   * @property {Array} additionalAllowedPackets Allow additional packets on parsing. Defined as array of packet classes, e.g. [PublicKeyPacket]
+   */
+  additionalAllowedPackets: [],
+  /**
    * @memberof module:config
    * @property {Boolean} showVersion Whether to include {@link module:config/config.versionString} in armored messages
    */

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -64,6 +64,9 @@ class PacketList extends Array {
    * @async
    */
   async read(bytes, allowedPackets, config = defaultConfig) {
+    if (config.additionalAllowedPackets.length) {
+      allowedPackets = { ...allowedPackets, ...util.constructAllowedPackets(config.additionalAllowedPackets) };
+    }
     this.stream = stream.transformPair(bytes, async (readable, writable) => {
       const writer = stream.getWriter(writable);
       try {


### PR DESCRIPTION
Following the discussion https://github.com/openpgpjs/openpgpjs/discussions/1617 this pull requests adds a new config option `additionalAllowedPackets`.

When parsing for example a SEIP packet, currently only the following nested packets are allowed: `LiteralDataPacket, CompressedDataPacket, OnePassSignaturePacket, SignaturePacket`.

With this new config option we can add additional packet classes to the list of allowed packets.