### PR TITLE
[v6] Disregard `config.aeadProtect` when encrypting to public keys

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -42,12 +42,14 @@ export default {
    * @property {Integer} deflateLevel Default zip/zlib compression level, between 1 and 9
    */
   deflateLevel: 6,
-
   /**
    * Use Authenticated Encryption with Additional Data (AEAD) protection for symmetric encryption.
+   * This setting is relevant for:
+   * - key generation (encryption key preferences)
+   * - password-based message encryption
+   * - private key encryption
    * Note: not all OpenPGP implementations are compatible with this option.
-   * **FUTURE OPENPGP.JS VERSIONS MAY BREAK COMPATIBILITY WHEN USING THIS OPTION**
-   * @see {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-07|RFC4880bis-07}
+   * @see {@link https://tools.ietf.org/html/draft-ietf-openpgp-crypto-refresh-10.html|draft-crypto-refresh-10}
    * @memberof module:config
    * @property {Boolean} aeadProtect
    */

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -44,10 +44,11 @@ export default {
   deflateLevel: 6,
   /**
    * Use Authenticated Encryption with Additional Data (AEAD) protection for symmetric encryption.
-   * This setting is relevant for:
-   * - key generation (encryption key preferences)
-   * - password-based message encryption
-   * - private key encryption
+   * This option is applicable to:
+   * - key generation (encryption key preferences),
+   * - password-based message encryption, and
+   * - private key encryption.
+   * In the case of message encryption using public keys, the encryption key preferences are respected instead.
    * Note: not all OpenPGP implementations are compatible with this option.
    * @see {@link https://tools.ietf.org/html/draft-ietf-openpgp-crypto-refresh-10.html|draft-crypto-refresh-10}
    * @memberof module:config

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -179,7 +179,11 @@ export async function getPreferredCompressionAlgo(keys = [], date = new Date(), 
  */
 export async function getPreferredCipherSuite(keys = [], date = new Date(), userIDs = [], config = defaultConfig) {
   const selfSigs = await Promise.all(keys.map((key, i) => key.getPrimarySelfSignature(date, userIDs[i], config)));
-  if (config.aeadProtect && selfSigs.every(selfSig => selfSig.features[0] & enums.features.seipdv2)) {
+  const withAEAD = keys.length ?
+    selfSigs.every(selfSig => selfSig.features[0] & enums.features.seipdv2) :
+    config.aeadProtect;
+
+  if (withAEAD) {
     const defaultCipherSuite = { symmetricAlgo: enums.symmetric.aes128, aeadAlgo: enums.aead.ocb };
     const desiredCipherSuite = { symmetricAlgo: config.preferredSymmetricAlgorithm, aeadAlgo: config.preferredAEADAlgorithm };
     return selfSigs.every(selfSig => selfSig.preferredCipherSuites && selfSig.preferredCipherSuites.some(


### PR DESCRIPTION
Determine whether AEAD should be used for encryption solely based the encryption key preferences.
Previously, the config flag was also used to control the behaviour, since AEAD messages were not standardised nor widely supported.

To generate keys that declare AEAD in their preferences, use `generateKey` with `config.aeadProtect = true`.