### PR TITLE
TS: Allow nullable date in VerifyOptions

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -657,7 +657,7 @@ interface VerifyOptions {
   /** (optional) detached signature for verification */
   signature?: Signature;
   /** (optional) use the given date for verification instead of the current time */
-  date?: Date;
+  date?: Date | null;
   config?: PartialConfig;
 }
 


### PR DESCRIPTION
It seems like the library allows passing `null` when calling `verify`, as it checks for null here
- https://github.com/openpgpjs/openpgpjs/blob/400b163f8411204f5de830b70e65fd86246cf933/src/key/helper.js#L73
- https://github.com/openpgpjs/openpgpjs/blob/400b163f8411204f5de830b70e65fd86246cf933/src/util.js#L78

but the TS declaration doesn't reflect that.