### PR TITLE
[v6] Update packet versions to the latest crypto refresh

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -317,7 +317,6 @@ interface Config {
   aeadProtect: boolean;
   allowUnauthenticatedMessages: boolean;
   allowUnauthenticatedStream: boolean;
-  checksumRequired: boolean;
   minRSABits: number;
   passwordCollisionCheck: boolean;
   revocationsExpire: boolean;

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -329,7 +329,7 @@ interface Config {
   allowInsecureVerificationWithReformattedKeys: boolean;
   constantTimePKCS1Decryption: boolean;
   constantTimePKCS1DecryptionSupportedSymmetricAlgorithms: Set<enums.symmetric>;
-  v5Keys: boolean;
+  v6Keys: boolean;
   preferredAEADAlgorithm: enums.aead;
   aeadChunkSizeByte: number;
   s2kType: enums.s2k.iterated | enums.s2k.argon2;

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -111,12 +111,16 @@ export class CleartextMessage {
    * @returns {String | ReadableStream<String>} ASCII armor.
    */
   armor(config = defaultConfig) {
-    let hashes = this.signature.packets.map(function(packet) {
-      return enums.read(enums.hash, packet.hashAlgorithm).toUpperCase();
-    });
-    hashes = hashes.filter(function(item, i, ar) { return ar.indexOf(item) === i; });
+    // emit header if one of the signatures has a version not 6
+    const emitHeader = this.signature.packets.some(packet => packet.version !== 6);
+    const hash = emitHeader ?
+      Array.from(new Set(this.signature.packets.map(
+        packet => enums.read(enums.hash, packet.hashAlgorithm).toUpperCase()
+      ))).join() :
+      null;
+
     const body = {
-      hash: hashes.join(),
+      hash,
       text: this.text,
       data: this.signature.packets.write()
     };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -68,13 +68,13 @@ export default {
    */
   aeadChunkSizeByte: 12,
   /**
-   * Use V5 keys.
+   * Use v6 keys.
    * Note: not all OpenPGP implementations are compatible with this option.
    * **FUTURE OPENPGP.JS VERSIONS MAY BREAK COMPATIBILITY WHEN USING THIS OPTION**
    * @memberof module:config
-   * @property {Boolean} v5Keys
+   * @property {Boolean} v6Keys
    */
-  v5Keys: false,
+  v6Keys: false,
   /**
    * S2K (String to Key) type, used for key derivation in the context of secret key encryption
    * and password-encrypted data. Weaker s2k options are not allowed.

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -131,11 +131,6 @@ export default {
    */
   allowUnauthenticatedStream: false,
   /**
-   * @memberof module:config
-   * @property {Boolean} checksumRequired Do not throw error when armor is missing a checksum
-   */
-  checksumRequired: false,
-  /**
    * Minimum RSA key size allowed for key generation and message signing, verification and encryption.
    * The default is 2047 since due to a bug, previous versions of OpenPGP.js could generate 2047-bit keys instead of 2048-bit ones.
    * @memberof module:config

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -58,7 +58,7 @@ export default {
    * @memberof module:config
    * @property {Integer} preferredAEADAlgorithm Default AEAD mode {@link module:enums.aead}
    */
-  preferredAEADAlgorithm: enums.aead.eax,
+  preferredAEADAlgorithm: enums.aead.gcm,
   /**
    * Chunk Size Byte for Authenticated Encryption with Additional Data (AEAD) mode
    * Only has an effect when aeadProtect is set to true.

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -121,7 +121,7 @@ export async function publicKeyDecrypt(algo, publicKeyParams, privateKeyParams, 
       const { A } = publicKeyParams;
       const { k } = privateKeyParams;
       const { ephemeralPublicKey, C } = sessionKeyParams;
-      if (!util.isAES(C.algorithm)) {
+      if (C.algorithm !== null && !util.isAES(C.algorithm)) {
         throw new Error('AES session key expected');
       }
       return publicKey.elliptic.ecdhX.decrypt(

--- a/src/crypto/hkdf.js
+++ b/src/crypto/hkdf.js
@@ -9,7 +9,7 @@ import util from '../util';
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
 
-export default async function HKDF(hashAlgo, inputKey, salt, info, outLen) {
+export default async function computeHKDF(hashAlgo, inputKey, salt, info, outLen) {
   const hash = enums.read(enums.webHash, hashAlgo);
   if (!hash) throw new Error('Hash algo not supported with HKDF');
 

--- a/src/crypto/mode/gcm.js
+++ b/src/crypto/mode/gcm.js
@@ -84,8 +84,14 @@ async function GCM(cipher, key) {
           if (webcryptoEmptyMessagesUnsupported && ct.length === tagLength) {
             return AES_GCM.decrypt(ct, key, iv, adata);
           }
-          const pt = await webCrypto.decrypt({ name: ALGO, iv, additionalData: adata, tagLength: tagLength * 8 }, _key, ct);
-          return new Uint8Array(pt);
+          try {
+            const pt = await webCrypto.decrypt({ name: ALGO, iv, additionalData: adata, tagLength: tagLength * 8 }, _key, ct);
+            return new Uint8Array(pt);
+          } catch (e) {
+            if (e.name === 'OperationError') {
+              throw new Error('Authentication tag mismatch');
+            }
+          }
         }
       };
     } catch (err) {

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -369,21 +369,18 @@ export function armor(messageType, body, partIndex, partTotal, customComment, co
     hash = body.hash;
     body = body.data;
   }
-  const bodyClone = stream.passiveClone(body);
   const result = [];
   switch (messageType) {
     case enums.armor.multipartSection:
       result.push('-----BEGIN PGP MESSAGE, PART ' + partIndex + '/' + partTotal + '-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP MESSAGE, PART ' + partIndex + '/' + partTotal + '-----\n');
       break;
     case enums.armor.multipartLast:
       result.push('-----BEGIN PGP MESSAGE, PART ' + partIndex + '-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP MESSAGE, PART ' + partIndex + '-----\n');
       break;
     case enums.armor.signed:
@@ -393,35 +390,30 @@ export function armor(messageType, body, partIndex, partTotal, customComment, co
       result.push('\n-----BEGIN PGP SIGNATURE-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP SIGNATURE-----\n');
       break;
     case enums.armor.message:
       result.push('-----BEGIN PGP MESSAGE-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP MESSAGE-----\n');
       break;
     case enums.armor.publicKey:
       result.push('-----BEGIN PGP PUBLIC KEY BLOCK-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP PUBLIC KEY BLOCK-----\n');
       break;
     case enums.armor.privateKey:
       result.push('-----BEGIN PGP PRIVATE KEY BLOCK-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP PRIVATE KEY BLOCK-----\n');
       break;
     case enums.armor.signature:
       result.push('-----BEGIN PGP SIGNATURE-----\n');
       result.push(addheader(customComment, config));
       result.push(base64.encode(body));
-      result.push('=', getCheckSum(bodyClone));
       result.push('-----END PGP SIGNATURE-----\n');
       break;
   }

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -190,12 +190,12 @@ export function unarmor(input) {
               } else {
                 verifyHeaders(lastHeaders);
                 headersDone = true;
-                if (textDone || type !== 2) {
+                if (textDone || type !== enums.armor.signed) {
                   resolve({ text, data, headers, type });
                   break;
                 }
               }
-            } else if (!textDone && type === 2) {
+            } else if (!textDone && type === enums.armor.signed) {
               if (!reSplit.test(line)) {
                 // Reverse dash-escaping for msg
                 text.push(line.replace(/^- /, ''));
@@ -289,7 +289,7 @@ export function armor(messageType, body, partIndex, partTotal, customComment, co
       break;
     case enums.armor.signed:
       result.push('-----BEGIN PGP SIGNED MESSAGE-----\n');
-      result.push('Hash: ' + hash + '\n\n');
+      result.push(hash ? `Hash: ${hash}\n\n` : '\n');
       result.push(text.replace(/^-/mg, '- -'));
       result.push('\n-----BEGIN PGP SIGNATURE-----\n');
       result.push(addheader(customComment, config));

--- a/src/enums.js
+++ b/src/enums.js
@@ -387,7 +387,8 @@ export default {
     signatureTarget: 31,
     embeddedSignature: 32,
     issuerFingerprint: 33,
-    preferredAEADAlgorithms: 34
+    preferredAEADAlgorithms: 34,
+    preferredCipherSuites: 39
   },
 
   /** Key flags

--- a/src/enums.js
+++ b/src/enums.js
@@ -371,7 +371,7 @@ export default {
     placeholderBackwardsCompatibility: 10,
     preferredSymmetricAlgorithms: 11,
     revocationKey: 12,
-    issuer: 16,
+    issuerKeyID: 16,
     notationData: 20,
     preferredHashAlgorithms: 21,
     preferredCompressionAlgorithms: 22,

--- a/src/enums.js
+++ b/src/enums.js
@@ -455,7 +455,8 @@ export default {
     aead: 2,
     /** 0x04 - Version 5 Public-Key Packet format and corresponding new
       *        fingerprint format */
-    v5Keys: 4
+    v5Keys: 4,
+    seipdv2: 8
   },
 
   /**

--- a/src/enums.js
+++ b/src/enums.js
@@ -190,6 +190,7 @@ export default {
   aead: {
     eax: 1,
     ocb: 2,
+    gcm: 3,
     experimentalGCM: 100 // Private algorithm
   },
 

--- a/src/enums.js
+++ b/src/enums.js
@@ -216,7 +216,8 @@ export default {
     userAttribute: 17,
     symEncryptedIntegrityProtectedData: 18,
     modificationDetectionCode: 19,
-    aeadEncryptedData: 20 // see IETF draft: https://tools.ietf.org/html/draft-ford-openpgp-format-00#section-2.1
+    aeadEncryptedData: 20, // see IETF draft: https://tools.ietf.org/html/draft-ford-openpgp-format-00#section-2.1
+    padding: 21
   },
 
   /** Data types in the literal packet

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -218,8 +218,6 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
       enums.hash.sha512
     ], config.preferredHashAlgorithm);
     signaturePacket.preferredCompressionAlgorithms = createPreferredAlgos([
-      enums.compression.zlib,
-      enums.compression.zip,
       enums.compression.uncompressed
     ], config.preferredCompressionAlgorithm);
     // integrity protection always enabled

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -195,10 +195,9 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
   function writeKeyProperties(signaturePacket) {
     signaturePacket.keyFlags = [enums.keyFlags.certifyKeys | enums.keyFlags.signData];
     const symmetricAlgorithms = createPreferredAlgos([
-      // prefer aes256, aes128, then aes192 (no WebCrypto support: https://www.chromium.org/blink/webcrypto#TOC-AES-support)
+      // prefer aes256, aes128, no aes192 (no Web Crypto support in Chrome: https://www.chromium.org/blink/webcrypto#TOC-AES-support)
       enums.symmetric.aes256,
-      enums.symmetric.aes128,
-      enums.symmetric.aes192
+      enums.symmetric.aes128
     ], config.preferredSymmetricAlgorithm);
     signaturePacket.preferredSymmetricAlgorithms = symmetricAlgorithms;
     if (config.aeadProtect) {

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -194,17 +194,24 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
 
   function writeKeyProperties(signaturePacket) {
     signaturePacket.keyFlags = [enums.keyFlags.certifyKeys | enums.keyFlags.signData];
-    signaturePacket.preferredSymmetricAlgorithms = createPreferredAlgos([
+    const symmetricAlgorithms = createPreferredAlgos([
       // prefer aes256, aes128, then aes192 (no WebCrypto support: https://www.chromium.org/blink/webcrypto#TOC-AES-support)
       enums.symmetric.aes256,
       enums.symmetric.aes128,
       enums.symmetric.aes192
     ], config.preferredSymmetricAlgorithm);
+    signaturePacket.preferredSymmetricAlgorithms = symmetricAlgorithms;
     if (config.aeadProtect) {
-      signaturePacket.preferredAEADAlgorithms = createPreferredAlgos([
+      const aeadAlgorithms = createPreferredAlgos([
+        enums.aead.gcm,
         enums.aead.eax,
         enums.aead.ocb
       ], config.preferredAEADAlgorithm);
+      signaturePacket.preferredCipherSuites = aeadAlgorithms.flatMap(aeadAlgorithm => {
+        return symmetricAlgorithms.map(symmetricAlgorithm => {
+          return [symmetricAlgorithm, aeadAlgorithm];
+        })
+      });
     }
     signaturePacket.preferredHashAlgorithms = createPreferredAlgos([
       // prefer fast asm.js implementations (SHA-256)

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -209,7 +209,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
       signaturePacket.preferredCipherSuites = aeadAlgorithms.flatMap(aeadAlgorithm => {
         return symmetricAlgorithms.map(symmetricAlgorithm => {
           return [symmetricAlgorithm, aeadAlgorithm];
-        })
+        });
       });
     }
     signaturePacket.preferredHashAlgorithms = createPreferredAlgos([

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -233,9 +233,6 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
     if (config.aeadProtect) {
       signaturePacket.features[0] |= enums.features.aead;
     }
-    if (config.v5Keys) {
-      signaturePacket.features[0] |= enums.features.v5Keys;
-    }
     if (options.keyExpirationTime > 0) {
       signaturePacket.keyExpirationTime = options.keyExpirationTime;
       signaturePacket.keyNeverExpires = false;

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -220,7 +220,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
     signaturePacket.features = [0];
     signaturePacket.features[0] |= enums.features.modificationDetection;
     if (config.aeadProtect) {
-      signaturePacket.features[0] |= enums.features.aead;
+      signaturePacket.features[0] |= enums.features.seipdv2;
     }
     if (options.keyExpirationTime > 0) {
       signaturePacket.keyExpirationTime = options.keyExpirationTime;

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -155,9 +155,9 @@ export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), us
  * @async
  */
 export async function getPreferredAlgo(type, keys = [], date = new Date(), userIDs = [], config = defaultConfig) {
-  const defaultAlgo = { // these are all must-implement in rfc4880bis
+  const defaultAlgo = { // these are all must-implement in the crypto refresh
     'symmetric': enums.symmetric.aes128,
-    'aead': enums.aead.eax,
+    'aead': enums.aead.ocb,
     'compression': enums.compression.uncompressed
   }[type];
   const preferredSenderAlgo = {

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -121,9 +121,9 @@ export async function getPreferredHashAlgo(key, keyPacket, date = new Date(), us
   let hashAlgo = config.preferredHashAlgorithm;
   let prefAlgo = hashAlgo;
   if (key) {
-    const primaryUser = await key.getPrimaryUser(date, userID, config);
-    if (primaryUser.selfCertification.preferredHashAlgorithms) {
-      [prefAlgo] = primaryUser.selfCertification.preferredHashAlgorithms;
+    const selfCertification = await key.getPrimarySelfSignature(date, userID, config);
+    if (selfCertification.preferredHashAlgorithms) {
+      [prefAlgo] = selfCertification.preferredHashAlgorithms;
       hashAlgo = crypto.hash.getHashByteLength(hashAlgo) <= crypto.hash.getHashByteLength(prefAlgo) ?
         prefAlgo : hashAlgo;
     }
@@ -175,8 +175,8 @@ export async function getPreferredAlgo(type, keys = [], date = new Date(), userI
   // otherwise we use the default algo
   // if no keys are available, preferredSenderAlgo is returned
   const senderAlgoSupport = await Promise.all(keys.map(async function(key, i) {
-    const primaryUser = await key.getPrimaryUser(date, userIDs[i], config);
-    const recipientPrefs = primaryUser.selfCertification[prefPropertyName];
+    const selfCertification = await key.getPrimarySelfSignature(date, userIDs[i], config);
+    const recipientPrefs = selfCertification[prefPropertyName];
     return !!recipientPrefs && recipientPrefs.indexOf(preferredSenderAlgo) >= 0;
   }));
   return senderAlgoSupport.every(Boolean) ? preferredSenderAlgo : defaultAlgo;
@@ -317,9 +317,9 @@ export async function isAEADSupported(keys, date = new Date(), userIDs = [], con
   let supported = true;
   // TODO replace when Promise.some or Promise.any are implemented
   await Promise.all(keys.map(async function(key, i) {
-    const primaryUser = await key.getPrimaryUser(date, userIDs[i], config);
-    if (!primaryUser.selfCertification.features ||
-        !(primaryUser.selfCertification.features[0] & enums.features.aead)) {
+    const selfCertification = await key.getPrimarySelfSignature(date, userIDs[i], config);
+    if (!selfCertification.features ||
+        !(selfCertification.features[0] & enums.features.aead)) {
       supported = false;
     }
   }));

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -319,7 +319,7 @@ export async function isAEADSupported(keys, date = new Date(), userIDs = [], con
   await Promise.all(keys.map(async function(key, i) {
     const selfCertification = await key.getPrimarySelfSignature(date, userIDs[i], config);
     if (!selfCertification.features ||
-        !(selfCertification.features[0] & enums.features.aead)) {
+        !(selfCertification.features[0] & enums.features.seipdv2)) {
       supported = false;
     }
   }));

--- a/src/key/index.js
+++ b/src/key/index.js
@@ -8,9 +8,9 @@ import {
 } from './factory';
 
 import {
-  getPreferredAlgo,
-  isAEADSupported,
   getPreferredHashAlgo,
+  getPreferredCompressionAlgo,
+  getPreferredCipherSuite,
   createSignaturePacket
 } from './helper';
 
@@ -25,9 +25,9 @@ export {
   readPrivateKeys,
   generate,
   reformat,
-  getPreferredAlgo,
-  isAEADSupported,
   getPreferredHashAlgo,
+  getPreferredCompressionAlgo,
+  getPreferredCipherSuite,
   createSignaturePacket,
   PrivateKey,
   PublicKey,

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -288,9 +288,9 @@ class Key {
     }
 
     try {
-      const primaryUser = await this.getPrimaryUser(date, userID, config);
+      const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
-          helper.isValidSigningKeyPacket(primaryKey, primaryUser.selfCertification, config)) {
+          helper.isValidSigningKeyPacket(primaryKey, selfCertification, config)) {
         helper.checkKeyRequirements(primaryKey, config);
         return this;
       }
@@ -334,9 +334,9 @@ class Key {
 
     try {
       // if no valid subkey for encryption, evaluate primary key
-      const primaryUser = await this.getPrimaryUser(date, userID, config);
+      const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
-          helper.isValidEncryptionKeyPacket(primaryKey, primaryUser.selfCertification)) {
+          helper.isValidEncryptionKeyPacket(primaryKey, selfCertification)) {
         helper.checkKeyRequirements(primaryKey, config);
         return this;
       }
@@ -380,18 +380,20 @@ class Key {
       throw new Error('Primary key is revoked');
     }
     // check for valid, unrevoked, unexpired self signature
-    const { selfCertification } = await this.getPrimaryUser(date, userID, config);
+    const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
     // check for expiration time in binding signatures
     if (helper.isDataExpired(primaryKey, selfCertification, date)) {
       throw new Error('Primary key is expired');
     }
-    // check for expiration time in direct signatures
-    const directSignature = await helper.getLatestValidSignature(
-      this.directSignatures, primaryKey, enums.signature.key, { key: primaryKey }, date, config
-    ).catch(() => {}); // invalid signatures are discarded, to avoid breaking the key
+    if (primaryKey.version !== 6) {
+      // check for expiration time in direct signatures (for V6 keys, the above already did so)
+      const directSignature = await helper.getLatestValidSignature(
+        this.directSignatures, primaryKey, enums.signature.key, { key: primaryKey }, date, config
+      ).catch(() => {}); // invalid signatures are discarded, to avoid breaking the key
 
-    if (directSignature && helper.isDataExpired(primaryKey, directSignature, date)) {
-      throw new Error('Primary key is expired');
+      if (directSignature && helper.isDataExpired(primaryKey, directSignature, date)) {
+        throw new Error('Primary key is expired');
+      }
     }
   }
 
@@ -406,12 +408,13 @@ class Key {
   async getExpirationTime(userID, config = defaultConfig) {
     let primaryKeyExpiry;
     try {
-      const { selfCertification } = await this.getPrimaryUser(null, userID, config);
+      const selfCertification = await this.getPrimarySelfSignature(null, userID, config);
       const selfSigKeyExpiry = helper.getKeyExpirationTime(this.keyPacket, selfCertification);
       const selfSigExpiry = selfCertification.getExpirationTime();
-      const directSignature = await helper.getLatestValidSignature(
-        this.directSignatures, this.keyPacket, enums.signature.key, { key: this.keyPacket }, null, config
-      ).catch(() => {});
+      const directSignature = this.keyPacket.version !== 6 && // For V6 keys, the above already returns the direct-key signature.
+        await helper.getLatestValidSignature(
+          this.directSignatures, this.keyPacket, enums.signature.key, { key: this.keyPacket }, null, config
+        ).catch(() => {});
       if (directSignature) {
         const directSigKeyExpiry = helper.getKeyExpirationTime(this.keyPacket, directSignature);
         // We do not support the edge case where the direct signature expires, since it would invalidate the corresponding key expiration,
@@ -427,6 +430,28 @@ class Key {
     return util.normalizeDate(primaryKeyExpiry);
   }
 
+
+  /**
+   * For V4 keys, returns the self-signature of the primary user.
+   * For V5 keys, returns the latest valid direct-key self-signature.
+   * This self-signature is to be used to check the key expiration,
+   * algorithm preferences, and so on.
+   * @param {Date} [date] - Use the given date for verification instead of the current time
+   * @param {Object} [userID] - User ID to get instead of the primary user for V4 keys, if it exists
+   * @param {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<SignaturePacket>} The primary self-signature
+   * @async
+   */
+  async getPrimarySelfSignature(date = new Date(), userID = {}, config = defaultConfig) {
+    const primaryKey = this.keyPacket;
+    if (primaryKey.version === 6) {
+      return helper.getLatestValidSignature(
+        this.directSignatures, primaryKey, enums.signature.key, { key: primaryKey }, date, config
+      );
+    }
+    const { selfCertification } = await this.getPrimaryUser(date, userID, config);
+    return selfCertification;
+  }
 
   /**
    * Returns primary user and most significant (latest valid) self signature

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -93,9 +93,9 @@ class PrivateKey extends PublicKey {
     }
 
     // evaluate primary key
-    const primaryUser = await this.getPrimaryUser(date, userID, config);
+    const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
     if ((!keyID || primaryKey.getKeyID().equals(keyID, true)) &&
-        helper.isValidDecryptionKeyPacket(primaryUser.selfCertification, config)) {
+        helper.isValidDecryptionKeyPacket(selfCertification, config)) {
       keys.push(this);
     }
 

--- a/src/message.js
+++ b/src/message.js
@@ -245,8 +245,8 @@ export class Message {
               const serialisedPKESK = pkeskPacket.write(); // make copies to be able to decrypt the PKESK packet multiple times
               await Promise.all((
                 expectedSymmetricAlgorithm ?
-                [expectedSymmetricAlgorithm] :
-                Array.from(config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms)
+                  [expectedSymmetricAlgorithm] :
+                  Array.from(config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms)
               ).map(async sessionKeyAlgorithm => {
                 const pkeskPacketCopy = new PublicKeyEncryptedSessionKeyPacket();
                 pkeskPacketCopy.read(serialisedPKESK);

--- a/src/message.js
+++ b/src/message.js
@@ -243,7 +243,11 @@ export class Message {
               // NB: as a result, if the data is encrypted with a non-suported cipher, decryption will always fail.
 
               const serialisedPKESK = pkeskPacket.write(); // make copies to be able to decrypt the PKESK packet multiple times
-              await Promise.all(Array.from(config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms).map(async sessionKeyAlgorithm => {
+              await Promise.all((
+                expectedSymmetricAlgorithm ?
+                [expectedSymmetricAlgorithm] :
+                Array.from(config.constantTimePKCS1DecryptionSupportedSymmetricAlgorithms)
+              ).map(async sessionKeyAlgorithm => {
                 const pkeskPacketCopy = new PublicKeyEncryptedSessionKeyPacket();
                 pkeskPacketCopy.read(serialisedPKESK);
                 const randomSessionKey = {

--- a/src/message.js
+++ b/src/message.js
@@ -204,9 +204,9 @@ export class Message {
             enums.symmetric.cast5 // Golang OpenPGP fallback
           ];
           try {
-            const primaryUser = await decryptionKey.getPrimaryUser(date, undefined, config); // TODO: Pass userID from somewhere.
-            if (primaryUser.selfCertification.preferredSymmetricAlgorithms) {
-              algos = algos.concat(primaryUser.selfCertification.preferredSymmetricAlgorithms);
+            const selfCertification = await decryptionKey.getPrimarySelfSignature(date, undefined, config); // TODO: Pass userID from somewhere.
+            if (selfCertification.preferredSymmetricAlgorithms) {
+              algos = algos.concat(selfCertification.preferredSymmetricAlgorithms);
             }
           } catch (e) {}
 

--- a/src/message.js
+++ b/src/message.js
@@ -397,12 +397,10 @@ export class Message {
 
     const msg = await Message.encryptSessionKey(sessionKeyData, algorithmName, aeadAlgorithmName, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, userIDs, config);
 
-    const symEncryptedPacket = new SymEncryptedIntegrityProtectedDataPacket();
-    if (aeadAlgorithmName) {
-      symEncryptedPacket.version = 2;
-      symEncryptedPacket.aeadAlgorithm = enums.write(enums.aead, aeadAlgorithmName);
-    }
-
+    const symEncryptedPacket = SymEncryptedIntegrityProtectedDataPacket.fromObject({
+      version: aeadAlgorithmName ? 2 : 1,
+      aeadAlgorithm: aeadAlgorithmName ? enums.write(enums.aead, aeadAlgorithmName) : null
+    });
     symEncryptedPacket.packets = this.packets;
 
     const algorithm = enums.write(enums.symmetric, algorithmName);

--- a/src/message.js
+++ b/src/message.js
@@ -392,13 +392,12 @@ export class Message {
 
     const msg = await Message.encryptSessionKey(sessionKeyData, algorithmName, aeadAlgorithmName, encryptionKeys, passwords, wildcard, encryptionKeyIDs, date, userIDs, config);
 
-    let symEncryptedPacket;
+    const symEncryptedPacket = new SymEncryptedIntegrityProtectedDataPacket();
     if (aeadAlgorithmName) {
-      symEncryptedPacket = new AEADEncryptedDataPacket();
+      symEncryptedPacket.version = 2;
       symEncryptedPacket.aeadAlgorithm = enums.write(enums.aead, aeadAlgorithmName);
-    } else {
-      symEncryptedPacket = new SymEncryptedIntegrityProtectedDataPacket();
     }
+
     symEncryptedPacket.packets = this.packets;
 
     const algorithm = enums.write(enums.symmetric, algorithmName);

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -58,8 +58,8 @@ export async function generateKey({ userIDs = [], passphrase, type = 'ecc', rsaB
   userIDs = toArray(userIDs);
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
-  if (userIDs.length === 0) {
-    throw new Error('UserIDs are required for key generation');
+  if (userIDs.length === 0 && !config.v6Keys) {
+    throw new Error('UserIDs are required for V4 keys');
   }
   if (type === 'rsa' && rsaBits < config.minRSABits) {
     throw new Error(`rsaBits should be at least ${config.minRSABits}, got: ${rsaBits}`);
@@ -102,8 +102,8 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase, keyExp
   userIDs = toArray(userIDs);
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
-  if (userIDs.length === 0) {
-    throw new Error('UserIDs are required for key reformat');
+  if (userIDs.length === 0 && privateKey.keyPacket.version !== 6) {
+    throw new Error('UserIDs are required for V4 keys');
   }
   const options = { privateKey, userIDs, passphrase, keyExpirationTime, date };
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -591,7 +591,7 @@ export async function decryptSessionKeys({ message, decryptionKeys, passwords, d
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
   try {
-    const sessionKeys = await message.decryptSessionKeys(decryptionKeys, passwords, date, config);
+    const sessionKeys = await message.decryptSessionKeys(decryptionKeys, passwords, undefined, date, config);
     return sessionKeys;
   } catch (err) {
     throw util.wrapError('Error decrypting session keys', err);

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -18,7 +18,7 @@
 import * as stream from '@openpgp/web-stream-tools';
 import { Message } from './message';
 import { CleartextMessage } from './cleartext';
-import { generate, reformat, getPreferredAlgo } from './key';
+import { generate, reformat, getPreferredCompressionAlgo } from './key';
 import defaultConfig from './config';
 import util from './util';
 import { checkKeyRequirements } from './key/helper';
@@ -284,7 +284,7 @@ export async function encrypt({ message, encryptionKeys, signingKeys, passwords,
       message = await message.sign(signingKeys, signature, signingKeyIDs, date, signingUserIDs, signatureNotations, config);
     }
     message = message.compress(
-      await getPreferredAlgo('compression', encryptionKeys, date, encryptionUserIDs, config),
+      await getPreferredCompressionAlgo(encryptionKeys, date, encryptionUserIDs, config),
       config
     );
     message = await message.encrypt(encryptionKeys, passwords, sessionKey, wildcard, encryptionKeyIDs, date, encryptionUserIDs, config);

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -21,6 +21,7 @@ import enums from '../enums';
 import util from '../util';
 import defaultConfig from '../config';
 import { UnsupportedError } from './packet';
+import { runAEAD } from './sym_encrypted_integrity_protected_data';
 
 import LiteralDataPacket from './literal_data';
 import CompressedDataPacket from './compressed_data';
@@ -101,7 +102,7 @@ class AEADEncryptedDataPacket {
    */
   async decrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
     this.packets = await PacketList.fromBinary(
-      await this.crypt('decrypt', key, stream.clone(this.encrypted)),
+      await runAEAD(this, 'decrypt', key, stream.clone(this.encrypted)),
       allowedPackets,
       config
     );
@@ -122,86 +123,7 @@ class AEADEncryptedDataPacket {
     this.iv = crypto.random.getRandomBytes(ivLength); // generate new random IV
     this.chunkSizeByte = config.aeadChunkSizeByte;
     const data = this.packets.write();
-    this.encrypted = await this.crypt('encrypt', key, data);
-  }
-
-  /**
-   * En/decrypt the payload.
-   * @param {encrypt|decrypt} fn - Whether to encrypt or decrypt
-   * @param {Uint8Array} key - The session key used to en/decrypt the payload
-   * @param {Uint8Array | ReadableStream<Uint8Array>} data - The data to en/decrypt
-   * @returns {Promise<Uint8Array | ReadableStream<Uint8Array>>}
-   * @async
-   */
-  async crypt(fn, key, data) {
-    const mode = crypto.getAEADMode(this.aeadAlgorithm);
-    const modeInstance = await mode(this.cipherAlgorithm, key);
-    const tagLengthIfDecrypting = fn === 'decrypt' ? mode.tagLength : 0;
-    const tagLengthIfEncrypting = fn === 'encrypt' ? mode.tagLength : 0;
-    const chunkSize = 2 ** (this.chunkSizeByte + 6) + tagLengthIfDecrypting; // ((uint64_t)1 << (c + 6))
-    const adataBuffer = new ArrayBuffer(21);
-    const adataArray = new Uint8Array(adataBuffer, 0, 13);
-    const adataTagArray = new Uint8Array(adataBuffer);
-    const adataView = new DataView(adataBuffer);
-    const chunkIndexArray = new Uint8Array(adataBuffer, 5, 8);
-    adataArray.set([0xC0 | AEADEncryptedDataPacket.tag, this.version, this.cipherAlgorithm, this.aeadAlgorithm, this.chunkSizeByte], 0);
-    let chunkIndex = 0;
-    let latestPromise = Promise.resolve();
-    let cryptedBytes = 0;
-    let queuedBytes = 0;
-    const iv = this.iv;
-    return stream.transformPair(data, async (readable, writable) => {
-      if (util.isStream(readable) !== 'array') {
-        const buffer = new TransformStream({}, {
-          highWaterMark: util.getHardwareConcurrency() * 2 ** (this.chunkSizeByte + 6),
-          size: array => array.length
-        });
-        stream.pipe(buffer.readable, writable);
-        writable = buffer.writable;
-      }
-      const reader = stream.getReader(readable);
-      const writer = stream.getWriter(writable);
-      try {
-        while (true) {
-          let chunk = await reader.readBytes(chunkSize + tagLengthIfDecrypting) || new Uint8Array();
-          const finalChunk = chunk.subarray(chunk.length - tagLengthIfDecrypting);
-          chunk = chunk.subarray(0, chunk.length - tagLengthIfDecrypting);
-          let cryptedPromise;
-          let done;
-          if (!chunkIndex || chunk.length) {
-            reader.unshift(finalChunk);
-            cryptedPromise = modeInstance[fn](chunk, mode.getNonce(iv, chunkIndexArray), adataArray);
-            queuedBytes += chunk.length - tagLengthIfDecrypting + tagLengthIfEncrypting;
-          } else {
-            // After the last chunk, we either encrypt a final, empty
-            // data chunk to get the final authentication tag or
-            // validate that final authentication tag.
-            adataView.setInt32(13 + 4, cryptedBytes); // Should be setInt64(13, ...)
-            cryptedPromise = modeInstance[fn](finalChunk, mode.getNonce(iv, chunkIndexArray), adataTagArray);
-            queuedBytes += tagLengthIfEncrypting;
-            done = true;
-          }
-          cryptedBytes += chunk.length - tagLengthIfDecrypting;
-          // eslint-disable-next-line no-loop-func
-          latestPromise = latestPromise.then(() => cryptedPromise).then(async crypted => {
-            await writer.ready;
-            await writer.write(crypted);
-            queuedBytes -= crypted.length;
-          }).catch(err => writer.abort(err));
-          if (done || queuedBytes > writer.desiredSize) {
-            await latestPromise; // Respect backpressure
-          }
-          if (!done) {
-            adataView.setInt32(5 + 4, ++chunkIndex); // Should be setInt64(5, ...)
-          } else {
-            await writer.close();
-            break;
-          }
-        }
-      } catch (e) {
-        await writer.abort(e);
-      }
-    });
+    this.encrypted = await runAEAD(this, 'encrypt', key, data);
   }
 }
 

--- a/src/packet/all_packets.js
+++ b/src/packet/all_packets.js
@@ -21,3 +21,4 @@ export { default as UserIDPacket } from './userid';
 export { default as SecretSubkeyPacket } from './secret_subkey';
 export { default as SignaturePacket } from './signature';
 export { default as TrustPacket } from './trust';
+export { default as PaddingPacket } from './padding';

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -308,6 +308,19 @@ export class UnsupportedError extends Error {
   }
 }
 
+// unknown packet types are handled differently depending on the packet criticality
+export class UnknownPacketError extends UnsupportedError {
+  constructor(...params) {
+    super(...params);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnsupportedError);
+    }
+
+    this.name = 'UnknownPacketError';
+  }
+}
+
 export class UnparseablePacket {
   constructor(tag, rawContent) {
     this.tag = tag;

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -74,10 +74,11 @@ class PacketList extends Array {
           await writer.ready;
           const done = await readPackets(readable, async parsed => {
             try {
-              if (parsed.tag === enums.packet.marker || parsed.tag === enums.packet.trust) {
+              if (parsed.tag === enums.packet.marker || parsed.tag === enums.packet.trust || parsed.tag === enums.packet.padding) {
                 // According to the spec, these packet types should be ignored and not cause parsing errors, even if not esplicitly allowed:
                 // - Marker packets MUST be ignored when received: https://github.com/openpgpjs/openpgpjs/issues/1145
                 // - Trust packets SHOULD be ignored outside of keyrings (unsupported): https://datatracker.ietf.org/doc/html/rfc4880#section-5.10
+                // - [Padding Packets] MUST be ignored when received: https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh#name-padding-packet-tag-21
                 return;
               }
               const packet = newPacketFromTag(parsed.tag, allowedPackets);

--- a/src/packet/padding.js
+++ b/src/packet/padding.js
@@ -37,7 +37,7 @@ class PaddingPacket {
    * Read a padding packet
    * @param {Uint8Array | ReadableStream<Uint8Array>} bytes
    */
-  read(bytes) {
+  read(bytes) { // eslint-disable-line no-unused-vars
     // Padding packets are ignored, so this function is never called.
   }
 

--- a/src/packet/padding.js
+++ b/src/packet/padding.js
@@ -1,0 +1,63 @@
+// OpenPGP.js - An OpenPGP implementation in javascript
+// Copyright (C) 2022 Proton AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+import crypto from '../crypto';
+import enums from '../enums';
+
+/**
+ * Implementation of the Padding Packet
+ *
+ * {@link https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh#name-padding-packet-tag-21}:
+ * Padding Packet
+ */
+class PaddingPacket {
+  static get tag() {
+    return enums.packet.padding;
+  }
+
+  constructor() {
+    this.padding = null;
+  }
+
+  /**
+   * Read a padding packet
+   * @param {Uint8Array | ReadableStream<Uint8Array>} bytes
+   */
+  read(bytes) {
+    // Padding packets are ignored, so this function is never called.
+  }
+
+  /**
+   * Write the padding packet
+   * @returns {Uint8Array} The padding packet.
+   */
+  write() {
+    return this.padding;
+  }
+
+  /**
+   * Create random padding.
+   * @param {Number} length - The length of padding to be generated.
+   * @throws {Error} if padding generation was not successful
+   * @async
+   */
+  async createPadding(length) {
+    this.padding = await crypto.random.getRandomBytes(length);
+  }
+}
+
+export default PaddingPacket;

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -47,7 +47,7 @@ class PublicKeyPacket {
      * Packet version
      * @type {Integer}
      */
-    this.version = config.v5Keys ? 5 : 4;
+    this.version = config.v6Keys ? 6 : 4;
     /**
      * Key creation date.
      * @type {Date}

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -21,8 +21,6 @@ import enums from '../enums';
 import util from '../util';
 import { UnsupportedError } from './packet';
 
-const VERSION = 3;
-
 /**
  * Public-Key Encrypted Session Key Packets (Tag 1)
  *
@@ -45,9 +43,16 @@ class PublicKeyEncryptedSessionKeyPacket {
   }
 
   constructor() {
-    this.version = 3;
+    this.version = null;
 
+    // For version 3:
     this.publicKeyID = new KeyID();
+
+    // For version 6:
+    this.publicKeyVersion = null;
+    this.publicKeyFingerprint = null;
+
+    // For all versions:
     this.publicKeyAlgorithm = null;
 
     this.sessionKey = null;
@@ -67,15 +72,39 @@ class PublicKeyEncryptedSessionKeyPacket {
    * @param {Uint8Array} bytes - Payload of a tag 1 packet
    */
   read(bytes) {
-    let i = 0;
-    this.version = bytes[i++];
-    if (this.version !== VERSION) {
+    let offset = 0;
+    this.version = bytes[offset++];
+    if (this.version !== 3 && this.version !== 6) {
       throw new UnsupportedError(`Version ${this.version} of the PKESK packet is unsupported.`);
     }
-    i += this.publicKeyID.read(bytes.subarray(i));
-    this.publicKeyAlgorithm = bytes[i++];
-    this.encrypted = crypto.parseEncSessionKeyParams(this.publicKeyAlgorithm, bytes.subarray(i), this.version);
-    if (this.publicKeyAlgorithm === enums.publicKey.x25519) {
+    if (this.version === 6) {
+      // A one-octet size of the following two fields:
+      // - A one octet key version number.
+      // - The fingerprint of the public key or subkey to which the session key is encrypted.
+      // The size may also be zero.
+      const versionAndFingerprintLength = bytes[offset++];
+      if (versionAndFingerprintLength) {
+        this.publicKeyVersion = bytes[offset++];
+        const fingerprintLength = versionAndFingerprintLength - 1;
+        this.publicKeyFingerprint = bytes.subarray(offset, offset + fingerprintLength); offset += fingerprintLength;
+        if (this.publicKeyVersion >= 5) {
+          // For v5/6 the Key ID is the high-order 64 bits of the fingerprint.
+          this.publicKeyID.read(this.publicKeyFingerprint);
+        } else {
+          // For v4 The Key ID is the low-order 64 bits of the fingerprint.
+          this.publicKeyID.read(this.publicKeyFingerprint.subarray(-8));
+        }
+      } else {
+        // The size may also be zero, and the key version and
+        // fingerprint omitted for an "anonymous recipient"
+        this.publicKeyID = KeyID.wildcard();
+      }
+    } else {
+      offset += this.publicKeyID.read(bytes.subarray(offset, offset + 8));
+    }
+    this.publicKeyAlgorithm = bytes[offset++];
+    this.encrypted = crypto.parseEncSessionKeyParams(this.publicKeyAlgorithm, bytes.subarray(offset));
+    if (this.version === 3 && this.publicKeyAlgorithm === enums.publicKey.x25519) {
       this.sessionKeyAlgorithm = enums.write(enums.symmetric, this.encrypted.C.algorithm);
     }
   }
@@ -87,11 +116,27 @@ class PublicKeyEncryptedSessionKeyPacket {
    */
   write() {
     const arr = [
-      new Uint8Array([this.version]),
-      this.publicKeyID.write(),
+      new Uint8Array([this.version])
+    ];
+
+    if (this.version === 6) {
+      if (this.publicKeyFingerprint !== null) {
+        arr.push(new Uint8Array([
+          this.publicKeyFingerprint.length + 1,
+          this.publicKeyVersion]
+        ));
+        arr.push(this.publicKeyFingerprint);
+      } else {
+        arr.push(new Uint8Array([0]));
+      }
+    } else {
+      arr.push(this.publicKeyID.write());
+    }
+
+    arr.push(
       new Uint8Array([this.publicKeyAlgorithm]),
       crypto.serializeParams(this.publicKeyAlgorithm, this.encrypted)
-    ];
+    );
 
     return util.concatUint8Array(arr);
   }
@@ -131,7 +176,7 @@ class PublicKeyEncryptedSessionKeyPacket {
     const { sessionKey, sessionKeyAlgorithm } = decodeSessionKey(this.version, this.publicKeyAlgorithm, decryptedData, randomSessionKey);
 
     // v3 Montgomery curves have cleartext cipher algo
-    if (this.publicKeyAlgorithm !== enums.publicKey.x25519) {
+    if (this.version === 3 && this.publicKeyAlgorithm !== enums.publicKey.x25519) {
       this.sessionKeyAlgorithm = sessionKeyAlgorithm;
     }
     this.sessionKey = sessionKey;
@@ -149,7 +194,7 @@ function encodeSessionKey(version, keyAlgo, cipherAlgo, sessionKeyData) {
     case enums.publicKey.ecdh: {
       // add checksum
       return util.concatUint8Array([
-        new Uint8Array([cipherAlgo]),
+        new Uint8Array(version === 6 ? [] : [cipherAlgo]),
         sessionKeyData,
         util.writeChecksum(sessionKeyData.subarray(sessionKeyData.length % 8))
       ]);
@@ -173,7 +218,9 @@ function decodeSessionKey(version, keyAlgo, decryptedData, randomSessionKey) {
       const checksum = decryptedData.subarray(decryptedData.length - 2);
       const computedChecksum = util.writeChecksum(result.subarray(result.length % 8));
       const isValidChecksum = computedChecksum[0] === checksum[0] & computedChecksum[1] === checksum[1];
-      const decryptedSessionKey = { sessionKeyAlgorithm: result[0], sessionKey: result.subarray(1) };
+      const decryptedSessionKey = version === 6 ?
+        { sessionKeyAlgorithm: null, sessionKey: result } :
+        { sessionKeyAlgorithm: result[0], sessionKey: result.subarray(1) };
       if (randomSessionKey) {
         // We must not leak info about the validity of the decrypted checksum or cipher algo.
         // The decrypted session key must be of the same algo and size as the random session key, otherwise we discard it and use the random data.
@@ -182,14 +229,15 @@ function decodeSessionKey(version, keyAlgo, decryptedData, randomSessionKey) {
           decryptedSessionKey.sessionKey.length === randomSessionKey.sessionKey.length;
         return {
           sessionKey: util.selectUint8Array(isValidPayload, decryptedSessionKey.sessionKey, randomSessionKey.sessionKey),
-          sessionKeyAlgorithm: util.selectUint8(
+          sessionKeyAlgorithm: version === 6 ? null : util.selectUint8(
             isValidPayload,
             decryptedSessionKey.sessionKeyAlgorithm,
             randomSessionKey.sessionKeyAlgorithm
           )
         };
       } else {
-        const isValidPayload = isValidChecksum && enums.read(enums.symmetric, decryptedSessionKey.sessionKeyAlgorithm);
+        const isValidPayload = isValidChecksum && (
+          version === 6 || enums.read(enums.symmetric, decryptedSessionKey.sessionKeyAlgorithm));
         if (isValidPayload) {
           return decryptedSessionKey;
         } else {

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -30,7 +30,7 @@ const verified = Symbol('verified');
 // Tampering with those invalidates the signature, so we still trust them and parse them.
 // All other unhashed subpackets are ignored.
 const allowedUnhashedSubpackets = new Set([
-  enums.signatureSubpacket.issuer,
+  enums.signatureSubpacket.issuerKeyID,
   enums.signatureSubpacket.issuerFingerprint,
   enums.signatureSubpacket.embeddedSignature
 ]);
@@ -278,7 +278,7 @@ class SignaturePacket {
     if (!this.issuerKeyID.isNull() && this.issuerKeyVersion < 5) {
       // If the version of [the] key is greater than 4, this subpacket
       // MUST NOT be included in the signature.
-      arr.push(writeSubPacket(sub.issuer, true, this.issuerKeyID.write()));
+      arr.push(writeSubPacket(sub.issuerKeyID, true, this.issuerKeyID.write()));
     }
     this.rawNotations.forEach(({ name, value, humanReadable, critical }) => {
       bytes = [new Uint8Array([humanReadable ? 0x80 : 0, 0, 0, 0])];
@@ -442,7 +442,7 @@ class SignaturePacket {
         this.revocationKeyFingerprint = bytes.subarray(mypos, mypos + 20);
         break;
 
-      case enums.signatureSubpacket.issuer:
+      case enums.signatureSubpacket.issuerKeyID:
         // Issuer
         if (this.version === 4) {
           this.issuerKeyID.read(bytes.subarray(mypos, bytes.length));

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -97,6 +97,7 @@ class SignaturePacket {
     this.issuerKeyVersion = null;
     this.issuerFingerprint = null;
     this.preferredAEADAlgorithms = null;
+    this.preferredCipherSuites = null;
 
     this.revoked = null;
     this[verified] = null;
@@ -346,6 +347,10 @@ class SignaturePacket {
       bytes = util.stringToUint8Array(util.uint8ArrayToString(this.preferredAEADAlgorithms));
       arr.push(writeSubPacket(sub.preferredAEADAlgorithms, false, bytes));
     }
+    if (this.preferredCipherSuites !== null) {
+      bytes = new Uint8Array([].concat(...this.preferredCipherSuites));
+      arr.push(writeSubPacket(sub.preferredCipherSuites, false, bytes));
+    }
 
     const result = util.concat(arr);
     const length = util.writeNumber(result.length, this.version === 6 ? 4 : 2);
@@ -550,6 +555,13 @@ class SignaturePacket {
       case enums.signatureSubpacket.preferredAEADAlgorithms:
         // Preferred AEAD Algorithms
         this.preferredAEADAlgorithms = [...bytes.subarray(mypos, bytes.length)];
+        break;
+      case enums.signatureSubpacket.preferredCipherSuites:
+        // Preferred AEAD Cipher Suites
+        this.preferredCipherSuites = [];
+        for (let i = mypos; i < bytes.length; i += 2) {
+          this.preferredCipherSuites.push([bytes[i], bytes[i + 1]]);
+        }
         break;
       default: {
         const err = new Error(`Unknown signature subpacket type ${type}`);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -214,7 +214,11 @@ class SignaturePacket {
 
     if (this.version === 6) {
       const saltLength = saltLengthForHash(this.hashAlgorithm);
-      this.salt = await crypto.random.getRandomBytes(saltLength);
+      if (this.salt === null) {
+        this.salt = crypto.random.getRandomBytes(saltLength);
+      } else if (saltLength !== this.salt.length) {
+        throw new Error('Provided salt does not have the required length');
+      }
     }
     const toHash = this.toHash(this.signatureType, data, detached);
     const hash = await this.hash(this.signatureType, data, toHash, detached);
@@ -823,7 +827,7 @@ function writeSubPacket(type, critical, data) {
  * @returns {Integer} Salt length.
  * @private
  */
-function saltLengthForHash(hashAlgorithm) {
+export function saltLengthForHash(hashAlgorithm) {
   switch (hashAlgorithm) {
     case enums.hash.sha256: return 16;
     case enums.hash.sha384: return 24;

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -72,7 +72,7 @@ class SymEncryptedIntegrityProtectedDataPacket {
       this.version = await reader.readByte();
       // - A one-octet version number with value 1 or 2.
       if (this.version !== 1 && this.version !== 2) {
-        throw new UnsupportedError(`Version ${version} of the SEIP packet is unsupported.`);
+        throw new UnsupportedError(`Version ${this.version} of the SEIP packet is unsupported.`);
       }
 
       if (this.version === 2) {

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -52,8 +52,22 @@ class SymEncryptedIntegrityProtectedDataPacket {
     return enums.packet.symEncryptedIntegrityProtectedData;
   }
 
+  static fromObject({ version, aeadAlgorithm }) {
+    if (version !== 1 && version !== 2) {
+      throw new Error('Unsupported SEIPD version');
+    }
+
+    const seip = new SymEncryptedIntegrityProtectedDataPacket();
+    seip.version = version;
+    if (version === 2) {
+      seip.aeadAlgorithm = aeadAlgorithm;
+    }
+
+    return seip;
+  }
+
   constructor() {
-    this.version = 1;
+    this.version = null;
 
     // The following 4 fields are for V2 only.
     /** @type {enums.symmetric} */

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -17,6 +17,7 @@
 
 import * as stream from '@openpgp/web-stream-tools';
 import crypto from '../crypto';
+import computeHKDF from '../crypto/hkdf';
 import enums from '../enums';
 import util from '../util';
 import defaultConfig from '../config';
@@ -36,8 +37,6 @@ const allowedPackets = /*#__PURE__*/ util.constructAllowedPackets([
   SignaturePacket
 ]);
 
-const VERSION = 1; // A one-octet version number of the data packet.
-
 /**
  * Implementation of the Sym. Encrypted Integrity Protected Data Packet (Tag 18)
  *
@@ -54,28 +53,55 @@ class SymEncryptedIntegrityProtectedDataPacket {
   }
 
   constructor() {
-    this.version = VERSION;
+    this.version = 1;
+
+    // The following 4 fields are for V2 only.
+    /** @type {enums.symmetric} */
+    this.cipherAlgorithm = null;
+    /** @type {enums.aead} */
+    this.aeadAlgorithm = null;
+    this.chunkSizeByte = null;
+    this.salt = null;
+
     this.encrypted = null;
     this.packets = null;
   }
 
   async read(bytes) {
     await stream.parse(bytes, async reader => {
-      const version = await reader.readByte();
-      // - A one-octet version number. The only currently defined value is 1.
-      if (version !== VERSION) {
+      this.version = await reader.readByte();
+      // - A one-octet version number with value 1 or 2.
+      if (this.version !== 1 && this.version !== 2) {
         throw new UnsupportedError(`Version ${version} of the SEIP packet is unsupported.`);
       }
 
+      if (this.version === 2) {
+        // - A one-octet cipher algorithm.
+        this.cipherAlgorithm = await reader.readByte();
+        // - A one-octet AEAD algorithm.
+        this.aeadAlgorithm = await reader.readByte();
+        // - A one-octet chunk size.
+        this.chunkSizeByte = await reader.readByte();
+        // - Thirty-two octets of salt. The salt is used to derive the message key and must be unique.
+        this.salt = await reader.readBytes(32);
+      }
+
+      // For V1:
       // - Encrypted data, the output of the selected symmetric-key cipher
       //   operating in Cipher Feedback mode with shift amount equal to the
       //   block size of the cipher (CFB-n where n is the block size).
+      // For V2:
+      // - Encrypted data, the output of the selected symmetric-key cipher operating in the given AEAD mode.
+      // - A final, summary authentication tag for the AEAD mode.
       this.encrypted = reader.remainder();
     });
   }
 
   write() {
-    return util.concat([new Uint8Array([VERSION]), this.encrypted]);
+    if (this.version === 2) {
+      return util.concat([new Uint8Array([this.version, this.cipherAlgorithm, this.aeadAlgorithm, this.chunkSizeByte]), this.salt, this.encrypted]);
+    }
+    return util.concat([new Uint8Array([this.version]), this.encrypted]);
   }
 
   /**
@@ -88,18 +114,27 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @async
    */
   async encrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
-    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
-
     let bytes = this.packets.write();
     if (stream.isArrayStream(bytes)) bytes = await stream.readToEnd(bytes);
-    const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
-    const mdc = new Uint8Array([0xD3, 0x14]); // modification detection code packet
 
-    const tohash = util.concat([prefix, bytes, mdc]);
-    const hash = await crypto.hash.sha1(stream.passiveClone(tohash));
-    const plaintext = util.concat([tohash, hash]);
+    if (this.version === 2) {
+      this.cipherAlgorithm = sessionKeyAlgorithm;
 
-    this.encrypted = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(blockSize), config);
+      this.salt = crypto.random.getRandomBytes(32);
+      this.chunkSizeByte = config.aeadChunkSizeByte;
+      this.encrypted = await runAEAD(this, 'encrypt', key, bytes);
+    } else {
+      const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
+
+      const prefix = await crypto.getPrefixRandom(sessionKeyAlgorithm);
+      const mdc = new Uint8Array([0xD3, 0x14]); // modification detection code packet
+
+      const tohash = util.concat([prefix, bytes, mdc]);
+      const hash = await crypto.hash.sha1(stream.passiveClone(tohash));
+      const plaintext = util.concat([tohash, hash]);
+
+      this.encrypted = await crypto.mode.cfb.encrypt(sessionKeyAlgorithm, key, plaintext, new Uint8Array(blockSize), config);
+    }
     return true;
   }
 
@@ -113,33 +148,152 @@ class SymEncryptedIntegrityProtectedDataPacket {
    * @async
    */
   async decrypt(sessionKeyAlgorithm, key, config = defaultConfig) {
-    const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
     let encrypted = stream.clone(this.encrypted);
     if (stream.isArrayStream(encrypted)) encrypted = await stream.readToEnd(encrypted);
-    const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(blockSize));
 
-    // there must be a modification detection code packet as the
-    // last packet and everything gets hashed except the hash itself
-    const realHash = stream.slice(stream.passiveClone(decrypted), -20);
-    const tohash = stream.slice(decrypted, 0, -20);
-    const verifyHash = Promise.all([
-      stream.readToEnd(await crypto.hash.sha1(stream.passiveClone(tohash))),
-      stream.readToEnd(realHash)
-    ]).then(([hash, mdc]) => {
-      if (!util.equalsUint8Array(hash, mdc)) {
-        throw new Error('Modification detected.');
+    let packetbytes;
+    if (this.version === 2) {
+      packetbytes = await runAEAD(this, 'decrypt', key, encrypted);
+    } else {
+      const { blockSize } = crypto.getCipher(sessionKeyAlgorithm);
+      const decrypted = await crypto.mode.cfb.decrypt(sessionKeyAlgorithm, key, encrypted, new Uint8Array(blockSize));
+
+      // there must be a modification detection code packet as the
+      // last packet and everything gets hashed except the hash itself
+      const realHash = stream.slice(stream.passiveClone(decrypted), -20);
+      const tohash = stream.slice(decrypted, 0, -20);
+      const verifyHash = Promise.all([
+        stream.readToEnd(await crypto.hash.sha1(stream.passiveClone(tohash))),
+        stream.readToEnd(realHash)
+      ]).then(([hash, mdc]) => {
+        if (!util.equalsUint8Array(hash, mdc)) {
+          throw new Error('Modification detected.');
+        }
+        return new Uint8Array();
+      });
+      const bytes = stream.slice(tohash, blockSize + 2); // Remove random prefix
+      packetbytes = stream.slice(bytes, 0, -2); // Remove MDC packet
+      packetbytes = stream.concat([packetbytes, stream.fromAsync(() => verifyHash)]);
+      if (!util.isStream(encrypted) || !config.allowUnauthenticatedStream) {
+        packetbytes = await stream.readToEnd(packetbytes);
       }
-      return new Uint8Array();
-    });
-    const bytes = stream.slice(tohash, blockSize + 2); // Remove random prefix
-    let packetbytes = stream.slice(bytes, 0, -2); // Remove MDC packet
-    packetbytes = stream.concat([packetbytes, stream.fromAsync(() => verifyHash)]);
-    if (!util.isStream(encrypted) || !config.allowUnauthenticatedStream) {
-      packetbytes = await stream.readToEnd(packetbytes);
     }
+
     this.packets = await PacketList.fromBinary(packetbytes, allowedPackets, config);
     return true;
   }
 }
 
 export default SymEncryptedIntegrityProtectedDataPacket;
+
+/**
+ * En/decrypt the payload.
+ * @param {encrypt|decrypt} fn - Whether to encrypt or decrypt
+ * @param {Uint8Array} key - The session key used to en/decrypt the payload
+ * @param {Uint8Array | ReadableStream<Uint8Array>} data - The data to en/decrypt
+ * @returns {Promise<Uint8Array | ReadableStream<Uint8Array>>}
+ * @async
+ */
+export async function runAEAD(packet, fn, key, data) {
+  const isSEIPDv2 = packet instanceof SymEncryptedIntegrityProtectedDataPacket && packet.version === 2;
+  const isAEADP = !isSEIPDv2 && packet.constructor.tag === enums.packet.aeadEncryptedData; // no `instanceof` to avoid importing the corresponding class (circular import)
+  if (!isSEIPDv2 && !isAEADP) throw new Error('Unexpected packet type');
+
+  const mode = crypto.getAEADMode(packet.aeadAlgorithm);
+  const tagLengthIfDecrypting = fn === 'decrypt' ? mode.tagLength : 0;
+  const tagLengthIfEncrypting = fn === 'encrypt' ? mode.tagLength : 0;
+  const chunkSize = 2 ** (packet.chunkSizeByte + 6) + tagLengthIfDecrypting; // ((uint64_t)1 << (c + 6))
+  const chunkIndexSizeIfAEADEP = isAEADP ? 8 : 0;
+  const adataBuffer = new ArrayBuffer(13 + chunkIndexSizeIfAEADEP);
+  const adataArray = new Uint8Array(adataBuffer, 0, 5 + chunkIndexSizeIfAEADEP);
+  const adataTagArray = new Uint8Array(adataBuffer);
+  const adataView = new DataView(adataBuffer);
+  const chunkIndexArray = new Uint8Array(adataBuffer, 5, 8);
+  adataArray.set([0xC0 | packet.constructor.tag, packet.version, packet.cipherAlgorithm, packet.aeadAlgorithm, packet.chunkSizeByte], 0);
+  let chunkIndex = 0;
+  let latestPromise = Promise.resolve();
+  let cryptedBytes = 0;
+  let queuedBytes = 0;
+  let iv;
+  let ivView;
+  if (isSEIPDv2) {
+    const { keySize } = crypto.getCipher(packet.cipherAlgorithm);
+    const { ivLength } = mode;
+    const info = new Uint8Array(adataBuffer, 0, 5);
+    const derived = await computeHKDF(enums.hash.sha256, key, packet.salt, info, keySize + ivLength);
+    key = derived.subarray(0, keySize);
+    iv = derived.subarray(keySize); // The last 8 bytes of HKDF output are unneeded, but this avoids one copy.
+    iv.fill(0, iv.length - 8);
+    ivView = new DataView(iv.buffer, iv.byteOffset, iv.byteLength);
+  } else { // AEADEncryptedDataPacket
+    iv = packet.iv;
+    // ivView is unused in this case
+  }
+  const modeInstance = await mode(packet.cipherAlgorithm, key);
+  return stream.transformPair(data, async (readable, writable) => {
+    if (util.isStream(readable) !== 'array') {
+      const buffer = new TransformStream({}, {
+        highWaterMark: util.getHardwareConcurrency() * 2 ** (packet.chunkSizeByte + 6),
+        size: array => array.length
+      });
+      stream.pipe(buffer.readable, writable);
+      writable = buffer.writable;
+    }
+    const reader = stream.getReader(readable);
+    const writer = stream.getWriter(writable);
+    try {
+      while (true) {
+        let chunk = await reader.readBytes(chunkSize + tagLengthIfDecrypting) || new Uint8Array();
+        const finalChunk = chunk.subarray(chunk.length - tagLengthIfDecrypting);
+        chunk = chunk.subarray(0, chunk.length - tagLengthIfDecrypting);
+        let cryptedPromise;
+        let done;
+        let nonce;
+        if (isSEIPDv2) { // SEIPD V2
+          nonce = iv;
+        } else { // AEADEncryptedDataPacket
+          nonce = iv.slice();
+          for (let i = 0; i < 8; i++) {
+            nonce[iv.length - 8 + i] ^= chunkIndexArray[i];
+          }
+        }
+        if (!chunkIndex || chunk.length) {
+          reader.unshift(finalChunk);
+          cryptedPromise = modeInstance[fn](chunk, nonce, adataArray);
+          queuedBytes += chunk.length - tagLengthIfDecrypting + tagLengthIfEncrypting;
+        } else {
+          // After the last chunk, we either encrypt a final, empty
+          // data chunk to get the final authentication tag or
+          // validate that final authentication tag.
+          adataView.setInt32(5 + chunkIndexSizeIfAEADEP + 4, cryptedBytes); // Should be setInt64(5 + chunkIndexSizeIfAEADEP, ...)
+          cryptedPromise = modeInstance[fn](finalChunk, nonce, adataTagArray);
+          queuedBytes += tagLengthIfEncrypting;
+          done = true;
+        }
+        cryptedBytes += chunk.length - tagLengthIfDecrypting;
+        // eslint-disable-next-line no-loop-func
+        latestPromise = latestPromise.then(() => cryptedPromise).then(async crypted => {
+          await writer.ready;
+          await writer.write(crypted);
+          queuedBytes -= crypted.length;
+        }).catch(err => writer.abort(err));
+        if (done || queuedBytes > writer.desiredSize) {
+          await latestPromise; // Respect backpressure
+        }
+        if (!done) {
+          if (isSEIPDv2) { // SEIPD V2
+            ivView.setInt32(iv.length - 4, ++chunkIndex); // Should be setInt64(iv.length - 8, ...)
+          } else { // AEADEncryptedDataPacket
+            adataView.setInt32(5 + 4, ++chunkIndex); // Should be setInt64(5, ...)
+          }
+        } else {
+          await writer.close();
+          break;
+        }
+      }
+    } catch (e) {
+      await writer.ready.catch(() => {});
+      await writer.abort(e);
+    }
+  });
+}

--- a/src/packet/sym_encrypted_integrity_protected_data.js
+++ b/src/packet/sym_encrypted_integrity_protected_data.js
@@ -260,6 +260,7 @@ export async function runAEAD(packet, fn, key, data) {
         if (!chunkIndex || chunk.length) {
           reader.unshift(finalChunk);
           cryptedPromise = modeInstance[fn](chunk, nonce, adataArray);
+          cryptedPromise.catch(() => {});
           queuedBytes += chunk.length - tagLengthIfDecrypting + tagLengthIfEncrypting;
         } else {
           // After the last chunk, we either encrypt a final, empty
@@ -267,6 +268,7 @@ export async function runAEAD(packet, fn, key, data) {
           // validate that final authentication tag.
           adataView.setInt32(5 + chunkIndexSizeIfAEADEP + 4, cryptedBytes); // Should be setInt64(5 + chunkIndexSizeIfAEADEP, ...)
           cryptedPromise = modeInstance[fn](finalChunk, nonce, adataTagArray);
+          cryptedPromise.catch(() => {});
           queuedBytes += tagLengthIfEncrypting;
           done = true;
         }

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -18,6 +18,7 @@
 import { newS2KFromConfig, newS2KFromType } from '../type/s2k';
 import defaultConfig from '../config';
 import crypto from '../crypto';
+import computeHKDF from '../crypto/hkdf';
 import enums from '../enums';
 import util from '../util';
 import { UnsupportedError } from './packet';
@@ -44,7 +45,7 @@ class SymEncryptedSessionKeyPacket {
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    */
   constructor(config = defaultConfig) {
-    this.version = config.aeadProtect ? 5 : 4;
+    this.version = config.aeadProtect ? 6 : 4;
     this.sessionKey = null;
     /**
      * Algorithm to encrypt the session key with
@@ -74,18 +75,28 @@ class SymEncryptedSessionKeyPacket {
   read(bytes) {
     let offset = 0;
 
-    // A one-octet version number. The only currently defined version is 4.
+    // A one-octet version number with value 4, 5 or 6.
     this.version = bytes[offset++];
-    if (this.version !== 4 && this.version !== 5) {
+    if (this.version !== 4 && this.version !== 5 && this.version !== 6) {
       throw new UnsupportedError(`Version ${this.version} of the SKESK packet is unsupported.`);
+    }
+
+    if (this.version === 6) {
+      // A one-octet scalar octet count of the following 5 fields.
+      offset++;
     }
 
     // A one-octet number describing the symmetric algorithm used.
     const algo = bytes[offset++];
 
-    if (this.version === 5) {
+    if (this.version >= 5) {
       // A one-octet AEAD algorithm.
       this.aeadAlgorithm = bytes[offset++];
+
+      if (this.version === 6) {
+        // A one-octet scalar octet count of the following field.
+        offset++;
+      }
     }
 
     // A string-to-key (S2K) specifier, length as defined above.
@@ -93,7 +104,7 @@ class SymEncryptedSessionKeyPacket {
     this.s2k = newS2KFromType(s2kType);
     offset += this.s2k.read(bytes.subarray(offset, bytes.length));
 
-    if (this.version === 5) {
+    if (this.version >= 5) {
       const mode = crypto.getAEADMode(this.aeadAlgorithm);
 
       // A starting initialization vector of size specified by the AEAD
@@ -103,7 +114,7 @@ class SymEncryptedSessionKeyPacket {
 
     // The encrypted session key itself, which is decrypted with the
     // string-to-key object. This is optional in version 4.
-    if (this.version === 5 || offset < bytes.length) {
+    if (this.version >= 5 || offset < bytes.length) {
       this.encrypted = bytes.subarray(offset, bytes.length);
       this.sessionKeyEncryptionAlgorithm = algo;
     } else {
@@ -123,10 +134,15 @@ class SymEncryptedSessionKeyPacket {
 
     let bytes;
 
-    if (this.version === 5) {
-      bytes = util.concatUint8Array([new Uint8Array([this.version, algo, this.aeadAlgorithm]), this.s2k.write(), this.iv, this.encrypted]);
+    const s2k = this.s2k.write();
+    if (this.version === 6) {
+      const s2kLen = s2k.length;
+      const fieldsLen = 3 + s2kLen + this.iv.length;
+      bytes = util.concatUint8Array([new Uint8Array([this.version, fieldsLen, algo, this.aeadAlgorithm, s2kLen]), s2k, this.iv, this.encrypted]);
+    } else if (this.version === 5) {
+      bytes = util.concatUint8Array([new Uint8Array([this.version, algo, this.aeadAlgorithm]), s2k, this.iv, this.encrypted]);
     } else {
-      bytes = util.concatUint8Array([new Uint8Array([this.version, algo]), this.s2k.write()]);
+      bytes = util.concatUint8Array([new Uint8Array([this.version, algo]), s2k]);
 
       if (this.encrypted !== null) {
         bytes = util.concatUint8Array([bytes, this.encrypted]);
@@ -150,10 +166,11 @@ class SymEncryptedSessionKeyPacket {
     const { blockSize, keySize } = crypto.getCipher(algo);
     const key = await this.s2k.produceKey(passphrase, keySize);
 
-    if (this.version === 5) {
+    if (this.version >= 5) {
       const mode = crypto.getAEADMode(this.aeadAlgorithm);
       const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
-      const modeInstance = await mode(algo, key);
+      const encryptionKey = this.version === 6 ? await computeHKDF(enums.hash.sha256, key, new Uint8Array(), adata, keySize) : key;
+      const modeInstance = await mode(algo, encryptionKey);
       this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
     } else if (this.encrypted !== null) {
       const decrypted = await crypto.mode.cfb.decrypt(algo, key, this.encrypted, new Uint8Array(blockSize));
@@ -183,24 +200,25 @@ class SymEncryptedSessionKeyPacket {
     this.s2k.generateSalt();
 
     const { blockSize, keySize } = crypto.getCipher(algo);
-    const encryptionKey = await this.s2k.produceKey(passphrase, keySize);
+    const key = await this.s2k.produceKey(passphrase, keySize);
 
     if (this.sessionKey === null) {
       this.sessionKey = crypto.generateSessionKey(this.sessionKeyAlgorithm);
     }
 
-    if (this.version === 5) {
+    if (this.version >= 5) {
       const mode = crypto.getAEADMode(this.aeadAlgorithm);
       this.iv = crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
-      const associatedData = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
+      const adata = new Uint8Array([0xC0 | SymEncryptedSessionKeyPacket.tag, this.version, this.sessionKeyEncryptionAlgorithm, this.aeadAlgorithm]);
+      const encryptionKey = this.version === 6 ? await computeHKDF(enums.hash.sha256, key, new Uint8Array(), adata, keySize) : key;
       const modeInstance = await mode(algo, encryptionKey);
-      this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, associatedData);
+      this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, adata);
     } else {
       const toEncrypt = util.concatUint8Array([
         new Uint8Array([this.sessionKeyAlgorithm]),
         this.sessionKey
       ]);
-      this.encrypted = await crypto.mode.cfb.encrypt(algo, encryptionKey, toEncrypt, new Uint8Array(blockSize), config);
+      this.encrypted = await crypto.mode.cfb.encrypt(algo, key, toEncrypt, new Uint8Array(blockSize), config);
     }
   }
 }

--- a/test/benchmarks/memory_usage.js
+++ b/test/benchmarks/memory_usage.js
@@ -119,6 +119,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
@@ -131,6 +132,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
@@ -142,7 +144,8 @@ class MemoryBenchamrkSuite {
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
-    assert.ok(encryptedMessage.packets[1] instanceof openpgp.AEADEncryptedDataPacket);
+    assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 2);
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
@@ -154,7 +157,8 @@ class MemoryBenchamrkSuite {
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
-    assert.ok(encryptedMessage.packets[1] instanceof openpgp.AEADEncryptedDataPacket);
+    assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 2);
     await openpgp.decrypt({ message: encryptedMessage, passwords, config });
   });
 
@@ -176,6 +180,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {
@@ -201,6 +206,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {
@@ -225,7 +231,8 @@ class MemoryBenchamrkSuite {
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
-    assert.ok(encryptedMessage.packets[1] instanceof openpgp.AEADEncryptedDataPacket);
+    assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 2);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {
@@ -250,7 +257,8 @@ class MemoryBenchamrkSuite {
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
-    assert.ok(encryptedMessage.packets[1] instanceof openpgp.AEADEncryptedDataPacket);
+    assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 2);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {
@@ -276,6 +284,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {
@@ -301,6 +310,7 @@ class MemoryBenchamrkSuite {
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
     assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 1);
     const { data: decryptedData } = await openpgp.decrypt({
       message: encryptedMessage,
       passwords,
@@ -329,7 +339,8 @@ class MemoryBenchamrkSuite {
 
     const armoredEncryptedMessage = await openpgp.encrypt({ message: plaintextMessage, passwords, config });
     const encryptedMessage = await openpgp.readMessage({ armoredMessage: armoredEncryptedMessage });
-    assert.ok(encryptedMessage.packets[1] instanceof openpgp.AEADEncryptedDataPacket);
+    assert.ok(encryptedMessage.packets[1] instanceof openpgp.SymEncryptedIntegrityProtectedDataPacket);
+    assert.ok(encryptedMessage.packets[1].version === 2);
     const { data: decryptedData } = await openpgp.decrypt({ message: encryptedMessage, passwords, config });
     // read out output stream to trigger decryption
     await new Promise(resolve => {

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -379,7 +379,6 @@ VWx8AtKEInT8YvN19cS2Jpr81jCN819IqgDr+YQezYMwZMzWISmA3w5Z3UCU
 lO771jlg4fHlWOZ2nJqselFlNc3X/VoZ8swmMkI6KVDV+rKaeyTWe61Up0Jj
 NJCB6+LWtabSoVIjNVgKwyKqyTLaESNwC2ogZwkdE8qPGiDFEHo4Gg9zuRof
 
-=trqv
 -----END PGP PUBLIC KEY BLOCK-----
 `;
 
@@ -390,7 +389,7 @@ NJCB6+LWtabSoVIjNVgKwyKqyTLaESNwC2ogZwkdE8qPGiDFEHo4Gg9zuRof
         .replace(/^(Version|Comment): .*$\n/mg, '')
     ).to.equal(
       pubKey
-        .replace('\n=', '=')
+        .replace('\n-', '-')
         .replace(/\n\r/g, '\n')
     );
   });

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -171,15 +171,7 @@ export default () => describe('ASCII armor', function() {
       '-----END PGP PRIVATE KEY BLOCK-----'
     ].join('\n');
 
-    // try with default config
-    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-
-    // try opposite config
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    await expect(openpgp.readKey({ armoredKey: privKey })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-
-    // back to default
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
+    await openpgp.readKey({ armoredKey: privKey });
   });
 
   it('Armor checksum validation - valid', async function () {
@@ -203,15 +195,7 @@ export default () => describe('ASCII armor', function() {
         '=wJNM',
         '-----END PGP PRIVATE KEY BLOCK-----'].join('\n');
 
-    // try with default config
     await openpgp.readKey({ armoredKey: privKey });
-
-    // try opposite config
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    await openpgp.readKey({ armoredKey: privKey });
-
-    // back to default
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
   });
 
   it('Armor checksum validation - missing', async function () {
@@ -234,23 +218,7 @@ export default () => describe('ASCII armor', function() {
         '71vlXMJNXvoCeuejiRw=',
         '-----END PGP PRIVATE KEY BLOCK-----'].join('\n');
 
-    // try with default config
-    if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-    } else {
-      await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
-    }
-
-    // try opposite config
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSum })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-    } else {
-      await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
-    }
-
-    // back to default
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
+    await openpgp.readKey({ armoredKey: privKeyNoCheckSum });
   });
 
   it('Armor checksum validation - missing - trailing newline', async function () {
@@ -274,23 +242,7 @@ export default () => describe('ASCII armor', function() {
         '-----END PGP PRIVATE KEY BLOCK-----',
         ''].join('\n');
 
-    // try with default config
-    if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-    } else {
-      await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
-    }
-
-    // try opposite config
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
-    if (openpgp.config.checksumRequired) {
-      await expect(openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline })).to.be.rejectedWith(/Ascii armor integrity check failed/);
-    } else {
-      await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
-    }
-
-    // back to default
-    openpgp.config.checksumRequired = !openpgp.config.checksumRequired;
+    await openpgp.readKey({ armoredKey: privKeyNoCheckSumWithTrailingNewline });
   });
 
   it('Accept header with trailing whitespace', async function () {

--- a/test/general/armor.js
+++ b/test/general/armor.js
@@ -36,12 +36,6 @@ export default () => describe('ASCII armor', function() {
     await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
   });
 
-  it('Exception if no header and non-MD5 signature', async function () {
-    let msg = getArmor(null);
-    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
-    await expect(msg).to.be.rejectedWith(Error, /If no "Hash" header in cleartext signed message, then only MD5 signatures allowed/);
-  });
-
   it('Exception if unknown hash algorithm', async function () {
     let msg = getArmor(['Hash: LAV750']);
     msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
@@ -66,18 +60,6 @@ export default () => describe('ASCII armor', function() {
     await expect(msg).to.be.rejectedWith(Error, /Only "Hash" header allowed in cleartext signed message/);
   });
 
-  it('Multiple wrong hash values', async function () {
-    let msg = getArmor(['Hash: SHA512, SHA256']);
-    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
-    await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
-  });
-
-  it('Multiple wrong hash values', async function () {
-    let msg = getArmor(['Hash: SHA512, SHA256']);
-    msg = openpgp.readCleartextMessage({ cleartextMessage: msg });
-    await expect(msg).to.be.rejectedWith(Error, /Hash algorithm mismatch in armor header and signature/);
-  });
-
   it('Filter whitespace in blank line', async function () {
     let msg = [
       '-----BEGIN PGP SIGNED MESSAGE-----',
@@ -97,11 +79,6 @@ export default () => describe('ASCII armor', function() {
 
     msg = await openpgp.readCleartextMessage({ cleartextMessage: msg });
     expect(msg).to.be.an.instanceof(openpgp.CleartextMessage);
-  });
-
-  it('Exception if header is not Hash in cleartext signed message', async function () {
-    const msg = openpgp.readCleartextMessage({ cleartextMessage: getArmor(['Ha sh: SHA256']) });
-    await expect(msg).to.be.rejectedWith(Error, /Only "Hash" header allowed in cleartext signed message/);
   });
 
   it('Ignore improperly formatted armor header', async function () {

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -272,6 +272,7 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       const { packets: [skesk, encData] } = encrypted;
       expect(skesk.version).to.equal(4); // cfb
       expect(encData.constructor.tag).to.equal(openpgp.enums.packet.symEncryptedIntegrityProtectedData);
+      expect(encData.version).to.equal(1);
       const { packets: [literal] } = await encrypted.decrypt(null, passwords, null, encrypted.fromStream, openpgp.config);
       expect(literal.constructor.tag).to.equal(openpgp.enums.packet.literalData);
 
@@ -284,7 +285,8 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       const encrypted2 = await openpgp.readMessage({ armoredMessage: armored2 });
       const { packets: [skesk2, encData2] } = encrypted2;
       expect(skesk2.version).to.equal(5);
-      expect(encData2.constructor.tag).to.equal(openpgp.enums.packet.aeadEncryptedData);
+      expect(encData2.constructor.tag).to.equal(openpgp.enums.packet.symEncryptedIntegrityProtectedData);
+      expect(encData2.version).to.equal(2);
       const { packets: [compressed] } = await encrypted2.decrypt(null, passwords, null, encrypted2.fromStream, openpgp.config);
       expect(compressed.constructor.tag).to.equal(openpgp.enums.packet.compressedData);
       expect(compressed.algorithm).to.equal(openpgp.enums.compression.zip);

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -116,10 +116,10 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
   });
 
   it('openpgp.generateKey', async function() {
-    const v5KeysVal = openpgp.config.v5Keys;
+    const v6KeysVal = openpgp.config.v6Keys;
     const preferredHashAlgorithmVal = openpgp.config.preferredHashAlgorithm;
     const showCommentVal = openpgp.config.showComment;
-    openpgp.config.v5Keys = false;
+    openpgp.config.v6Keys = false;
     openpgp.config.preferredHashAlgorithm = openpgp.enums.hash.sha256;
     openpgp.config.showComment = false;
 
@@ -134,7 +134,7 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       expect(key.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(openpgp.config.preferredHashAlgorithm);
 
       const config = {
-        v5Keys: true,
+        v6Keys: true,
         showComment: true,
         preferredHashAlgorithm: openpgp.enums.hash.sha512
       };
@@ -144,11 +144,11 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       };
       const { privateKey: privateKeyArmored2 } = await openpgp.generateKey(opt2);
       const key2 = await openpgp.readKey({ armoredKey: privateKeyArmored2 });
-      expect(key2.keyPacket.version).to.equal(5);
+      expect(key2.keyPacket.version).to.equal(6);
       expect(privateKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
       expect(key2.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(config.preferredHashAlgorithm);
     } finally {
-      openpgp.config.v5Keys = v5KeysVal;
+      openpgp.config.v6Keys = v6KeysVal;
       openpgp.config.preferredHashAlgorithm = preferredHashAlgorithmVal;
       openpgp.config.showComment = showCommentVal;
     }

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -146,7 +146,7 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       const key2 = await openpgp.readKey({ armoredKey: privateKeyArmored2 });
       expect(key2.keyPacket.version).to.equal(6);
       expect(privateKeyArmored2.indexOf(openpgp.config.commentString) > 0).to.be.true;
-      expect(key2.users[0].selfCertifications[0].preferredHashAlgorithms[0]).to.equal(config.preferredHashAlgorithm);
+      expect(key2.directSignatures[0].preferredHashAlgorithms[0]).to.equal(config.preferredHashAlgorithm);
     } finally {
       openpgp.config.v6Keys = v6KeysVal;
       openpgp.config.preferredHashAlgorithm = preferredHashAlgorithmVal;

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -284,7 +284,7 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
       const armored2 = await openpgp.encrypt({ message, passwords, config });
       const encrypted2 = await openpgp.readMessage({ armoredMessage: armored2 });
       const { packets: [skesk2, encData2] } = encrypted2;
-      expect(skesk2.version).to.equal(5);
+      expect(skesk2.version).to.equal(6);
       expect(encData2.constructor.tag).to.equal(openpgp.enums.packet.symEncryptedIntegrityProtectedData);
       expect(encData2.version).to.equal(2);
       const { packets: [compressed] } = await encrypted2.decrypt(null, passwords, null, encrypted2.fromStream, openpgp.config);

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -6,7 +6,7 @@ chaiUse(chaiAsPromised);
 
 import openpgp from '../initOpenpgp.js';
 import util from '../../src/util.js';
-import { isAEADSupported, getPreferredAlgo } from '../../src/key';
+import { getPreferredCipherSuite } from '../../src/key';
 import KeyID from '../../src/type/keyid.js';
 
 
@@ -3643,76 +3643,85 @@ aU71tdtNBQ==
     expect(revKey.armor()).not.to.match(/Comment: This is a revocation certificate/);
   });
 
-  it("getPreferredAlgo('symmetric') - one key", async function() {
+  it('getPreferredCipherSuite - one key', async function() {
     const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
-    const prefAlgo = await getPreferredAlgo('symmetric', [key1], undefined, undefined, {
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
       ...openpgp.config, preferredSymmetricAlgorithm: openpgp.enums.symmetric.aes256
     });
-    expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes256);
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes256);
+    expect(aeadAlgo).to.equal(undefined);
   });
 
-  it("getPreferredAlgo('symmetric') - two key", async function() {
+  it('getPreferredCipherSuite - two keys', async function() {
     const { aes128, aes192, cast5 } = openpgp.enums.symmetric;
     const [key1, key2] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = [6, aes192, cast5];
-    const prefAlgo = await getPreferredAlgo('symmetric', [key1, key2], undefined, undefined, {
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1, key2], undefined, undefined, {
       ...openpgp.config, preferredSymmetricAlgorithm: openpgp.enums.symmetric.aes192
     });
-    expect(prefAlgo).to.equal(aes192);
-    const prefAlgo2 = await getPreferredAlgo('symmetric', [key1, key2], undefined, undefined, {
+    expect(symmetricAlgo).to.equal(aes192);
+    expect(aeadAlgo).to.equal(undefined);
+    const { symmetricAlgo: symmetricAlgo2, aeadAlgo: aeadAlgo2 } = await getPreferredCipherSuite([key1, key2], undefined, undefined, {
       ...openpgp.config, preferredSymmetricAlgorithm: openpgp.enums.symmetric.aes256
     });
-    expect(prefAlgo2).to.equal(aes128);
+    expect(symmetricAlgo2).to.equal(aes128);
+    expect(aeadAlgo2).to.equal(undefined);
   });
 
-  it("getPreferredAlgo('symmetric') - two key - one without pref", async function() {
+  it('getPreferredCipherSuite - two keys - one without pref', async function() {
     const [key1, key2] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = null;
-    const prefAlgo = await getPreferredAlgo('symmetric', [key1, key2]);
-    expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes128);
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1, key2]);
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes128);
+    expect(aeadAlgo).to.equal(undefined);
   });
 
-  it("getPreferredAlgo('aead') - one key - OCB", async function() {
+  it('getPreferredCipherSuite with AEAD - one key - GCM', async function() {
     const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key1.getPrimaryUser();
-    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    primaryUser.selfCertification.preferredAEADAlgorithms = [2,1];
-    const prefAlgo = await getPreferredAlgo('aead', [key1], undefined, undefined, {
-      ...openpgp.config, preferredAEADAlgorithm: openpgp.enums.aead.ocb
+    primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    primaryUser.selfCertification.preferredCipherSuites = [[9, 3], [9, 2]];
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
+      ...openpgp.config,
+      aeadProtect: true,
+      preferredAEADAlgorithm: openpgp.enums.aead.gcm
     });
-    expect(prefAlgo).to.equal(openpgp.enums.aead.ocb);
-    const supported = await isAEADSupported([key1]);
-    expect(supported).to.be.true;
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes256);
+    expect(aeadAlgo).to.equal(openpgp.enums.aead.gcm);
   });
 
-  it("getPreferredAlgo('aead') - two key - one without pref", async function() {
+  it('getPreferredCipherSuite with AEAD - two keys - one without pref', async function() {
     const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
-    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    primaryUser.selfCertification.preferredAEADAlgorithms = [2,1];
+    primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    primaryUser.selfCertification.preferredCipherSuites = [[9, 3], [9, 2]];
     const primaryUser2 = await key2.getPrimaryUser();
-    primaryUser2.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    const prefAlgo = await getPreferredAlgo('aead', [key1, key2]);
-    expect(prefAlgo).to.equal(openpgp.enums.aead.eax);
-    const supported = await isAEADSupported([key1, key2]);
-    expect(supported).to.be.true;
+    primaryUser2.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1, key2], undefined, undefined, {
+      ...openpgp.config,
+      aeadProtect: true
+    });
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes128);
+    expect(aeadAlgo).to.equal(openpgp.enums.aead.ocb);
   });
 
-  it("getPreferredAlgo('aead') - two key - one with no support", async function() {
+  it('getPreferredCipherSuite with AEAD - two keys - one with no support', async function() {
     const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
-    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    primaryUser.selfCertification.preferredAEADAlgorithms = [2,1];
-    const prefAlgo = await getPreferredAlgo('aead', [key1, key2]);
-    expect(prefAlgo).to.equal(openpgp.enums.aead.eax);
-    const supported = await isAEADSupported([key1, key2]);
-    expect(supported).to.be.false;
+    primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    primaryUser.selfCertification.preferredCipherSuites = [[9, 3], [9, 2]];
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1, key2], undefined, undefined, {
+      ...openpgp.config,
+      aeadProtect: true
+    });
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes256);
+    expect(aeadAlgo).to.equal(undefined);
   });
 
   it('User attribute packet read & write', async function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2258,7 +2258,7 @@ function versionSpecificTests() {
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.uncompressed, compr.zlib, compr.zip]);
 
       let expectedFeatures;
-      if (openpgp.config.v5Keys) {
+      if (openpgp.config.v6Keys) {
         expectedFeatures = [7]; // v5 + aead + mdc
       } else if (openpgp.config.aeadProtect) {
         expectedFeatures = [3]; // aead + mdc
@@ -2303,7 +2303,7 @@ function versionSpecificTests() {
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.zip, compr.zlib, compr.uncompressed]);
 
       let expectedFeatures;
-      if (openpgp.config.v5Keys) {
+      if (openpgp.config.v6Keys) {
         expectedFeatures = [7]; // v5 + aead + mdc
       } else if (openpgp.config.aeadProtect) {
         expectedFeatures = [3]; // aead + mdc
@@ -2894,30 +2894,30 @@ function versionSpecificTests() {
 }
 
 export default () => describe('Key', function() {
-  let v5KeysVal;
+  let v6KeysVal;
   let aeadProtectVal;
 
   tryTests('V4', versionSpecificTests, {
     if: !openpgp.config.ci,
     beforeEach: function() {
-      v5KeysVal = openpgp.config.v5Keys;
-      openpgp.config.v5Keys = false;
+      v6KeysVal = openpgp.config.v6Keys;
+      openpgp.config.v6Keys = false;
     },
     afterEach: function() {
-      openpgp.config.v5Keys = v5KeysVal;
+      openpgp.config.v6Keys = v6KeysVal;
     }
   });
 
-  tryTests('V5', versionSpecificTests, {
+  tryTests('V6', versionSpecificTests, {
     if: !openpgp.config.ci,
     beforeEach: function() {
-      v5KeysVal = openpgp.config.v5Keys;
+      v6KeysVal = openpgp.config.v6Keys;
       aeadProtectVal = openpgp.config.aeadProtect;
-      openpgp.config.v5Keys = true;
+      openpgp.config.v6Keys = true;
       openpgp.config.aeadProtect = true;
     },
     afterEach: function() {
-      openpgp.config.v5Keys = v5KeysVal;
+      openpgp.config.v6Keys = v6KeysVal;
       openpgp.config.aeadProtect = aeadProtectVal;
     }
   });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2300,10 +2300,10 @@ XfA3pqV4mTzF
         openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.experimentalGCM;
         openpgp.config.v6Keys = true;
 
-        // Monkey-patch AEAD feature flag
-        publicKey.users[0].selfCertifications[0].features = [7];
-        publicKey_2000_2008.users[0].selfCertifications[0].features = [7];
-        publicKey_2038_2045.users[0].selfCertifications[0].features = [7];
+        // Monkey-patch SEIPD V2 feature flag
+        publicKey.users[0].selfCertifications[0].features = [9];
+        publicKey_2000_2008.users[0].selfCertifications[0].features = [9];
+        publicKey_2038_2045.users[0].selfCertifications[0].features = [9];
       }
     });
 
@@ -2313,10 +2313,10 @@ XfA3pqV4mTzF
         openpgp.config.aeadProtect = true;
         openpgp.config.aeadChunkSizeByte = 0;
 
-        // Monkey-patch AEAD feature flag
-        publicKey.users[0].selfCertifications[0].features = [7];
-        publicKey_2000_2008.users[0].selfCertifications[0].features = [7];
-        publicKey_2038_2045.users[0].selfCertifications[0].features = [7];
+        // Monkey-patch SEIPD V2 feature flag
+        publicKey.users[0].selfCertifications[0].features = [9];
+        publicKey_2000_2008.users[0].selfCertifications[0].features = [9];
+        publicKey_2038_2045.users[0].selfCertifications[0].features = [9];
       }
     });
 
@@ -2326,10 +2326,10 @@ XfA3pqV4mTzF
         openpgp.config.aeadProtect = true;
         openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.ocb;
 
-        // Monkey-patch AEAD feature flag
-        publicKey.users[0].selfCertifications[0].features = [7];
-        publicKey_2000_2008.users[0].selfCertifications[0].features = [7];
-        publicKey_2038_2045.users[0].selfCertifications[0].features = [7];
+        // Monkey-patch SEIPD V2 feature flag
+        publicKey.users[0].selfCertifications[0].features = [9];
+        publicKey_2000_2008.users[0].selfCertifications[0].features = [9];
+        publicKey_2038_2045.users[0].selfCertifications[0].features = [9];
       }
     });
 
@@ -2626,7 +2626,7 @@ XfA3pqV4mTzF
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-            expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(false);
+            expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(false);
             return openpgp.decrypt(decOpt);
           }).then(function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
@@ -2649,7 +2649,7 @@ XfA3pqV4mTzF
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             expect(encrypted).to.match(/^-----BEGIN PGP MESSAGE/);
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-            expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(false);
+            expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(false);
             return openpgp.decrypt(decOpt);
           }).then(function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
@@ -2668,7 +2668,7 @@ XfA3pqV4mTzF
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-            expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(openpgp.config.aeadProtect);
+            expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(openpgp.config.aeadProtect);
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
@@ -2692,7 +2692,7 @@ XfA3pqV4mTzF
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-            expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(openpgp.config.aeadProtect);
+            expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(openpgp.config.aeadProtect);
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
@@ -2715,7 +2715,7 @@ XfA3pqV4mTzF
           };
           return openpgp.encrypt(encOpt).then(async function (encrypted) {
             decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-            expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(false);
+            expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(false);
             return openpgp.decrypt(decOpt);
           }).then(async function (decrypted) {
             expect(decrypted.data).to.equal(plaintext);
@@ -2746,7 +2746,7 @@ XfA3pqV4mTzF
             };
             return openpgp.encrypt(encOpt).then(async function (encrypted) {
               decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
-              expect(!!decOpt.message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(openpgp.config.aeadProtect);
+              expect(decOpt.message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(openpgp.config.aeadProtect);
               return openpgp.decrypt(decOpt);
             }).then(async function (decrypted) {
               expect(decrypted.data).to.equal(plaintext);
@@ -2775,7 +2775,7 @@ XfA3pqV4mTzF
             detached: true
           });
           const message = await openpgp.readMessage({ armoredMessage: encrypted });
-          expect(!!message.packets.findPacket(openpgp.enums.packet.aeadEncryptedData)).to.equal(openpgp.config.aeadProtect);
+          expect(message.packets.findPacket(openpgp.enums.packet.symEncryptedIntegrityProtectedData).version === 2).to.equal(openpgp.config.aeadProtect);
           const decrypted = await openpgp.decrypt({
             message,
             signature: await openpgp.readSignature({ armoredSignature: signed }),

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1311,6 +1311,40 @@ VFBLG8uc9IiaKann/DYBAJcZNZHRSfpDoV2pUA5EAEi2MdjxkRysFQnYPRAu
       await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith('Error decrypting message: Decryption key is not decrypted.');
     });
 
+    it('should decrypt test vector X25519-AEAD-OCB (PKESK v6, SEIPDv2)', async function() {
+      // test vector https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-10.html#appendix-A.8
+      const armoredMessage = `-----BEGIN PGP MESSAGE-----
+
+wV0GIQYSyD8ecG9jCP4VGkF3Q6HwM3kOk+mXhIjR2zeNqZMIhRmHzxjV8bU/gXzO
+WgBM85PMiVi93AZfJfhK9QmxfdNnZBjeo1VDeVZheQHgaVf7yopqR6W1FT6NOrfS
+aQIHAgZhZBZTW+CwcW1g4FKlbExAf56zaw76/prQoN+bAzxpohup69LA7JW/Vp0l
+yZnuSj3hcFj0DfqLTGgr4/u717J+sPWbtQBfgMfG9AOIwwrUBqsFE9zW+f1zdlYo
+bhF30A+IitsxxA==
+-----END PGP MESSAGE-----`;
+
+      const privateKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xUsGY4d/4xsAAAAg+U2nu0jWCmHlZ3BqZYfQMxmZu52JGggkLq2EVD34laMAGXKB
+exK+cH6NX1hs5hNhIB00TrJmosgv3mg1ditlsLfCsQYfGwoAAABCBYJjh3/jAwsJ
+BwUVCg4IDAIWAAKbAwIeCSIhBssYbE8GCaaX5NUt+mxyKwwfHifBilZwj2Ul7Ce6
+2azJBScJAgcCAAAAAK0oIBA+LX0ifsDm185Ecds2v8lwgyU2kCcUmKfvBXbAf6rh
+RYWzuQOwEn7E/aLwIwRaLsdry0+VcallHhSu4RN6HWaEQsiPlR4zxP/TP7mhfVEe
+7XWPxtnMUMtf15OyA51YBMdLBmOHf+MZAAAAIIaTJINn+eUBXbki+PSAld2nhJh/
+LVmFsS+60WyvXkQ1AE1gCk95TUR3XFeibg/u/tVY6a//1q0NWC1X+yui3O24wpsG
+GBsKAAAALAWCY4d/4wKbDCIhBssYbE8GCaaX5NUt+mxyKwwfHifBilZwj2Ul7Ce6
+2azJAAAAAAQBIKbpGG2dWTX8j+VjFM21J0hqWlEg+bdiojWnKfA5AQpWUWtnNwDE
+M0g12vYxoWM8Y81W+bHBw805I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUr
+k0mXubZvyl4GBg==
+-----END PGP PRIVATE KEY BLOCK-----` });
+
+      const { data: decryptedData } = await openpgp.decrypt({
+        message: await openpgp.readMessage({ armoredMessage }),
+        decryptionKeys: privateKey
+      });
+
+      expect(decryptedData).to.equal('Hello, world!');
+    });
+
     it('decrypt/verify should succeed with valid signature  (expectSigned=true)', async function () {
       const publicKey = await openpgp.readKey({ armoredKey: pub_key });
       const privateKey = await openpgp.decryptKey({

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2231,7 +2231,7 @@ XfA3pqV4mTzF
     let aeadProtectVal;
     let preferredAEADAlgorithmVal;
     let aeadChunkSizeByteVal;
-    let v5KeysVal;
+    let v6KeysVal;
     let minRSABitsVal;
 
     beforeEach(async function() {
@@ -2248,7 +2248,7 @@ XfA3pqV4mTzF
       aeadProtectVal = openpgp.config.aeadProtect;
       preferredAEADAlgorithmVal = openpgp.config.preferredAEADAlgorithm;
       aeadChunkSizeByteVal = openpgp.config.aeadChunkSizeByte;
-      v5KeysVal = openpgp.config.v5Keys;
+      v6KeysVal = openpgp.config.v6Keys;
       minRSABitsVal = openpgp.config.minRSABits;
 
       openpgp.config.minRSABits = 512;
@@ -2258,7 +2258,7 @@ XfA3pqV4mTzF
       openpgp.config.aeadProtect = aeadProtectVal;
       openpgp.config.preferredAEADAlgorithm = preferredAEADAlgorithmVal;
       openpgp.config.aeadChunkSizeByte = aeadChunkSizeByteVal;
-      openpgp.config.v5Keys = v5KeysVal;
+      openpgp.config.v6Keys = v6KeysVal;
       openpgp.config.minRSABits = minRSABitsVal;
     });
 
@@ -2293,12 +2293,12 @@ XfA3pqV4mTzF
       }
     });
 
-    tryTests('GCM mode (V5 keys)', tests, {
+    tryTests('GCM mode (V6 keys)', tests, {
       if: true,
       beforeEach: function() {
         openpgp.config.aeadProtect = true;
         openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.experimentalGCM;
-        openpgp.config.v5Keys = true;
+        openpgp.config.v6Keys = true;
 
         // Monkey-patch AEAD feature flag
         publicKey.users[0].selfCertifications[0].features = [7];

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -11,7 +11,7 @@ import crypto from '../../src/crypto';
 import * as random from '../../src/crypto/random.js';
 import util from '../../src/util.js';
 import keyIDType from '../../src/type/keyid.js';
-import { isAEADSupported } from '../../src/key';
+import { getPreferredCipherSuite } from '../../src/key';
 
 import * as input from './testInputs.js';
 
@@ -3054,7 +3054,8 @@ XfA3pqV4mTzF
         it('should fail to decrypt modified message', async function() {
           const allowUnauthenticatedStream = openpgp.config.allowUnauthenticatedStream;
           const { privateKey: key } = await openpgp.generateKey({ userIDs: [{ email: 'test@email.com' }], format: 'object' });
-          expect(await isAEADSupported([key])).to.equal(openpgp.config.aeadProtect);
+          const { aeadAlgo } = await getPreferredCipherSuite([key], undefined, undefined, openpgp.config);
+          expect(!!aeadAlgo).to.equal(openpgp.config.aeadProtect);
 
           const data = await openpgp.encrypt({ message: await openpgp.createMessage({ binary: new Uint8Array(500) }), encryptionKeys: [key.toPublic()] });
           const encrypted = data.substr(0, 500) + (data[500] === 'a' ? 'b' : 'a') + data.substr(501);

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -15,7 +15,6 @@ import { getPreferredCipherSuite } from '../../src/key';
 
 import * as input from './testInputs.js';
 
-const detectNode = () => typeof globalThis.process === 'object' && typeof globalThis.process.versions === 'object';
 const detectBrowser = () => typeof navigator === 'object';
 
 const pub_key = [
@@ -2331,7 +2330,7 @@ XfA3pqV4mTzF
       if: true,
       beforeEach: function() {
         openpgp.config.aeadProtect = true;
-        openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.experimentalGCM;
+        openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.gcm;
         openpgp.config.v6Keys = true;
 
         // Monkey-patch SEIPD V2 feature flag
@@ -2346,6 +2345,7 @@ XfA3pqV4mTzF
       beforeEach: function() {
         openpgp.config.aeadProtect = true;
         openpgp.config.aeadChunkSizeByte = 0;
+        openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.eax;
 
         // Monkey-patch SEIPD V2 feature flag
         publicKey.users[0].selfCertifications[0].features = [9];
@@ -2355,7 +2355,7 @@ XfA3pqV4mTzF
     });
 
     tryTests('OCB mode', tests, {
-      if: !openpgp.config.ci,
+      if: true,
       beforeEach: function() {
         openpgp.config.aeadProtect = true;
         openpgp.config.preferredAEADAlgorithm = openpgp.enums.aead.ocb;
@@ -3086,60 +3086,92 @@ XfA3pqV4mTzF
         });
 
         it('should fail to decrypt modified message', async function() {
-          const allowUnauthenticatedStream = openpgp.config.allowUnauthenticatedStream;
-          const { privateKey: key } = await openpgp.generateKey({ userIDs: [{ email: 'test@email.com' }], format: 'object' });
-          const { aeadAlgo } = await getPreferredCipherSuite([key], undefined, undefined, openpgp.config);
-          expect(!!aeadAlgo).to.equal(openpgp.config.aeadProtect);
-
-          const data = await openpgp.encrypt({ message: await openpgp.createMessage({ binary: new Uint8Array(500) }), encryptionKeys: [key.toPublic()] });
-          const encrypted = data.substr(0, 500) + (data[500] === 'a' ? 'b' : 'a') + data.substr(501);
           await loadStreamsPolyfill();
-          try {
-            for (const allowStreaming of [true, false]) {
-              openpgp.config.allowUnauthenticatedStream = allowStreaming;
-              for (const [i, encryptedData] of [
-                encrypted,
-                new ReadableStream({
-                  start(controller) {
-                    controller.enqueue(encrypted);
-                    controller.close();
-                  }
-                }),
-                new ReadableStream({
-                  start() {
-                    this.remaining = encrypted.split('\n');
-                  },
-                  async pull(controller) {
-                    if (this.remaining.length) {
-                      await new Promise(res => setTimeout(res));
-                      controller.enqueue(this.remaining.shift() + '\n');
-                    } else {
-                      controller.close();
-                    }
-                  }
-                })
-              ].entries()) {
-                let stepReached = 0;
-                try {
-                  const message = await openpgp.readMessage({ armoredMessage: encryptedData });
-                  stepReached = 1;
-                  const { data: decrypted } = await openpgp.decrypt({ message: message, decryptionKeys: [key] });
-                  stepReached = 2;
-                  await stream.readToEnd(decrypted);
-                } catch (e) {
-                  expect(e.message).to.match(/Modification detected|Authentication tag mismatch|Unsupported state or unable to authenticate data/);
-                  expect(stepReached).to.equal(
-                    i === 0 ? 1 :
-                      (openpgp.config.aeadChunkSizeByte === 0 && (i === 2 || detectNode() || util.getHardwareConcurrency() < 8)) || (!openpgp.config.aeadProtect && openpgp.config.allowUnauthenticatedStream) ? 2 :
-                        1
-                  );
-                  continue;
-                }
-                throw new Error(`Expected "Modification detected" error in subtest ${i}`);
+          // need to generate new key with AEAD support
+          const { privateKey } = await openpgp.generateKey({ userIDs: [{ email: 'test@email.com' }], type: 'rsa', format: 'object' });
+          const { aeadAlgo } = await getPreferredCipherSuite([privateKey], undefined, undefined, openpgp.config);
+          // sanity check
+          expect(aeadAlgo).to.equal(openpgp.config.aeadProtect ? openpgp.config.preferredAEADAlgorithm : undefined);
+
+          const encrypted = await openpgp.encrypt({
+            message: await openpgp.createMessage({ binary: new Uint8Array(500) }),
+            encryptionKeys: privateKey
+          });
+          // corrupt the SEIPD packet
+          const encryptedCorrupted = encrypted.substr(0, 1000) + (encrypted[1000] === 'a' ? 'b' : 'a') + encrypted.substr(1001);
+
+          const generateSingleChunkStream = () => (
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(encryptedCorrupted);
+                controller.close();
               }
+            })
+          );
+          const generateMultiChunkStream = () => (
+            new ReadableStream({
+              start() {
+                this.remaining = encryptedCorrupted.split('\n');
+              },
+              async pull(controller) {
+                if (this.remaining.length) {
+                  // sleep to slow down enqeueing
+                  await new Promise(resolve => { setTimeout(resolve); });
+                  controller.enqueue(this.remaining.shift() + '\n');
+                } else {
+                  controller.close();
+                }
+              }
+            })
+          );
+
+          if (openpgp.config.aeadProtect) {
+            const expectedError = /Authentication tag mismatch|Unsupported state or unable to authenticate data/;
+            // AEAD fails either on AEAD chunk decryption or when reading the decrypted stream:
+            // if the corruption is in the first AEAD chunk, then `openpgp.decrypt` will throw
+            // when reading the decrypted stream to parse the packet list.
+            await Promise.all([
+              testStreamingDecryption(encryptedCorrupted, true, expectedError, true),
+              testStreamingDecryption(encryptedCorrupted, false, expectedError, true),
+              // `config.allowUnauthenticatedStream` does not apply to AEAD
+              testStreamingDecryption(generateSingleChunkStream(), true, expectedError, openpgp.config.aeadChunkSizeByte > 0),
+              testStreamingDecryption(generateSingleChunkStream(), false, expectedError, openpgp.config.aeadChunkSizeByte > 0),
+              // Increasing number of streaming chunks should not affect the result
+              testStreamingDecryption(generateMultiChunkStream(), true, expectedError, openpgp.config.aeadChunkSizeByte > 0),
+              testStreamingDecryption(generateMultiChunkStream(), false, expectedError, openpgp.config.aeadChunkSizeByte > 0)
+            ]);
+          } else {
+            const expectedError = /Modification detected/;
+            await Promise.all([
+              testStreamingDecryption(encryptedCorrupted, true, expectedError, true),
+              testStreamingDecryption(encryptedCorrupted, false, expectedError, true),
+              testStreamingDecryption(generateSingleChunkStream(), true, expectedError, false),
+              testStreamingDecryption(generateSingleChunkStream(), false, expectedError, true),
+              // Increasing number of streaming chunks should not affect the result
+              testStreamingDecryption(generateMultiChunkStream(), true, expectedError, false),
+              testStreamingDecryption(generateMultiChunkStream(), false, expectedError, true)
+            ]);
+          }
+
+          async function testStreamingDecryption(encryptedDataOrStream, allowUnauthenticatedStream, expectedErrorMessage, expectedFailureOnDecrypt = null) {
+            // parsing the message won't fail since armor checksum is ignored
+            const message = await openpgp.readMessage({ armoredMessage: encryptedDataOrStream });
+            let didFailOnDecrypt = true;
+
+            try {
+              const { data: decrypted } = await openpgp.decrypt({
+                message,
+                decryptionKeys: [privateKey],
+                config: { allowUnauthenticatedStream }
+              });
+              didFailOnDecrypt = false;
+              await stream.readToEnd(decrypted);
+              // expected to have thrown
+              throw new Error(`Expected decryption to fail with error ${expectedErrorMessage}`);
+            } catch (e) {
+              expect(e.message).to.match(expectedErrorMessage);
+              expect(didFailOnDecrypt).to.equal(expectedFailureOnDecrypt);
             }
-          } finally {
-            openpgp.config.allowUnauthenticatedStream = allowUnauthenticatedStream;
           }
         });
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -474,6 +474,7 @@ export default () => describe('Packet', function() {
 
     return crypto.generateParams(rsa, keySize, 65537).then(function({ publicParams, privateParams }) {
       const enc = new openpgp.PublicKeyEncryptedSessionKeyPacket();
+      enc.version = 3;
       const msg = new openpgp.PacketList();
       const msg2 = new openpgp.PacketList();
 
@@ -523,6 +524,7 @@ export default () => describe('Packet', function() {
     key = key[0];
 
     const enc = new openpgp.PublicKeyEncryptedSessionKeyPacket();
+    enc.version = 3;
     const secret = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
 
     enc.sessionKey = secret;

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -1514,6 +1514,20 @@ kePFjAnu9cpynKXu3usf8+FuBw2zLsg1Id1n7ttxoAte416KjBN9lFBt8mcu
       ).to.be.rejectedWith(/Unsupported S2K type/);
     });
 
+    it('Throws on critical packet even with tolerant mode enabled', async function() {
+      const unknownPacketTag39 = util.hexToUint8Array('e70a750064bf943d6e756c6c'); // critical tag
+
+      await expect(openpgp.PacketList.fromBinary(unknownPacketTag39, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false, ignoreMalformedPackets: false })).to.be.rejectedWith(/Unknown packet type/);
+      await expect(openpgp.PacketList.fromBinary(unknownPacketTag39, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true, ignoreMalformedPackets: true })).to.be.rejectedWith(/Unknown packet type/);
+    });
+
+    it('Ignores non-critical packet even with tolerant mode disabled', async function() {
+      const unknownPacketTag63 = util.hexToUint8Array('ff0a750064bf943d6e756c6c'); // non-critical tag
+
+      await expect(openpgp.PacketList.fromBinary(unknownPacketTag63, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: false, ignoreMalformedPackets: false })).to.eventually.have.length(0);
+      await expect(openpgp.PacketList.fromBinary(unknownPacketTag63, allAllowedPackets, { ...openpgp.config, ignoreUnsupportedPackets: true, ignoreMalformedPackets: true })).to.eventually.have.length(0);
+    });
+
     it('Throws on disallowed packet even with tolerant mode enabled', async function() {
       const packets = new openpgp.PacketList();
       packets.push(new openpgp.LiteralDataPacket());

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -137,6 +137,7 @@ export default () => describe('Packet', function() {
 
     const literal = new openpgp.LiteralDataPacket();
     const enc = new openpgp.SymEncryptedIntegrityProtectedDataPacket();
+    enc.version = 1;
     enc.packets = new openpgp.PacketList();
     enc.packets.push(literal);
     const msg = new openpgp.PacketList();
@@ -616,6 +617,7 @@ export default () => describe('Packet', function() {
       literal.setText(testText);
       const skesk = new openpgp.SymEncryptedSessionKeyPacket();
       const seip = new openpgp.SymEncryptedIntegrityProtectedDataPacket();
+      seip.version = 1;
       seip.packets = new openpgp.PacketList();
       seip.packets.push(literal);
       const msg = new openpgp.PacketList();

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -854,8 +854,36 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
   });
 
   it('Writing of unencrypted v5 secret key packet', async function() {
-    const originalV5KeysSetting = openpgp.config.v5Keys;
-    openpgp.config.v5Keys = true;
+    const packet = new openpgp.SecretKeyPacket();
+    packet.version = 5;
+    packet.privateParams = { key: new Uint8Array([1, 2, 3]) };
+    packet.publicParams = { pubKey: new Uint8Array([4, 5, 6]) };
+    packet.algorithm = openpgp.enums.publicKey.rsaSign;
+    packet.isEncrypted = false;
+    packet.s2kUsage = 0;
+
+    const written = packet.write();
+    expect(written.length).to.equal(28);
+
+    /* The serialized length of private data */
+    expect(written[17]).to.equal(0);
+    expect(written[18]).to.equal(0);
+    expect(written[19]).to.equal(0);
+    expect(written[20]).to.equal(5);
+
+    /**
+     * The private data
+     *
+     * The 2 bytes missing here are the length prefix of the MPI
+     */
+    expect(written[23]).to.equal(1);
+    expect(written[24]).to.equal(2);
+    expect(written[25]).to.equal(3);
+  });
+
+  it('Writing of unencrypted v6 secret key packet', async function() {
+    const originalv6KeysSetting = openpgp.config.v6Keys;
+    openpgp.config.v6Keys = true;
 
     try {
       const packet = new openpgp.SecretKeyPacket();
@@ -867,24 +895,18 @@ V+HOQJQxXJkVRYa3QrFUehiMzTeqqMdgC6ZqJy7+
       packet.s2kUsage = 0;
 
       const written = packet.write();
-      expect(written.length).to.equal(28);
-
-      /* The serialized length of private data */
-      expect(written[17]).to.equal(0);
-      expect(written[18]).to.equal(0);
-      expect(written[19]).to.equal(0);
-      expect(written[20]).to.equal(5);
+      expect(written.length).to.equal(21);
 
       /**
        * The private data
        *
        * The 2 bytes missing here are the length prefix of the MPI
        */
-      expect(written[23]).to.equal(1);
-      expect(written[24]).to.equal(2);
-      expect(written[25]).to.equal(3);
+      expect(written[18]).to.equal(1);
+      expect(written[19]).to.equal(2);
+      expect(written[20]).to.equal(3);
     } finally {
-      openpgp.config.v5Keys = originalV5KeysSetting;
+      openpgp.config.v6Keys = originalv6KeysSetting;
     }
   });
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -152,7 +152,7 @@ export default () => describe('Packet', function() {
     expect(await stringify(msg2[0].packets[0].data)).to.equal(stringify(literal.data));
   });
 
-  it('Sym. encrypted AEAD protected packet', function() {
+  it('Sym. encrypted AEAD protected packet (AEADP)', function() {
     const aeadProtectVal = openpgp.config.aeadProtect;
     openpgp.config.aeadProtect = false;
 
@@ -201,7 +201,7 @@ export default () => describe('Packet', function() {
     return cryptStub;
   }
 
-  it('Sym. encrypted AEAD protected packet is encrypted in parallel (AEAD, GCM)', async function() {
+  it('Sym. encrypted AEAD protected packet is encrypted in parallel (AEADP, GCM)', async function() {
     const webCrypto = util.getWebCrypto();
     if (!webCrypto || util.getNodeCrypto()) return;
     const encryptStub = cryptStub(webCrypto, 'encrypt');
@@ -236,7 +236,7 @@ export default () => describe('Packet', function() {
     }
   });
 
-  it('Sym. encrypted AEAD protected packet test vector (AEAD)', async function() {
+  it('AEAD Encrypted Data packet test vector (AEADP)', async function() {
     // From https://gitlab.com/openpgp-wg/rfc4880bis/commit/00b20923e6233fb6ff1666ecd5acfefceb32907d
 
     const nodeCrypto = util.getNodeCrypto();
@@ -516,7 +516,7 @@ export default () => describe('Packet', function() {
     }
   });
 
-  it('Sym. encrypted session key reading/writing test vector (EAX, AEAD)', async function() {
+  it('Sym. encrypted session key reading/writing test vector (AEAD, EAX)', async function() {
     // From https://gitlab.com/openpgp-wg/rfc4880bis/blob/00b20923/back.mkd#sample-aead-eax-encryption-and-decryption
 
     const nodeCrypto = util.getNodeCrypto();

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1365,6 +1365,47 @@ DAAKCRDyMVUMT0fjjlnQAQDFHUs6TIcxrNTtEZFjUFm1M0PJ1Dng/cDW4xN80fsn
     expect(notations[1].critical).to.be.false;
   });
 
+  it('Verify v6 cleartext signed message with openpgp.verify', async function() {
+    // test vector from https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-08.html#name-sample-v6-certificate-trans
+    const cleartextMessage = `-----BEGIN PGP SIGNED MESSAGE-----
+
+What we need from the grocery store:
+
+- - tofu
+- - vegetables
+- - noodles
+
+-----BEGIN PGP SIGNATURE-----
+
+wpgGARsKAAAAKQWCY5ijYyIhBssYbE8GCaaX5NUt+mxyKwwfHifBilZwj2Ul7Ce6
+2azJAAAAAGk2IHZJX1AhiJD39eLuPBgiUU9wUA9VHYblySHkBONKU/usJ9BvuAqo
+/FvLFuGWMbKAdA+epq7V4HOtAPlBWmU8QOd6aud+aSunHQaaEJ+iTFjP2OMW0KBr
+NK2ay45cX1IVAQ==
+-----END PGP SIGNATURE-----`;
+
+    const publicKey = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xioGY4d/4xsAAAAg+U2nu0jWCmHlZ3BqZYfQMxmZu52JGggkLq2EVD34laPCsQYf
+GwoAAABCBYJjh3/jAwsJBwUVCg4IDAIWAAKbAwIeCSIhBssYbE8GCaaX5NUt+mxy
+KwwfHifBilZwj2Ul7Ce62azJBScJAgcCAAAAAK0oIBA+LX0ifsDm185Ecds2v8lw
+gyU2kCcUmKfvBXbAf6rhRYWzuQOwEn7E/aLwIwRaLsdry0+VcallHhSu4RN6HWaE
+QsiPlR4zxP/TP7mhfVEe7XWPxtnMUMtf15OyA51YBM4qBmOHf+MZAAAAIIaTJINn
++eUBXbki+PSAld2nhJh/LVmFsS+60WyvXkQ1wpsGGBsKAAAALAWCY4d/4wKbDCIh
+BssYbE8GCaaX5NUt+mxyKwwfHifBilZwj2Ul7Ce62azJAAAAAAQBIKbpGG2dWTX8
+j+VjFM21J0hqWlEg+bdiojWnKfA5AQpWUWtnNwDEM0g12vYxoWM8Y81W+bHBw805
+I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
+-----END PGP PUBLIC KEY BLOCK-----` });
+
+    const plaintext = 'What we need from the grocery store:\n\n- tofu\n- vegetables\n- noodles\n';
+    const message = await openpgp.readCleartextMessage({ cleartextMessage });
+
+    const { signatures, data } = await openpgp.verify({ message, verificationKeys: publicKey });
+    expect(data).to.equal(plaintext);
+    expect(signatures).to.have.length(1);
+    expect(await signatures[0].verified).to.be.true;
+    expect((await signatures[0].signature).packets.length).to.equal(1);
+  });
+
   it('Verify cleartext signed message with two signatures with openpgp.verify', async function() {
     const cleartextMessage =
       ['-----BEGIN PGP SIGNED MESSAGE-----',

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -21,7 +21,7 @@ import {
 (async () => {
 
   // Generate keys
-  const keyOptions = { userIDs: [{ email: 'user@corp.co' }], config: { v5Keys: true } };
+  const keyOptions = { userIDs: [{ email: 'user@corp.co' }], config: { v6Keys: true } };
   const { privateKey: privateKeyArmored, publicKey: publicKeyArmored } = await generateKey(keyOptions);
   const { privateKey: privateKeyBinary } = await generateKey({ ...keyOptions, format: 'binary' });
   const { privateKey, publicKey, revocationCertificate } = await generateKey({ ...keyOptions, format: 'object' });


### PR DESCRIPTION
Implement the new packet versions from [draft-ietf-openpgp-crypto-refresh-08](https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-08).

Fixes part of #1442; replaces #1505.

TODO:

- [x] update AEAD-encryption mechanism for private keys
- [x] cross-check with go-crypto
- [x] rebase on top of Ed25519 update to then add test vectors from RFC
- [x] add changes from https://github.com/twiss/openpgpjs/pull/3
- [x] add config to support v4 keys with legacy AEAD mode (from werner's draft) -- TODO in separate PR
- [x] properly squash commits 
