### PR TITLE
Add `revoke` to `Subkey` in type definition

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -101,6 +101,7 @@ export class Subkey {
   public getExpirationTime(date?: Date, config?: Config): Promise<Date | typeof Infinity | null>
   public isRevoked(signature: SignaturePacket, key: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public update(subKey: Subkey, date?: Date, config?: Config): Promise<void>
+  public revoke(primaryKey: SecretKeyPacket, reasonForRevocation?: ReasonForRevocation, date?: Date, config?: Config): Promise<Subkey>;
 }
 
 export interface User {


### PR DESCRIPTION
This PR adds `Subkey.revoke` implemented in following to the type definition.
https://github.com/openpgpjs/openpgpjs/blob/v5.8.0/src/key/subkey.js#L86