### PR TITLE
TS: add declaration for `verify` with `CleartextMessage` input

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -228,18 +228,17 @@ export function decrypt<T extends MaybeStream<Data>>(options: DecryptOptions & {
   string
 }>;
 
-export function verify<T extends MaybeStream<Data>>(options: VerifyOptions & { message: Message<T>, format: 'binary' }): Promise<VerifyMessageResult & {
-  data:
+export function verify(options: VerifyOptions & { message: CleartextMessage, format?: 'utf8' }): Promise<VerifyMessageResult<string>>;
+export function verify<T extends MaybeStream<Data>>(options: VerifyOptions & { message: Message<T>, format: 'binary' }): Promise<VerifyMessageResult<
   T extends WebStream<infer X> ? WebStream<Uint8Array> :
   T extends NodeStream<infer X> ? NodeStream<Uint8Array> :
   Uint8Array
-}>;
-export function verify<T extends MaybeStream<Data>>(options: VerifyOptions & { message: Message<T> }): Promise<VerifyMessageResult & {
-  data:
+>>;
+export function verify<T extends MaybeStream<Data>>(options: VerifyOptions & { message: Message<T> }): Promise<VerifyMessageResult<
   T extends WebStream<infer X> ? WebStream<string> :
   T extends NodeStream<infer X> ? NodeStream<string> :
   string
-}>;
+>>;
 
 /** Class that represents an OpenPGP message.  Can be an encrypted message, signed message, compressed message or literal message
  */
@@ -721,8 +720,8 @@ interface DecryptMessageResult {
   filename: string;
 }
 
-interface VerifyMessageResult {
-  data: MaybeStream<Data>;
+interface VerifyMessageResult<T extends MaybeStream<Data> = MaybeStream<Data>> {
+  data: T;
   signatures: VerificationResult[];
 }
 

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -113,6 +113,12 @@ import {
 
   // Sign cleartext message (armored)
   const cleartextMessage = await createCleartextMessage({ text: 'hello' });
+  const verificationResult = await verify({ message: cleartextMessage, verificationKeys: publicKey });
+  const verifiedCleartextData: string = verificationResult.data;
+  expect(verifiedCleartextData).to.equal(cleartextMessage.getText());
+  // @ts-expect-error Binary output not available for cleartext messages
+  try { await verify({ message: cleartextMessage, verificationKeys: publicKey, format: 'binary' }) } catch (e) {}
+
   const clearSignedArmor = await sign({ signingKeys: privateKeys, message: cleartextMessage });
   expect(clearSignedArmor).to.include('-----BEGIN PGP SIGNED MESSAGE-----');
   const clearSignedObject: CleartextMessage = await sign({ signingKeys: privateKeys, message: cleartextMessage, format: 'object' });


### PR DESCRIPTION
Fix #1582 .
Also, make `VerifyMessageResult` generic. This change should be backwards compatible since a default type is set.