### PR TITLE
[v6] Add `config.parseAEADEncryptedV4KeysAsLegacy ` to support AEAD-encrypted v4 keys from OpenPGP.js v5 or older

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -56,6 +56,13 @@ export default {
    */
   aeadProtect: false,
   /**
+   * When reading private keys which were encrypted by OpenPGP.js v5 (or older) using `config.aeadProtect = true`
+   * and `config.v5Keys = false`, this option must be set, otherwise key parsing and/or key decryption will fail.
+   * Note: only set this flag if you know that the keys are of the legacy type, as non-legacy keys
+   * will be processed incorrectly.
+   */
+  parseAEADEncryptedV4KeysAsLegacy: false,
+  /**
    * Default Authenticated Encryption with Additional Data (AEAD) encryption mode
    * Only has an effect when aeadProtect is set to true.
    * @memberof module:config

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -56,8 +56,9 @@ export default {
    */
   aeadProtect: false,
   /**
-   * When reading private keys which were encrypted by OpenPGP.js v5 (or older) using `config.aeadProtect = true`
-   * and `config.v5Keys = false`, this option must be set, otherwise key parsing and/or key decryption will fail.
+   * When reading OpenPGP v4 private keys (e.g. those generated in OpenPGP.js when not setting `config.v5Keys = true`)
+   * which were encrypted by OpenPGP.js v5 (or older) using `config.aeadProtect = true`,
+   * this option must be set, otherwise key parsing and/or key decryption will fail.
    * Note: only set this flag if you know that the keys are of the legacy type, as non-legacy keys
    * will be processed incorrectly.
    */


### PR DESCRIPTION
This commit adds the config flag `parseAEADEncryptedV4KeysAsLegacy `.
When reading private keys which were encrypted by OpenPGP.js v5 (or older) using `config.aeadProtect = true` and `config.v5Keys = false`, this option must be set, otherwise key parsing and/or key decryption will fail.

OpenPGP.js up to v5 used to support encrypting v4 keys using AEAD as specified by draft RFC4880bis (https://www.ietf.org/archive/id/draft-ietf-openpgp-rfc4880bis-10.html#section-5.5.3-3.5).
The config option to do so was not initially marked as "experimental", so there is a risk that some apps have been using it in production.
This legacy format is incompatible, but fundamentally indistinguishable, from that of the crypto-refresh for v4 keys, merged in #1630 . If a key is parsed based on the wrong format, the parsing may still succeed, but key decryption will always fail.
Thus, we rely on the caller to instruct us to process the key as legacy, via the new config flag.

