### PR TITLE
Fix CFB decryption performance in JS fallback for ciphers other than AES

### DIFF
--- a/src/crypto/mode/cfb.js
+++ b/src/crypto/mode/cfb.js
@@ -119,7 +119,7 @@ export async function decrypt(algo, key, ciphertext, iv) {
     let j = 0;
     while (chunk ? ct.length >= block_size : ct.length) {
       const decblock = cipherfn.encrypt(blockp);
-      blockp = ct;
+      blockp = ct.subarray(0, block_size);
       for (i = 0; i < block_size; i++) {
         plaintext[j++] = blockp[i] ^ decblock[i];
       }


### PR DESCRIPTION
By calling the underlying cipher decryption function for one block at a time.
Before, the entire ciphertext was passed for decryption, but only a subset of it (equal to the block size) was actually processed in each iteration.
This resulted in a lot of extra work for e.g. Cast5 decryption, whose decryption function supported decrypting more than a block at once.

This issue affected non-AES ciphers (legacy), such as Cast5, in Node 18+ or in browser.

Fix #1668 .