### PR TITLE
Use released version of interop test suite docker.

### DIFF
--- a/.github/workflows/sop-test-suite.yml
+++ b/.github/workflows/sop-test-suite.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run interoperability test suite
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/protonmail/openpgp-interop-test-docker:pmfork
+      image: ghcr.io/protonmail/openpgp-interop-test-docker:v1.1.1
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}


### PR DESCRIPTION
Instead of pointing to a branch of the test suite docker image, we can use the image corresponding to a specific release.