### PR TITLE
`crypto-refresh`: add support for new Ed25519/X25519 keys, signatures and messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prebrowsertest": "npm run build-test",
     "browsertest": "npm start -- -o test/unittests.html",
     "test-browser": "karma start test/karma.conf.js",
-    "test-browserstack": "karma start test/karma.conf.js --browsers bs_safari_latest,bs_ios_15,bs_safari_13_1",
+    "test-browserstack": "karma start test/karma.conf.js --browsers bs_safari_latest,bs_ios_14,bs_safari_13_1",
     "coverage": "nyc npm test",
     "lint": "eslint .",
     "docs": "jsdoc --configure .jsdocrc.js --destination docs --recurse README.md src && printf '%s' 'docs.openpgpjs.org' > docs/CNAME",

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -33,7 +33,7 @@ import KDFParams from '../type/kdf_params';
 import enums from '../enums';
 import util from '../util';
 import OID from '../type/oid';
-import { Curve } from './public_key/elliptic/curves';
+import { CurveWithOID } from './public_key/elliptic/oid_curves';
 import { UnsupportedError } from '../packet/packet';
 import ECDHXSymmetricKey from '../type/ecdh_x_symkey';
 
@@ -219,14 +219,14 @@ export function parsePrivateKeyParams(algo, bytes, publicParams) {
     }
     case enums.publicKey.ecdsa:
     case enums.publicKey.ecdh: {
-      const curve = new Curve(publicParams.oid);
+      const curve = new CurveWithOID(publicParams.oid);
       let d = util.readMPI(bytes.subarray(read)); read += d.length + 2;
       d = util.leftPad(d, curve.payloadSize);
       return { read, privateParams: { d } };
     }
     case enums.publicKey.eddsa:
     case enums.publicKey.ed25519Legacy: {
-      const curve = new Curve(publicParams.oid);
+      const curve = new CurveWithOID(publicParams.oid);
       let seed = util.readMPI(bytes.subarray(read)); read += seed.length + 2;
       seed = util.leftPad(seed, curve.payloadSize);
       return { read, privateParams: { seed } };

--- a/src/crypto/hkdf.js
+++ b/src/crypto/hkdf.js
@@ -9,13 +9,53 @@ import util from '../util';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
+const nodeSubtleCrypto = nodeCrypto && nodeCrypto.webcrypto && nodeCrypto.webcrypto.subtle;
 
-export default async function HKDF(hashAlgo, key, salt, info, length) {
+export default async function HKDF(hashAlgo, inputKey, salt, info, outLen) {
   const hash = enums.read(enums.webHash, hashAlgo);
   if (!hash) throw new Error('Hash algo not supported with HKDF');
 
-  const crypto = webCrypto || nodeCrypto.webcrypto.subtle;
-  const importedKey = await crypto.importKey('raw', key, 'HKDF', false, ['deriveBits']);
-  const bits = await crypto.deriveBits({ name: 'HKDF', hash, salt, info }, importedKey, length * 8);
-  return new Uint8Array(bits);
+  if (webCrypto || nodeSubtleCrypto) {
+    const crypto = webCrypto || nodeSubtleCrypto;
+    const importedKey = await crypto.importKey('raw', inputKey, 'HKDF', false, ['deriveBits']);
+    const bits = await crypto.deriveBits({ name: 'HKDF', hash, salt, info }, importedKey, outLen * 8);
+    return new Uint8Array(bits);
+  }
+
+  if (nodeCrypto) {
+    const hashAlgoName = enums.read(enums.hash, hashAlgo);
+    // Node-only HKDF implementation based on https://www.rfc-editor.org/rfc/rfc5869
+
+    const computeHMAC = (hmacKey, hmacMessage) => nodeCrypto.createHmac(hashAlgoName, hmacKey).update(hmacMessage).digest();
+    // Step 1: Extract
+    // PRK = HMAC-Hash(salt, IKM)
+    const pseudoRandomKey = computeHMAC(salt, inputKey);
+
+    const hashLen = pseudoRandomKey.length;
+
+    // Step 2: Expand
+    // HKDF-Expand(PRK, info, L) -> OKM
+    const n = Math.ceil(outLen / hashLen);
+    const outputKeyingMaterial = new Uint8Array(n * hashLen);
+
+    // HMAC input buffer updated at each iteration
+    const roundInput = new Uint8Array(hashLen + info.length + 1);
+    // T_i and last byte are updated at each iteration, but `info` remains constant
+    roundInput.set(info, hashLen);
+
+    for (let i = 0; i < n; i++) {
+      // T(0) = empty string (zero length)
+      // T(i) = HMAC-Hash(PRK, T(i-1) | info | i)
+      roundInput[roundInput.length - 1] = i + 1;
+      // t = T(i+1)
+      const t = computeHMAC(pseudoRandomKey, i > 0 ? roundInput : roundInput.subarray(hashLen));
+      roundInput.set(t, 0);
+
+      outputKeyingMaterial.set(t, i * hashLen);
+    }
+
+    return outputKeyingMaterial.subarray(0, outLen);
+  }
+
+  throw new Error('No HKDF implementation available');
 }

--- a/src/crypto/hkdf.js
+++ b/src/crypto/hkdf.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview This module implements HKDF using either the WebCrypto API or Node.js' crypto API.
+ * @module crypto/hkdf
+ * @private
+ */
+
+import enums from '../enums';
+import util from '../util';
+
+const webCrypto = util.getWebCrypto();
+const nodeCrypto = util.getNodeCrypto();
+
+export default async function HKDF(hashAlgo, key, salt, info, length) {
+  const hash = enums.read(enums.webHash, hashAlgo);
+  if (!hash) throw new Error('Hash algo not supported with HKDF');
+
+  const crypto = webCrypto || nodeCrypto.webcrypto.subtle;
+  const importedKey = await crypto.importKey('raw', key, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.deriveBits({ name: 'HKDF', hash, salt, info }, importedKey, length * 8);
+  return new Uint8Array(bits);
+}

--- a/src/crypto/mode/cfb.js
+++ b/src/crypto/mode/cfb.js
@@ -57,7 +57,7 @@ export async function encrypt(algo, key, plaintext, iv, config) {
   if (util.getNodeCrypto() && nodeAlgos[algoName]) { // Node crypto library.
     return nodeEncrypt(algo, key, plaintext, iv);
   }
-  if (algoName.substr(0, 3) === 'aes') {
+  if (util.isAES(algo)) {
     return aesEncrypt(algo, key, plaintext, iv, config);
   }
 
@@ -100,7 +100,7 @@ export async function decrypt(algo, key, ciphertext, iv) {
   if (util.getNodeCrypto() && nodeAlgos[algoName]) { // Node crypto library.
     return nodeDecrypt(algo, key, ciphertext, iv);
   }
-  if (algoName.substr(0, 3) === 'aes') {
+  if (util.isAES(algo)) {
     return aesDecrypt(algo, key, ciphertext, iv);
   }
 

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -22,7 +22,7 @@
  */
 
 import nacl from '@openpgp/tweetnacl/nacl-fast-light';
-import { Curve, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams } from './curves';
+import { CurveWithOID, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams } from './oid_curves';
 import * as aesKW from '../../aes_kw';
 import { getRandomBytes } from '../../random';
 import hash from '../../hash';
@@ -86,7 +86,7 @@ async function kdf(hashAlgo, X, length, param, stripLeading = false, stripTraili
 /**
  * Generate ECDHE ephemeral key and secret from public key
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} Q - Recipient public key
  * @returns {Promise<{publicKey: Uint8Array, sharedKey: Uint8Array}>}
  * @async
@@ -129,7 +129,7 @@ async function genPublicEphemeralKey(curve, Q) {
 export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
   const m = pkcs5.encode(data);
 
-  const curve = new Curve(oid);
+  const curve = new CurveWithOID(oid);
   const { publicKey, sharedKey } = await genPublicEphemeralKey(curve, Q);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipher(kdfParams.cipher);
@@ -141,7 +141,7 @@ export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
 /**
  * Generate ECDHE secret from private key and public part of ephemeral key
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} V - Public part of ephemeral key
  * @param {Uint8Array} Q - Recipient public key
  * @param {Uint8Array} d - Recipient private key
@@ -189,7 +189,7 @@ async function genPrivateEphemeralKey(curve, V, Q, d) {
  * @async
  */
 export async function decrypt(oid, kdfParams, V, C, Q, d, fingerprint) {
-  const curve = new Curve(oid);
+  const curve = new CurveWithOID(oid);
   const { sharedKey } = await genPrivateEphemeralKey(curve, V, Q, d);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipher(kdfParams.cipher);
@@ -209,7 +209,7 @@ export async function decrypt(oid, kdfParams, V, C, Q, d, fingerprint) {
 /**
  * Generate ECDHE secret from private key and public part of ephemeral key using webCrypto
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} V - Public part of ephemeral key
  * @param {Uint8Array} Q - Recipient public key
  * @param {Uint8Array} d - Recipient private key
@@ -262,7 +262,7 @@ async function webPrivateEphemeralKey(curve, V, Q, d) {
 /**
  * Generate ECDHE ephemeral key and secret from public key using webCrypto
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} Q - Recipient public key
  * @returns {Promise<{publicKey: Uint8Array, sharedKey: Uint8Array}>}
  * @async
@@ -310,7 +310,7 @@ async function webPublicEphemeralKey(curve, Q) {
 /**
  * Generate ECDHE secret from private key and public part of ephemeral key using indutny/elliptic
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} V - Public part of ephemeral key
  * @param {Uint8Array} d - Recipient private key
  * @returns {Promise<{secretKey: Uint8Array, sharedKey: Uint8Array}>}
@@ -330,7 +330,7 @@ async function ellipticPrivateEphemeralKey(curve, V, d) {
 /**
  * Generate ECDHE ephemeral key and secret from public key using indutny/elliptic
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} Q - Recipient public key
  * @returns {Promise<{publicKey: Uint8Array, sharedKey: Uint8Array}>}
  * @async
@@ -350,7 +350,7 @@ async function ellipticPublicEphemeralKey(curve, Q) {
 /**
  * Generate ECDHE secret from private key and public part of ephemeral key using nodeCrypto
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} V - Public part of ephemeral key
  * @param {Uint8Array} d - Recipient private key
  * @returns {Promise<{secretKey: Uint8Array, sharedKey: Uint8Array}>}
@@ -367,7 +367,7 @@ async function nodePrivateEphemeralKey(curve, V, d) {
 /**
  * Generate ECDHE ephemeral key and secret from public key using nodeCrypto
  *
- * @param {Curve} curve - Elliptic curve object
+ * @param {CurveWithOID} curve - Elliptic curve object
  * @param {Uint8Array} Q - Recipient public key
  * @returns {Promise<{publicKey: Uint8Array, sharedKey: Uint8Array}>}
  * @async

--- a/src/crypto/public_key/elliptic/ecdh_x.js
+++ b/src/crypto/public_key/elliptic/ecdh_x.js
@@ -20,7 +20,7 @@ const HKDF_INFO = {
 /**
  * Generate ECDH key for Montgomery curves
  * @param {module:enums.publicKey} algo - Algorithm identifier
- * @returns Promise<{ A, k }>
+ * @returns {Promise<{ A: Uint8Array, k: Uint8Array }>}
  */
 export async function generate(algo) {
   switch (algo) {

--- a/src/crypto/public_key/elliptic/ecdh_x.js
+++ b/src/crypto/public_key/elliptic/ecdh_x.js
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Key encryption and decryption for RFC 6637 ECDH
+ * @module crypto/public_key/elliptic/ecdh
+ * @private
+ */
+
+import nacl from '@openpgp/tweetnacl/nacl-fast-light';
+import * as aesKW from '../../aes_kw';
+import { getRandomBytes } from '../../random';
+
+import enums from '../../../enums';
+import util from '../../../util';
+import getCipher from '../../cipher/getCipher';
+import computeHKDF from '../../hkdf';
+
+const HKDF_INFO = {
+  x25519: util.encodeUTF8('OpenPGP X25519')
+};
+
+/**
+ * Generate ECDH key for Montgomery curves
+ * @param {module:enums.publicKey} algo - Algorithm identifier
+ * @returns Promise<{ A, k }>
+ */
+export async function generate(algo) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      // k stays in little-endian, unlike legacy ECDH over curve25519
+      const k = getRandomBytes(32);
+      k[0] &= 248;
+      k[31] = (k[31] & 127) | 64;
+      const { publicKey: A } = nacl.box.keyPair.fromSecretKey(k);
+      return { A, k };
+    }
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+/**
+* Validate ECDH parameters
+* @param {module:enums.publicKey} algo - Algorithm identifier
+* @param {Uint8Array} A - ECDH public point
+* @param {Uint8Array} k - ECDH secret scalar
+* @returns {Promise<Boolean>} Whether params are valid.
+* @async
+*/
+export async function validateParams(algo, A, k) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      /**
+       * Derive public point A' from private key
+       * and expect A == A'
+       */
+      const { publicKey } = nacl.box.keyPair.fromSecretKey(k);
+      return util.equalsUint8Array(A, publicKey);
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Wrap and encrypt a session key
+ *
+ * @param {module:enums.publicKey} algo - Algorithm identifier
+ * @param {Uint8Array} data - session key data to be encrypted
+ * @param {Uint8Array} recipientA - Recipient public key (K_B)
+ * @returns {Promise<{
+ *  ephemeralPublicKey: Uint8Array,
+ * wrappedKey: Uint8Array
+ * }>} ephemeral public key (K_A) and encrypted key
+ * @async
+ */
+export async function encrypt(algo, data, recipientA) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      const ephemeralSecretKey = getRandomBytes(32);
+      const sharedSecret = nacl.scalarMult(ephemeralSecretKey, recipientA);
+      const { publicKey: ephemeralPublicKey } = nacl.box.keyPair.fromSecretKey(ephemeralSecretKey);
+      const hkdfInput = util.concatUint8Array([
+        ephemeralPublicKey,
+        recipientA,
+        sharedSecret
+      ]);
+      const { keySize } = getCipher(enums.symmetric.aes128);
+      const encryptionKey = await computeHKDF(enums.hash.sha256, hkdfInput, new Uint8Array(), HKDF_INFO.x25519, keySize);
+      const wrappedKey = aesKW.wrap(encryptionKey, data);
+      return { ephemeralPublicKey, wrappedKey };
+    }
+
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+/**
+ * Decrypt and unwrap the session key
+ *
+ * @param {module:enums.publicKey} algo - Algorithm identifier
+ * @param {Uint8Array} ephemeralPublicKey - (K_A)
+ * @param {Uint8Array} wrappedKey,
+ * @param {Uint8Array} A - Recipient public key (K_b), needed for KDF
+ * @param {Uint8Array} k - Recipient secret key (b)
+ * @returns {Promise<Uint8Array>} decrypted session key data
+ * @async
+ */
+export async function decrypt(algo, ephemeralPublicKey, wrappedKey, A, k) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      const sharedSecret = nacl.scalarMult(k, ephemeralPublicKey);
+      const hkdfInput = util.concatUint8Array([
+        ephemeralPublicKey,
+        A,
+        sharedSecret
+      ]);
+      const { keySize } = getCipher(enums.symmetric.aes128);
+      const encryptionKey = await computeHKDF(enums.hash.sha256, hkdfInput, new Uint8Array(), HKDF_INFO.x25519, keySize);
+      return aesKW.unwrap(encryptionKey, wrappedKey);
+    }
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}

--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -25,7 +25,7 @@ import enums from '../../../enums';
 import util from '../../../util';
 import { getRandomBytes } from '../../random';
 import hash from '../../hash';
-import { Curve, webCurves, privateToJWK, rawPublicToJWK, validateStandardParams } from './curves';
+import { CurveWithOID, webCurves, privateToJWK, rawPublicToJWK, validateStandardParams } from './oid_curves';
 import { getIndutnyCurve, keyFromPrivate, keyFromPublic } from './indutnyKey';
 
 const webCrypto = util.getWebCrypto();
@@ -46,7 +46,7 @@ const nodeCrypto = util.getNodeCrypto();
  * @async
  */
 export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed) {
-  const curve = new Curve(oid);
+  const curve = new CurveWithOID(oid);
   if (message && !util.isStream(message)) {
     const keyPair = { publicKey, privateKey };
     switch (curve.type) {
@@ -91,7 +91,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
  * @async
  */
 export async function verify(oid, hashAlgo, signature, message, publicKey, hashed) {
-  const curve = new Curve(oid);
+  const curve = new CurveWithOID(oid);
   if (message && !util.isStream(message)) {
     switch (curve.type) {
       case 'web':
@@ -125,7 +125,7 @@ export async function verify(oid, hashAlgo, signature, message, publicKey, hashe
  * @async
  */
 export async function validateParams(oid, Q, d) {
-  const curve = new Curve(oid);
+  const curve = new CurveWithOID(oid);
   // Reject curves x25519 and ed25519
   if (curve.keyType !== enums.publicKey.ecdsa) {
     return false;

--- a/src/crypto/public_key/elliptic/eddsa.js
+++ b/src/crypto/public_key/elliptic/eddsa.js
@@ -104,19 +104,19 @@ export async function verify(algo, hashAlgo, { RS }, m, publicKey, hashed) {
  * Validate (non-legacy) EdDSA parameters
  * @param {module:enums.publicKey} algo - Algorithm identifier
  * @param {Uint8Array} A - EdDSA public point
- * @param {Uint8Array} k - EdDSA secret seed
+ * @param {Uint8Array} seed - EdDSA secret seed
  * @param {Uint8Array} oid - (legacy only) EdDSA OID
  * @returns {Promise<Boolean>} Whether params are valid.
  * @async
  */
-export async function validateParams(algo, A, k) {
+export async function validateParams(algo, A, seed) {
   switch (algo) {
     case enums.publicKey.ed25519: {
       /**
        * Derive public point A' from private key
        * and expect A == A'
        */
-      const { publicKey } = nacl.sign.keyPair.fromSeed(k);
+      const { publicKey } = nacl.sign.keyPair.fromSeed(seed);
       return util.equalsUint8Array(A, publicKey);
     }
 

--- a/src/crypto/public_key/elliptic/eddsa.js
+++ b/src/crypto/public_key/elliptic/eddsa.js
@@ -33,7 +33,7 @@ nacl.hash = bytes => new Uint8Array(sha512().update(bytes).digest());
 /**
  * Generate (non-legacy) EdDSA key
  * @param {module:enums.publicKey} algo - Algorithm identifier
- * @returns Promise<{ A, seed }>
+ * @returns {Promise<{ A: Uint8Array, seed: Uint8Array }>}
  */
 export async function generate(algo) {
   switch (algo) {
@@ -56,8 +56,7 @@ export async function generate(algo) {
  * @param {Uint8Array} privateKey - Private key used to sign the message
  * @param {Uint8Array} hashed - The hashed message
  * @returns {Promise<{
- *   r: Uint8Array,
- *   s: Uint8Array
+ *   RS: Uint8Array
  * }>} Signature of the message
  * @async
  */

--- a/src/crypto/public_key/elliptic/index.js
+++ b/src/crypto/public_key/elliptic/index.js
@@ -27,9 +27,10 @@
 
 import { Curve, generate, getPreferredHashAlgo } from './curves';
 import * as ecdsa from './ecdsa';
+import * as eddsaLegacy from './eddsa_legacy';
 import * as eddsa from './eddsa';
 import * as ecdh from './ecdh';
 
 export {
-  Curve, ecdh, ecdsa, eddsa, generate, getPreferredHashAlgo
+  Curve, ecdh, ecdsa, eddsaLegacy, eddsa, generate, getPreferredHashAlgo
 };

--- a/src/crypto/public_key/elliptic/index.js
+++ b/src/crypto/public_key/elliptic/index.js
@@ -25,7 +25,7 @@
  * @private
  */
 
-import { Curve, generate, getPreferredHashAlgo } from './curves';
+import { CurveWithOID, generate, getPreferredHashAlgo } from './oid_curves';
 import * as ecdsa from './ecdsa';
 import * as eddsaLegacy from './eddsa_legacy';
 import * as eddsa from './eddsa';
@@ -33,5 +33,5 @@ import * as ecdh from './ecdh';
 import * as ecdhX from './ecdh_x';
 
 export {
-  Curve, ecdh, ecdhX, ecdsa, eddsaLegacy, eddsa, generate, getPreferredHashAlgo
+  CurveWithOID, ecdh, ecdhX, ecdsa, eddsaLegacy, eddsa, generate, getPreferredHashAlgo
 };

--- a/src/crypto/public_key/elliptic/index.js
+++ b/src/crypto/public_key/elliptic/index.js
@@ -30,7 +30,8 @@ import * as ecdsa from './ecdsa';
 import * as eddsaLegacy from './eddsa_legacy';
 import * as eddsa from './eddsa';
 import * as ecdh from './ecdh';
+import * as ecdhX from './ecdh_x';
 
 export {
-  Curve, ecdh, ecdsa, eddsaLegacy, eddsa, generate, getPreferredHashAlgo
+  Curve, ecdh, ecdhX, ecdsa, eddsaLegacy, eddsa, generate, getPreferredHashAlgo
 };

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -131,7 +131,7 @@ const curves = {
   }
 };
 
-class Curve {
+class CurveWithOID {
   constructor(oidOrName, params) {
     try {
       if (util.isArray(oidOrName) ||
@@ -208,7 +208,7 @@ class Curve {
 async function generate(curve) {
   const BigInteger = await util.getBigInteger();
 
-  curve = new Curve(curve);
+  curve = new CurveWithOID(curve);
   const keyPair = await curve.genKeyPair();
   const Q = new BigInteger(keyPair.publicKey).toUint8Array();
   const secret = new BigInteger(keyPair.privateKey).toUint8Array('be', curve.payloadSize);
@@ -293,7 +293,7 @@ async function validateStandardParams(algo, oid, Q, d) {
 }
 
 export {
-  Curve, curves, webCurves, nodeCurves, generate, getPreferredHashAlgo, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams
+  CurveWithOID, curves, webCurves, nodeCurves, generate, getPreferredHashAlgo, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams
 };
 
 //////////////////////////

--- a/src/crypto/signature.js
+++ b/src/crypto/signature.js
@@ -97,7 +97,7 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
     }
     case enums.publicKey.ecdsa: {
       const { oid, Q } = publicParams;
-      const curveSize = new publicKey.elliptic.Curve(oid).payloadSize;
+      const curveSize = new publicKey.elliptic.CurveWithOID(oid).payloadSize;
       // padding needed for webcrypto
       const r = util.leftPad(signature.r, curveSize);
       const s = util.leftPad(signature.s, curveSize);

--- a/src/enums.js
+++ b/src/enums.js
@@ -90,7 +90,7 @@ export default {
     gnu: 101
   },
 
-  /** {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-9.1|RFC4880bis-04, section 9.1}
+  /** {@link https://tools.ietf.org/html/draft-ietf-openpgp-crypto-refresh-08.html#section-9.1|crypto-refresh RFC, section 9.1}
    * @enum {Integer}
    * @readonly
    */
@@ -109,13 +109,22 @@ export default {
     ecdh: 18,
     /** ECDSA (Sign only) [RFC6637] */
     ecdsa: 19,
-    /** EdDSA (Sign only)
+    /** EdDSA (Sign only) - deprecated by crypto-refresh (replaced by `ed25519` identifier below)
      * [{@link https://tools.ietf.org/html/draft-koch-eddsa-for-openpgp-04|Draft RFC}] */
-    eddsa: 22,
+    ed25519Legacy: 22, // NB: this is declared before `eddsa` to translate 22 to 'eddsa' for backwards compatibility
+    eddsa: 22, // to be deprecated in v6
     /** Reserved for AEDH */
     aedh: 23,
     /** Reserved for AEDSA */
-    aedsa: 24
+    aedsa: 24,
+    /** ECDH 25519 (encrypt only) */
+    x25519: 25,
+    /** ECDH 448 (encrypt only) */
+    x448: 26,
+    /** EdDSA 25519 (sign only) */
+    ed25519: 27,
+    /** EdDSA 448 (sign only) */
+    eddsa448: 28
   },
 
   /** {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC4880, section 9.2}

--- a/src/enums.js
+++ b/src/enums.js
@@ -117,14 +117,14 @@ export default {
     aedh: 23,
     /** Reserved for AEDSA */
     aedsa: 24,
-    /** ECDH 25519 (encrypt only) */
+    /** X25519 (Encrypt only) */
     x25519: 25,
-    /** ECDH 448 (encrypt only) */
+    /** X448 (Encrypt only) */
     x448: 26,
-    /** EdDSA 25519 (sign only) */
+    /** Ed25519 (Sign only) */
     ed25519: 27,
-    /** EdDSA 448 (sign only) */
-    eddsa448: 28
+    /** Ed448 (Sign only) */
+    ed448: 28
   },
 
   /** {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC4880, section 9.2}

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -260,7 +260,7 @@ class PublicKeyPacket {
     const modulo = this.publicParams.n || this.publicParams.p;
     if (modulo) {
       result.bits = util.uint8ArrayBitLength(modulo);
-    } else {
+    } else if (this.publicParams.oid) {
       result.curve = this.publicParams.oid.getName();
     }
     return result;

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -67,13 +67,17 @@ class PublicKeyEncryptedSessionKeyPacket {
    * @param {Uint8Array} bytes - Payload of a tag 1 packet
    */
   read(bytes) {
-    this.version = bytes[0];
+    let i = 0;
+    this.version = bytes[i++];
     if (this.version !== VERSION) {
       throw new UnsupportedError(`Version ${this.version} of the PKESK packet is unsupported.`);
     }
-    this.publicKeyID.read(bytes.subarray(1, bytes.length));
-    this.publicKeyAlgorithm = bytes[9];
-    this.encrypted = crypto.parseEncSessionKeyParams(this.publicKeyAlgorithm, bytes.subarray(10));
+    i += this.publicKeyID.read(bytes.subarray(i));
+    this.publicKeyAlgorithm = bytes[i++];
+    this.encrypted = crypto.parseEncSessionKeyParams(this.publicKeyAlgorithm, bytes.subarray(i), this.version);
+    if (this.publicKeyAlgorithm === enums.publicKey.x25519) {
+      this.sessionKeyAlgorithm = enums.write(enums.symmetric, this.encrypted.C.algorithm);
+    }
   }
 
   /**
@@ -99,14 +103,10 @@ class PublicKeyEncryptedSessionKeyPacket {
    * @async
    */
   async encrypt(key) {
-    const data = util.concatUint8Array([
-      new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]),
-      this.sessionKey,
-      util.writeChecksum(this.sessionKey)
-    ]);
     const algo = enums.write(enums.publicKey, this.publicKeyAlgorithm);
+    const encoded = encodeSessionKey(this.version, algo, this.sessionKeyAlgorithm, this.sessionKey);
     this.encrypted = await crypto.publicKeyEncrypt(
-      algo, key.publicParams, data, key.getFingerprintBytes());
+      algo, this.sessionKeyAlgorithm, key.publicParams, encoded, key.getFingerprintBytes());
   }
 
   /**
@@ -123,35 +123,85 @@ class PublicKeyEncryptedSessionKeyPacket {
       throw new Error('Decryption error');
     }
 
-    const randomPayload = randomSessionKey ? util.concatUint8Array([
-      new Uint8Array([randomSessionKey.sessionKeyAlgorithm]),
-      randomSessionKey.sessionKey,
-      util.writeChecksum(randomSessionKey.sessionKey)
-    ]) : null;
-    const decoded = await crypto.publicKeyDecrypt(this.publicKeyAlgorithm, key.publicParams, key.privateParams, this.encrypted, key.getFingerprintBytes(), randomPayload);
-    const symmetricAlgoByte = decoded[0];
-    const sessionKey = decoded.subarray(1, decoded.length - 2);
-    const checksum = decoded.subarray(decoded.length - 2);
-    const computedChecksum = util.writeChecksum(sessionKey);
-    const isValidChecksum = computedChecksum[0] === checksum[0] & computedChecksum[1] === checksum[1];
+    const randomPayload = randomSessionKey ?
+      encodeSessionKey(this.version, this.publicKeyAlgorithm, randomSessionKey.sessionKeyAlgorithm, randomSessionKey.sessionKey) :
+      null;
+    const decryptedData = await crypto.publicKeyDecrypt(this.publicKeyAlgorithm, key.publicParams, key.privateParams, this.encrypted, key.getFingerprintBytes(), randomPayload);
 
-    if (randomSessionKey) {
-      // We must not leak info about the validity of the decrypted checksum or cipher algo.
-      // The decrypted session key must be of the same algo and size as the random session key, otherwise we discard it and use the random data.
-      const isValidPayload = isValidChecksum & symmetricAlgoByte === randomSessionKey.sessionKeyAlgorithm & sessionKey.length === randomSessionKey.sessionKey.length;
-      this.sessionKeyAlgorithm = util.selectUint8(isValidPayload, symmetricAlgoByte, randomSessionKey.sessionKeyAlgorithm);
-      this.sessionKey = util.selectUint8Array(isValidPayload, sessionKey, randomSessionKey.sessionKey);
+    const { sessionKey, sessionKeyAlgorithm } = decodeSessionKey(this.version, this.publicKeyAlgorithm, decryptedData, randomSessionKey);
 
-    } else {
-      const isValidPayload = isValidChecksum && enums.read(enums.symmetric, symmetricAlgoByte);
-      if (isValidPayload) {
-        this.sessionKey = sessionKey;
-        this.sessionKeyAlgorithm = symmetricAlgoByte;
-      } else {
-        throw new Error('Decryption error');
-      }
+    // v3 Montgomery curves have cleartext cipher algo
+    if (this.publicKeyAlgorithm !== enums.publicKey.x25519) {
+      this.sessionKeyAlgorithm = sessionKeyAlgorithm;
     }
+    this.sessionKey = sessionKey;
   }
 }
 
 export default PublicKeyEncryptedSessionKeyPacket;
+
+
+function encodeSessionKey(version, keyAlgo, cipherAlgo, sessionKeyData) {
+  switch (keyAlgo) {
+    case enums.publicKey.rsaEncrypt:
+    case enums.publicKey.rsaEncryptSign:
+    case enums.publicKey.elgamal:
+    case enums.publicKey.ecdh: {
+      // add checksum
+      return util.concatUint8Array([
+        new Uint8Array([cipherAlgo]),
+        sessionKeyData,
+        util.writeChecksum(sessionKeyData.subarray(sessionKeyData.length % 8))
+      ]);
+    }
+    case enums.publicKey.x25519:
+      return sessionKeyData;
+    default:
+      throw new Error('Unsupported public key algorithm');
+  }
+}
+
+
+function decodeSessionKey(version, keyAlgo, decryptedData, randomSessionKey) {
+  switch (keyAlgo) {
+    case enums.publicKey.rsaEncrypt:
+    case enums.publicKey.rsaEncryptSign:
+    case enums.publicKey.elgamal:
+    case enums.publicKey.ecdh: {
+      // verify checksum in constant time
+      const result = decryptedData.subarray(0, decryptedData.length - 2);
+      const checksum = decryptedData.subarray(decryptedData.length - 2);
+      const computedChecksum = util.writeChecksum(result.subarray(result.length % 8));
+      const isValidChecksum = computedChecksum[0] === checksum[0] & computedChecksum[1] === checksum[1];
+      const decryptedSessionKey = { sessionKeyAlgorithm: result[0], sessionKey: result.subarray(1) };
+      if (randomSessionKey) {
+        // We must not leak info about the validity of the decrypted checksum or cipher algo.
+        // The decrypted session key must be of the same algo and size as the random session key, otherwise we discard it and use the random data.
+        const isValidPayload = isValidChecksum &
+          decryptedSessionKey.sessionKeyAlgorithm === randomSessionKey.sessionKeyAlgorithm &
+          decryptedSessionKey.sessionKey.length === randomSessionKey.sessionKey.length;
+        return {
+          sessionKey: util.selectUint8Array(isValidPayload, decryptedSessionKey.sessionKey, randomSessionKey.sessionKey),
+          sessionKeyAlgorithm: util.selectUint8(
+            isValidPayload,
+            decryptedSessionKey.sessionKeyAlgorithm,
+            randomSessionKey.sessionKeyAlgorithm
+          )
+        };
+      } else {
+        const isValidPayload = isValidChecksum && enums.read(enums.symmetric, decryptedSessionKey.sessionKeyAlgorithm);
+        if (isValidPayload) {
+          return decryptedSessionKey;
+        } else {
+          throw new Error('Decryption error');
+        }
+      }
+    }
+    case enums.publicKey.x25519:
+      return {
+        sessionKey: decryptedData
+      };
+    default:
+      throw new Error('Unsupported public key algorithm');
+  }
+}

--- a/src/type/ecdh_symkey.js
+++ b/src/type/ecdh_symkey.js
@@ -16,7 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /**
- * Encoded symmetric key for ECDH
+ * Encoded symmetric key for ECDH (incl. legacy x25519)
  *
  * @module type/ecdh_symkey
  * @private
@@ -26,26 +26,23 @@ import util from '../util';
 
 class ECDHSymmetricKey {
   constructor(data) {
-    if (typeof data === 'undefined') {
-      data = new Uint8Array([]);
-    } else if (util.isString(data)) {
-      data = util.stringToUint8Array(data);
-    } else {
-      data = new Uint8Array(data);
+    if (data) {
+      this.data = data;
     }
-    this.data = data;
   }
 
   /**
-   * Read an ECDHSymmetricKey from an Uint8Array
-   * @param {Uint8Array} input - Where to read the encoded symmetric key from
+   * Read an ECDHSymmetricKey from an Uint8Array:
+   * - 1 octect for the length `l`
+   * - `l` octects of encoded session key data
+   * @param {Uint8Array} bytes
    * @returns {Number} Number of read bytes.
    */
-  read(input) {
-    if (input.length >= 1) {
-      const length = input[0];
-      if (input.length >= 1 + length) {
-        this.data = input.subarray(1, 1 + length);
+  read(bytes) {
+    if (bytes.length >= 1) {
+      const length = bytes[0];
+      if (bytes.length >= 1 + length) {
+        this.data = bytes.subarray(1, 1 + length);
         return 1 + this.data.length;
       }
     }
@@ -54,7 +51,7 @@ class ECDHSymmetricKey {
 
   /**
    * Write an ECDHSymmetricKey as an Uint8Array
-   * @returns  {Uint8Array}  An array containing the value
+   * @returns  {Uint8Array} Serialised data
    */
   write() {
     return util.concatUint8Array([new Uint8Array([this.data.length]), this.data]);

--- a/src/type/ecdh_x_symkey.js
+++ b/src/type/ecdh_x_symkey.js
@@ -1,0 +1,47 @@
+/**
+ * Encoded symmetric key for x25519 and x448
+ * The payload format varies for v3 and v6 PKESK:
+ * the former includes an algorithm byte preceeding the encrypted session key.
+ *
+ * @module type/x25519x448_symkey
+ */
+
+import util from '../util';
+
+class ECDHXSymmetricKey {
+  static fromObject({ wrappedKey, algorithm }) {
+    const instance = new ECDHXSymmetricKey();
+    instance.wrappedKey = wrappedKey;
+    instance.algorithm = algorithm;
+    return instance;
+  }
+
+  /**
+   * - 1 octect for the length `l`
+   * - `l` octects of encoded session key data (with optional leading algorithm byte)
+   * @param {Uint8Array} bytes
+   * @returns {Number} Number of read bytes.
+   */
+  read(bytes) {
+    let read = 0;
+    let followLength = bytes[read++];
+    this.algorithm = followLength % 2 ? bytes[read++] : null; // session key size is always even
+    followLength -= followLength % 2;
+    this.wrappedKey = bytes.subarray(read, read + followLength); read += followLength;
+  }
+
+  /**
+   * Write an MontgomerySymmetricKey as an Uint8Array
+   * @returns  {Uint8Array} Serialised data
+   */
+  write() {
+    return util.concatUint8Array([
+      this.algorithm ?
+        new Uint8Array([this.wrappedKey.length + 1, this.algorithm]) :
+        new Uint8Array([this.wrappedKey.length]),
+      this.wrappedKey
+    ]);
+  }
+}
+
+export default ECDHXSymmetricKey;

--- a/src/type/keyid.js
+++ b/src/type/keyid.js
@@ -42,6 +42,7 @@ class KeyID {
    */
   read(bytes) {
     this.bytes = util.uint8ArrayToString(bytes.subarray(0, 8));
+    return this.bytes.length;
   }
 
   /**

--- a/src/util.js
+++ b/src/util.js
@@ -25,6 +25,7 @@
 
 import * as stream from '@openpgp/web-stream-tools';
 import { getBigInteger } from './biginteger';
+import enums from './enums';
 
 const debugMode = (() => {
   try {
@@ -605,6 +606,12 @@ const util = {
    */
   selectUint8: function(cond, a, b) {
     return (a & (256 - cond)) | (b & (255 + cond));
+  },
+  /**
+   * @param {module:enums.symmetric} cipherAlgo
+   */
+  isAES: function(cipherAlgo) {
+    return cipherAlgo === enums.symmetric.aes128 || cipherAlgo === enums.symmetric.aes192 || cipherAlgo === enums.symmetric.aes256;
   }
 };
 

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -269,7 +269,7 @@ module.exports = () => describe('API functional testing', function() {
 
     it('Asymmetric using RSA with eme_pkcs1 padding', function () {
       const symmKey = crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
-      return crypto.publicKeyEncrypt(algoRSA, RSAPublicParams, symmKey).then(RSAEncryptedData => {
+      return crypto.publicKeyEncrypt(algoRSA, openpgp.enums.symmetric.aes256, RSAPublicParams, symmKey).then(RSAEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoRSA, RSAPublicParams, RSAPrivateParams, RSAEncryptedData
         ).then(data => {
@@ -280,7 +280,7 @@ module.exports = () => describe('API functional testing', function() {
 
     it('Asymmetric using Elgamal with eme_pkcs1 padding', function () {
       const symmKey = crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
-      return crypto.publicKeyEncrypt(algoElGamal, elGamalPublicParams, symmKey).then(ElgamalEncryptedData => {
+      return crypto.publicKeyEncrypt(algoElGamal, openpgp.enums.symmetric.aes256, elGamalPublicParams, symmKey).then(ElgamalEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoElGamal, elGamalPublicParams, elGamalPrivateParams, ElgamalEncryptedData
         ).then(data => {

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -20,7 +20,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
       data = new Uint8Array(data);
     }
     return Promise.resolve().then(() => {
-      const curve = new elliptic_curves.Curve(oid);
+      const curve = new elliptic_curves.CurveWithOID(oid);
       return elliptic_curves.ecdh.decrypt(
         new OID(curve.oid),
         new KDFParams({ cipher, hash }),
@@ -138,7 +138,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
     if (!openpgp.config.useIndutnyElliptic && !util.getNodeCrypto()) {
       this.skip();
     }
-    const curve = new elliptic_curves.Curve('secp256k1');
+    const curve = new elliptic_curves.CurveWithOID('secp256k1');
     const oid = new OID(curve.oid);
     const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
     const data = util.stringToUint8Array('test');
@@ -148,7 +148,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   });
 
   it('Different keys', async function () {
-    const curve = new elliptic_curves.Curve('curve25519');
+    const curve = new elliptic_curves.CurveWithOID('curve25519');
     const oid = new OID(curve.oid);
     const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
     const data = util.stringToUint8Array('test');
@@ -159,7 +159,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   });
 
   it('Invalid fingerprint', async function () {
-    const curve = new elliptic_curves.Curve('curve25519');
+    const curve = new elliptic_curves.CurveWithOID('curve25519');
     const oid = new OID(curve.oid);
     const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
     const data = util.stringToUint8Array('test');
@@ -170,7 +170,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
   });
 
   it('Successful exchange x25519 (legacy)', async function () {
-    const curve = new elliptic_curves.Curve('curve25519');
+    const curve = new elliptic_curves.CurveWithOID('curve25519');
     const oid = new OID(curve.oid);
     const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
     const data = util.stringToUint8Array('test');
@@ -190,7 +190,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
 
   ['p256', 'p384', 'p521'].forEach(curveName => {
     it(`NIST ${curveName} - Successful exchange`, async function () {
-      const curve = new elliptic_curves.Curve(curveName);
+      const curve = new elliptic_curves.CurveWithOID(curveName);
       const oid = new OID(curve.oid);
       const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
       const data = util.stringToUint8Array('test');
@@ -233,7 +233,7 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
           this.skip();
         }
 
-        const curve = new elliptic_curves.Curve(curveName);
+        const curve = new elliptic_curves.CurveWithOID(curveName);
         const oid = new OID(curve.oid);
         const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
         const data = util.stringToUint8Array('test');

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -8,6 +8,7 @@ const KDFParams = require('../../src/type/kdf_params');
 const elliptic_curves = require('../../src/crypto/public_key/elliptic');
 const util = require('../../src/util');
 const elliptic_data = require('./elliptic_data');
+const random = require('../../src/crypto/random');
 
 const key_data = elliptic_data.key_data;
 /* eslint-disable no-invalid-this */
@@ -131,52 +132,107 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
     71, 245, 86, 3, 168, 101, 74, 209, 105
   ]);
 
-  describe('ECDHE key generation', function () {
-    const ecdh = elliptic_curves.ecdh;
+  const ecdh = elliptic_curves.ecdh;
 
-    it('Invalid curve', async function () {
-      if (!openpgp.config.useIndutnyElliptic && !util.getNodeCrypto()) {
-        this.skip();
-      }
-      const curve = new elliptic_curves.Curve('secp256k1');
+  it('Invalid curve', async function () {
+    if (!openpgp.config.useIndutnyElliptic && !util.getNodeCrypto()) {
+      this.skip();
+    }
+    const curve = new elliptic_curves.Curve('secp256k1');
+    const oid = new OID(curve.oid);
+    const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+    const data = util.stringToUint8Array('test');
+    expect(
+      ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1)
+    ).to.be.rejectedWith(Error, /Public key is not valid for specified curve|Failed to translate Buffer to a EC_POINT|Unknown point format/);
+  });
+
+  it('Different keys', async function () {
+    const curve = new elliptic_curves.Curve('curve25519');
+    const oid = new OID(curve.oid);
+    const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+    const data = util.stringToUint8Array('test');
+    const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
+    await expect(
+      ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint1)
+    ).to.be.rejectedWith(/Key Data Integrity failed/);
+  });
+
+  it('Invalid fingerprint', async function () {
+    const curve = new elliptic_curves.Curve('curve25519');
+    const oid = new OID(curve.oid);
+    const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+    const data = util.stringToUint8Array('test');
+    const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q2, fingerprint1);
+    await expect(
+      ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint2)
+    ).to.be.rejectedWith(/Key Data Integrity failed/);
+  });
+
+  it('Successful exchange x25519 (legacy)', async function () {
+    const curve = new elliptic_curves.Curve('curve25519');
+    const oid = new OID(curve.oid);
+    const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
+    const data = util.stringToUint8Array('test');
+    const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
+    expect(await ecdh.decrypt(oid, kdfParams, V, C, Q1, d1, fingerprint1)).to.deep.equal(data);
+  });
+
+  it('Successful exchange x25519', async function () {
+    const { ecdhX } = elliptic_curves;
+    const data = random.getRandomBytes(32);
+    // Bob's keys from https://www.rfc-editor.org/rfc/rfc7748#section-6.1
+    const b = util.hexToUint8Array('5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb');
+    const K_B = util.hexToUint8Array('de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f');
+    const { ephemeralPublicKey, wrappedKey } = await ecdhX.encrypt(openpgp.enums.publicKey.x25519, data, K_B);
+    expect(await ecdhX.decrypt(openpgp.enums.publicKey.x25519, ephemeralPublicKey, wrappedKey, K_B, b)).to.deep.equal(data);
+  });
+
+  ['p256', 'p384', 'p521'].forEach(curveName => {
+    it(`NIST ${curveName} - Successful exchange`, async function () {
+      const curve = new elliptic_curves.Curve(curveName);
       const oid = new OID(curve.oid);
       const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
       const data = util.stringToUint8Array('test');
-      expect(
-        ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1)
-      ).to.be.rejectedWith(Error, /Public key is not valid for specified curve|Failed to translate Buffer to a EC_POINT|Unknown point format/);
+      const Q = key_data[curveName].pub;
+      const d = key_data[curveName].priv;
+      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1);
+      expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
     });
-    it('Different keys', async function () {
-      const curve = new elliptic_curves.Curve('curve25519');
-      const oid = new OID(curve.oid);
-      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
-      const data = util.stringToUint8Array('test');
-      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
-      await expect(
-        ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint1)
-      ).to.be.rejectedWith(/Key Data Integrity failed/);
+  });
+
+  describe('Comparing decrypting with and without native crypto', () => {
+    let sinonSandbox;
+    let getWebCryptoStub;
+    let getNodeCryptoStub;
+
+    beforeEach(function () {
+      sinonSandbox = sandbox.create();
     });
-    it('Invalid fingerprint', async function () {
-      const curve = new elliptic_curves.Curve('curve25519');
-      const oid = new OID(curve.oid);
-      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
-      const data = util.stringToUint8Array('test');
-      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q2, fingerprint1);
-      await expect(
-        ecdh.decrypt(oid, kdfParams, V, C, Q2, d2, fingerprint2)
-      ).to.be.rejectedWith(/Key Data Integrity failed/);
+
+    afterEach(function () {
+      sinonSandbox.restore();
     });
-    it('Successful exchange curve25519', async function () {
-      const curve = new elliptic_curves.Curve('curve25519');
-      const oid = new OID(curve.oid);
-      const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
-      const data = util.stringToUint8Array('test');
-      const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1);
-      expect(await ecdh.decrypt(oid, kdfParams, V, C, Q1, d1, fingerprint1)).to.deep.equal(data);
-    });
+
+    const disableNative = () => {
+      enableNative();
+      // stubbed functions return undefined
+      getWebCryptoStub = sinonSandbox.stub(util, 'getWebCrypto');
+      getNodeCryptoStub = sinonSandbox.stub(util, 'getNodeCrypto');
+    };
+    const enableNative = () => {
+      getWebCryptoStub && getWebCryptoStub.restore();
+      getNodeCryptoStub && getNodeCryptoStub.restore();
+    };
 
     ['p256', 'p384', 'p521'].forEach(curveName => {
-      it(`NIST ${curveName} - Successful exchange`, async function () {
+      it(`NIST ${curveName}`, async function () {
+        const nodeCrypto = util.getNodeCrypto();
+        const webCrypto = util.getWebCrypto();
+        if (!nodeCrypto && !webCrypto) {
+          this.skip();
+        }
+
         const curve = new elliptic_curves.Curve(curveName);
         const oid = new OID(curve.oid);
         const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
@@ -184,58 +240,14 @@ module.exports = () => describe('ECDH key exchange @lightweight', function () {
         const Q = key_data[curveName].pub;
         const d = key_data[curveName].priv;
         const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1);
+
+        const nativeDecryptSpy = webCrypto ? sinonSandbox.spy(webCrypto, 'deriveBits') : sinonSandbox.spy(nodeCrypto, 'createECDH');
         expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
-      });
-    });
-
-    describe('Comparing decrypting with and without native crypto', () => {
-      let sinonSandbox;
-      let getWebCryptoStub;
-      let getNodeCryptoStub;
-
-      beforeEach(function () {
-        sinonSandbox = sandbox.create();
-      });
-
-      afterEach(function () {
-        sinonSandbox.restore();
-      });
-
-      const disableNative = () => {
-        enableNative();
-        // stubbed functions return undefined
-        getWebCryptoStub = sinonSandbox.stub(util, 'getWebCrypto');
-        getNodeCryptoStub = sinonSandbox.stub(util, 'getNodeCrypto');
-      };
-      const enableNative = () => {
-        getWebCryptoStub && getWebCryptoStub.restore();
-        getNodeCryptoStub && getNodeCryptoStub.restore();
-      };
-
-      ['p256', 'p384', 'p521'].forEach(curveName => {
-        it(`NIST ${curveName}`, async function () {
-          const nodeCrypto = util.getNodeCrypto();
-          const webCrypto = util.getWebCrypto();
-          if (!nodeCrypto && !webCrypto) {
-            this.skip();
-          }
-
-          const curve = new elliptic_curves.Curve(curveName);
-          const oid = new OID(curve.oid);
-          const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
-          const data = util.stringToUint8Array('test');
-          const Q = key_data[curveName].pub;
-          const d = key_data[curveName].priv;
-          const { publicKey: V, wrappedKey: C } = await ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1);
-
-          const nativeDecryptSpy = webCrypto ? sinonSandbox.spy(webCrypto, 'deriveBits') : sinonSandbox.spy(nodeCrypto, 'createECDH');
-          expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
-          disableNative();
-          expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
-          if (curveName !== 'p521') { // safari does not implement p521 in webcrypto
-            expect(nativeDecryptSpy.calledOnce).to.be.true;
-          }
-        });
+        disableNative();
+        expect(await ecdh.decrypt(oid, kdfParams, V, C, Q, d, fingerprint1)).to.deep.equal(data);
+        if (curveName !== 'p521') { // safari does not implement p521 in webcrypto
+          expect(nativeDecryptSpy.calledOnce).to.be.true;
+        }
       });
     });
   });

--- a/test/crypto/elliptic.js
+++ b/test/crypto/elliptic.js
@@ -59,10 +59,10 @@ module.exports = () => describe('Elliptic Curve Cryptography @lightweight', func
   describe('Basic Operations', function () {
     it('Creating curve from name or oid', function (done) {
       Object.keys(openpgp.enums.curve).forEach(function(name_or_oid) {
-        expect(new elliptic_curves.Curve(name_or_oid)).to.exist;
+        expect(new elliptic_curves.CurveWithOID(name_or_oid)).to.exist;
       });
       Object.values(openpgp.enums.curve).forEach(function(name_or_oid) {
-        expect(new elliptic_curves.Curve(name_or_oid)).to.exist;
+        expect(new elliptic_curves.CurveWithOID(name_or_oid)).to.exist;
       });
       done();
     });
@@ -73,7 +73,7 @@ module.exports = () => describe('Elliptic Curve Cryptography @lightweight', func
       const names = config.useIndutnyElliptic ? ['p256', 'p384', 'p521', 'secp256k1', 'curve25519', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'] :
         ['p256', 'p384', 'p521', 'curve25519'];
       return Promise.all(names.map(function (name) {
-        const curve = new elliptic_curves.Curve(name);
+        const curve = new elliptic_curves.CurveWithOID(name);
         return curve.genKeyPair().then(keyPair => {
           expect(keyPair).to.exist;
         });
@@ -243,7 +243,7 @@ module.exports = () => describe('Elliptic Curve Cryptography @lightweight', func
         .to.eventually.be.true.notify(done);
     });
     it('Sign and verify message', function () {
-      const curve = new elliptic_curves.Curve('p521');
+      const curve = new elliptic_curves.CurveWithOID('p521');
       return curve.genKeyPair().then(async keyPair => {
         const keyPublic = new Uint8Array(keyPair.publicKey);
         const keyPrivate = new Uint8Array(keyPair.privateKey);

--- a/test/crypto/hkdf.js
+++ b/test/crypto/hkdf.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+
+const computeHKDF = require('../../src/crypto/hkdf');
+const enums = require('../../src/enums');
+const util = require('../../src/util');
+
+// WebCrypto implements HKDF natively, no need to test it
+const maybeDescribe = util.getNodeCrypto() ? describe : describe;
+
+module.exports = () => maybeDescribe('HKDF test vectors', function() {
+  // Vectors from https://www.rfc-editor.org/rfc/rfc5869#appendix-A
+  it('Test Case 1', async function() {
+    const inputKey = util.hexToUint8Array('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b');
+    const salt = util.hexToUint8Array('000102030405060708090a0b0c');
+    const info = util.hexToUint8Array('f0f1f2f3f4f5f6f7f8f9');
+    const outLen = 42;
+
+    const actual = await computeHKDF(enums.hash.sha256, inputKey, salt, info, outLen);
+    const expected = util.hexToUint8Array('3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865');
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('Test Case 2', async function() {
+    const inputKey = util.hexToUint8Array('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f');
+    const salt = util.hexToUint8Array('606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf');
+    const info = util.hexToUint8Array('b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff');
+    const outLen = 82;
+
+    const actual = await computeHKDF(enums.hash.sha256, inputKey, salt, info, outLen);
+    const expected = util.hexToUint8Array('b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87');
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('Test Case 3', async function() {
+    const inputKey = util.hexToUint8Array('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b');
+    const salt = new Uint8Array();
+    const info = new Uint8Array();
+    const outLen = 42;
+
+    const actual = await computeHKDF(enums.hash.sha256, inputKey, salt, info, outLen);
+    const expected = util.hexToUint8Array('8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8');
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -6,6 +6,7 @@ module.exports = () => describe('Crypto', function () {
   require('./ecdh')();
   require('./pkcs5')();
   require('./aes_kw')();
+  require('./hkdf')();
   require('./gcm')();
   require('./eax')();
   require('./ocb')();

--- a/test/crypto/validate.js
+++ b/test/crypto/validate.js
@@ -87,7 +87,7 @@ async function generatePrivateKeyObject(options) {
 
 /* eslint-disable no-invalid-this */
 module.exports = () => {
-  describe('EdDSA parameter validation', function() {
+  describe('EdDSA parameter validation (legacy format)', function() {
     let eddsaKey;
     before(async () => {
       eddsaKey = await generatePrivateKeyObject({ curve: 'ed25519' });

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3015,17 +3015,27 @@ zWBsBR8VnoOVfEE+VQk6YAi7cTSjcMjfsIez9FYtAQDKo9aCMhUohYyqvhZjn8aS
   it('Parsing V4 key using new curve25519 format', async function() {
     const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
-xUkEZBw5PBscroGar9fsilA0q9AX979pBhTNkGQ69vQGGW7kxRxNuABB+eAw
-JrQ9A3o1gUJg28ORTQd72+kFo87184qR97a6rRGFzQR0ZXN0wogEEBsIAD4F
-gmQcOTwECwkHCAmQT/m+Rl22Ps8DFQgKBBYAAgECGQECmwMCHgEWIQSUlOfm
-G7MWJd2909ZP+b5GXbY+zwAAVs/4pWH4l7pWcTATBavVqSATMKi4A+usp89G
-J/qaHc+qmcEpIMmPNvLQ7n4F4kEXk8Zwz+OXovVWLQ+Njl5gzooF
-=wYg1
+xUkEZB3qzRto01j2k2pwN5ux9w70stPinAdXULLr20CRW7U7h2GSeACch0M+
+qzQg8yjFQ8VBvu3uwgKH9senoHmj72lLSCLTmhFKzQR0ZXN0wogEEBsIAD4F
+gmQd6s0ECwkHCAmQIf45+TuC+xMDFQgKBBYAAgECGQECmwMCHgEWIQSWEzMi
+jJUHvyIbVKIh/jn5O4L7EwAAUhaHNlgudvxARdPPETUzVgjuWi+YIz8w1xIb
+lHQMvIrbe2sGCQIethpWofd0x7DHuv/ciHg+EoxJ/Td6h4pWtIoKx0kEZB3q
+zRm4CyA7quliq7yx08AoOqHTuuCgvpkSdEhpp3pEyejQOgBo0p6ywIiLPllY
+0t+jpNspHpAGfXID6oqjpYuJw3AfVRBlwnQEGBsIACoFgmQd6s0JkCH+Ofk7
+gvsTApsMFiEElhMzIoyVB78iG1SiIf45+TuC+xMAAGgQuN9G73446ykvJ/mL
+sCZ7zGFId2gBd1EnG0FTC4npfOKpck0X8dngByrCxU8LDSfvjsEp/xDAiKsQ
+aU71tdtNBQ==
+=e7jT
 -----END PGP PRIVATE KEY BLOCK-----` });
     // sanity checks
     await expect(privateKey.validate()).to.be.fulfilled;
     const signingKey = await privateKey.getSigningKey();
     expect(signingKey.keyPacket.algorithm).to.equal(openpgp.enums.publicKey.ed25519);
+    expect(signingKey.getAlgorithmInfo()).to.deep.equal({ algorithm: 'ed25519' });
+
+    const encryptionKey = await privateKey.getEncryptionKey();
+    expect(encryptionKey.keyPacket.algorithm).to.equal(openpgp.enums.publicKey.x25519);
+    expect(encryptionKey.getAlgorithmInfo()).to.deep.equal({ algorithm: 'x25519' });
   });
 
   it('Testing key ID and fingerprint for V4 keys', async function() {
@@ -4120,7 +4130,7 @@ XvmoLueOOShu01X/kaylMqaT8w==
       expect(await signatures[0].verified).to.be.true;
     });
 
-    it('encrypt/decrypt data with the new subkey correctly using curve25519', async function() {
+    it('encrypt/decrypt data with the new subkey correctly using curve25519 (legacy format)', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
       const vData = 'the data to encrypted!';
       const opt = { curve: 'curve25519', userIDs: [userID], format: 'object', subkeys:[] };

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3012,6 +3012,22 @@ zWBsBR8VnoOVfEE+VQk6YAi7cTSjcMjfsIez9FYtAQDKo9aCMhUohYyqvhZjn8aS
     })).to.be.rejectedWith(/Cannot read KDFParams/);
   });
 
+  it('Parsing V4 key using new curve25519 format', async function() {
+    const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xUkEZBw5PBscroGar9fsilA0q9AX979pBhTNkGQ69vQGGW7kxRxNuABB+eAw
+JrQ9A3o1gUJg28ORTQd72+kFo87184qR97a6rRGFzQR0ZXN0wogEEBsIAD4F
+gmQcOTwECwkHCAmQT/m+Rl22Ps8DFQgKBBYAAgECGQECmwMCHgEWIQSUlOfm
+G7MWJd2909ZP+b5GXbY+zwAAVs/4pWH4l7pWcTATBavVqSATMKi4A+usp89G
+J/qaHc+qmcEpIMmPNvLQ7n4F4kEXk8Zwz+OXovVWLQ+Njl5gzooF
+=wYg1
+-----END PGP PRIVATE KEY BLOCK-----` });
+    // sanity checks
+    await expect(privateKey.validate()).to.be.fulfilled;
+    const signingKey = await privateKey.getSigningKey();
+    expect(signingKey.keyPacket.algorithm).to.equal(openpgp.enums.publicKey.ed25519);
+  });
+
   it('Testing key ID and fingerprint for V4 keys', async function() {
     const pubKeysV4 = await openpgp.readKeys({ armoredKeys: twoKeys });
     expect(pubKeysV4).to.exist;
@@ -4077,7 +4093,7 @@ XvmoLueOOShu01X/kaylMqaT8w==
       await subkey.verify();
     });
 
-    it('sign/verify data with the new subkey correctly using curve25519', async function() {
+    it('sign/verify data with the new subkey correctly using curve25519 (legacy format)', async function() {
       const userID = { name: 'test', email: 'a@b.com' };
       const opt = { curve: 'curve25519', userIDs: [userID], format: 'object', subkeys:[] };
       const { privateKey } = await openpgp.generateKey(opt);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -4035,6 +4035,34 @@ bsZgJWVlAa5eil6J9ePX2xbo1vVAkLQdzE9+1jL+l7PRIZuVBQ==
           expect(await verified.signatures[0].verified).to.be.true;
         });
       });
+
+      it('sign/verify with new Ed25519 format', async function () {
+        // v4 key, which we do not support generating
+        const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xUkEZBw5PBscroGar9fsilA0q9AX979pBhTNkGQ69vQGGW7kxRxNuABB+eAw
+JrQ9A3o1gUJg28ORTQd72+kFo87184qR97a6rRGFzQR0ZXN0wogEEBsIAD4F
+gmQcOTwECwkHCAmQT/m+Rl22Ps8DFQgKBBYAAgECGQECmwMCHgEWIQSUlOfm
+G7MWJd2909ZP+b5GXbY+zwAAVs/4pWH4l7pWcTATBavVqSATMKi4A+usp89G
+J/qaHc+qmcEpIMmPNvLQ7n4F4kEXk8Zwz+OXovVWLQ+Njl5gzooF
+=wYg1
+-----END PGP PRIVATE KEY BLOCK-----
+  ` });
+        const plaintext = 'plaintext';
+
+        const signed = await openpgp.sign({
+          message: await openpgp.createMessage({ text: plaintext }),
+          signingKeys: privateKey
+        });
+
+        const { signatures, data } = await openpgp.verify({
+          message: await openpgp.readMessage({ armoredMessage: signed }),
+          verificationKeys: privateKey
+        });
+        expect(data).to.equal(plaintext);
+        expect(signatures).to.have.length(1);
+        expect(await signatures[0].verified).to.be.true;
+      });
     });
 
     describe('Errors', function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2018,6 +2018,65 @@ aOU=
       expect(await stream.readToEnd(streamedData)).to.equal(text);
     });
 
+    it('supports decrypting new x25519 format', async function () {
+      // v4 key
+      const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xUkEZIbSkxsHknQrXGfb+kM2iOsOvin8yE05ff5hF8KE6k+saspAZQCy/kfFUYc2
+GkpOHc42BI+MsysKzk4ofjBAfqM+bb7goQ3hzRV1c2VyIDx1c2VyQHRlc3QudGVz
+dD7ChwQTGwgAPQUCZIbSkwmQQezK2iB2tIkWIQRqZza9wQZcwxpjGYNB7MraIHa0
+iQIbAwIeAQIZAQILBwIVCAIWAAMnBwIAAFOeZ7jrKZsCzRfu1ffFa77074st0zRo
+BTJXoXBQ1ZzLjsh+ZO6fB2odnYJtQYstv45H/3JyLVogcMnFeYmHeSP3AMdJBGSG
+0pMZfpd7TiOQv7uKSK+k4HT9lKr5+dmvb7vox/8ids6unEkAF1v8fCKogIrtBWVT
+nVbwnovjM3LLexpXFZSgTKRcNMgPRMJ0BBgbCAAqBQJkhtKTCZBB7MraIHa0iRYh
+BGpnNr3BBlzDGmMZg0HsytogdrSJAhsMAADCYs2I9wBakIu9Hhxs4R3Jq9F8J7AH
+yxsNL0GomZ+hxiE0MOZwRr10DxfVaRabF1fcf9PHSHX2SwEFXUKMIHgbMQs=
+=bJqd
+-----END PGP PRIVATE KEY BLOCK-----` });
+
+      const messageToDecrypt = `-----BEGIN PGP MESSAGE-----
+
+wUQDYc6clYlCdtoZ3rAsvBDIwvoLmvM0zwViG8Ec0PgFfN5R6C4BqEZD53UZB1WM
+J68hXSj1Sa235XAUYE1pZerTKhglvdI9Aeve8+L0w5RDMjmBBA50Yv/YT8liqhNi
+mNwbfFbSNhZYWjFada77EKBn60j8QT/xCQzLR1clci7ieW2knw==
+=NKye
+-----END PGP MESSAGE-----`;
+      const { data } = await openpgp.decrypt({
+        message: await openpgp.readMessage({ armoredMessage: messageToDecrypt }),
+        decryptionKeys: privateKey
+      });
+      expect(data).to.equal('Hello World!');
+    });
+
+    it('supports encrypting new x25519 format', async function () {
+      // v4 key
+      const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xUkEZIbSkxsHknQrXGfb+kM2iOsOvin8yE05ff5hF8KE6k+saspAZQCy/kfFUYc2
+GkpOHc42BI+MsysKzk4ofjBAfqM+bb7goQ3hzRV1c2VyIDx1c2VyQHRlc3QudGVz
+dD7ChwQTGwgAPQUCZIbSkwmQQezK2iB2tIkWIQRqZza9wQZcwxpjGYNB7MraIHa0
+iQIbAwIeAQIZAQILBwIVCAIWAAMnBwIAAFOeZ7jrKZsCzRfu1ffFa77074st0zRo
+BTJXoXBQ1ZzLjsh+ZO6fB2odnYJtQYstv45H/3JyLVogcMnFeYmHeSP3AMdJBGSG
+0pMZfpd7TiOQv7uKSK+k4HT9lKr5+dmvb7vox/8ids6unEkAF1v8fCKogIrtBWVT
+nVbwnovjM3LLexpXFZSgTKRcNMgPRMJ0BBgbCAAqBQJkhtKTCZBB7MraIHa0iRYh
+BGpnNr3BBlzDGmMZg0HsytogdrSJAhsMAADCYs2I9wBakIu9Hhxs4R3Jq9F8J7AH
+yxsNL0GomZ+hxiE0MOZwRr10DxfVaRabF1fcf9PHSHX2SwEFXUKMIHgbMQs=
+=bJqd
+-----END PGP PRIVATE KEY BLOCK-----` });
+      const plaintext = 'plaintext';
+
+      const signed = await openpgp.encrypt({
+        message: await openpgp.createMessage({ text: plaintext }),
+        encryptionKeys: privateKey
+      });
+
+      const { data } = await openpgp.decrypt({
+        message: await openpgp.readMessage({ armoredMessage: signed }),
+        decryptionKeys: privateKey
+      });
+      expect(data).to.equal(plaintext);
+    });
+
     it('should support encrypting with encrypted key with unknown s2k (unparseableKeyMaterial)', async function() {
       const originalDecryptedKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
@@ -2063,7 +2122,6 @@ VFBLG8uc9IiaKann/DYBAJcZNZHRSfpDoV2pUA5EAEi2MdjxkRysFQnYPRAu
         decryptionKeys: originalDecryptedKey
       });
       expect(decrypted.data).to.equal('test');
-    });
   });
 
   describe('encryptSessionKey - unit tests', function() {

--- a/test/general/streaming.js
+++ b/test/general/streaming.js
@@ -730,7 +730,7 @@ function tests() {
     expect(await verified.signatures[0].verified).to.be.true;
   });
 
-  it('Detached sign small message using x25519 curve keys', async function() {
+  it('Detached sign small message using curve25519 keys (legacy format)', async function() {
     dataArrived(); // Do not wait until data arrived.
     const data = global.ReadableStream ? new global.ReadableStream({
       async start(controller) {

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -11,7 +11,7 @@ const util = require('../../src/util');
 
 const input = require('./testInputs');
 
-module.exports = () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cryptography', function () {
+module.exports = () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cryptography (legacy format)', function () {
   const data = {
     light: {
       id: '1ecdf026c0245830',

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -218,7 +218,7 @@ module.exports = () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cr
   describe('Ed25519 Test Vectors from RFC8032', function () {
     // https://tools.ietf.org/html/rfc8032#section-7.1
     function testVector(vector) {
-      const curve = new elliptic.Curve('ed25519');
+      const curve = new elliptic.CurveWithOID('ed25519');
       const { publicKey } = nacl.sign.keyPair.fromSeed(util.hexToUint8Array(vector.SECRET_KEY));
       expect(publicKey).to.deep.equal(util.hexToUint8Array(vector.PUBLIC_KEY));
       const data = vector.MESSAGE;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -109,12 +109,12 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'Catalina'
       },
-      bs_ios_15: {
+      bs_ios_14: {
         base: 'BrowserStack',
-        device: 'iPhone 13',
+        device: 'iPhone 12',
         real_mobile: true,
         os: 'ios',
-        os_version: '15'
+        os_version: '14'
       }
     },
 


### PR DESCRIPTION
This addition is backwards compatible. We offer no way to generate v4 keys in the new format, since existing implementations might not support them.

TODO
- [x] update kdf to include public key
- [x] test with messages (to decrypt and verify) from gopenpgp
- [x] ~merge after introducing support for intended recipient (no longer needed after spec's kdf change)~
- [x] enforce using AES (https://gitlab.com/openpgp-wg/rfc4880bis/-/merge_requests/276) (done in x448 PR, so it's only needed if we don't merge that on in v5)
- [x] merge lukas changes
- [x] ~change base branch (to be merged into v6)~ we merge to v5 as there are no breaking changes
