### PR TITLE
[v6] Fix parsing of v6 signatures with unknown hash algorithm

### DIFF
--- a/src/crypto/hash/index.js
+++ b/src/crypto/hash/index.js
@@ -101,7 +101,7 @@ export default {
       case enums.hash.sha3_512:
         return this.sha3_512(data);
       default:
-        throw new Error('Invalid hash function.');
+        throw new Error('Unsupported hash function');
     }
   },
 

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -116,7 +116,7 @@ class OnePassSignaturePacket {
 
       // A one-octet salt size. The value MUST match the value defined
       // for the hash algorithm as specified in Table 23 (Hash algorithm registry).
-      // To allow parsing unknown hash algos, we only check the expected salt length when signing.
+      // To allow parsing unknown hash algos, we only check the expected salt length when verifying.
       const saltLength = bytes[mypos++];
 
       // The salt; a random value value of the specified size.

--- a/src/packet/one_pass_signature.js
+++ b/src/packet/one_pass_signature.js
@@ -16,7 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import * as stream from '@openpgp/web-stream-tools';
-import SignaturePacket, { saltLengthForHash } from './signature';
+import SignaturePacket from './signature';
 import KeyID from '../type/keyid';
 import enums from '../enums';
 import util from '../util';
@@ -116,10 +116,8 @@ class OnePassSignaturePacket {
 
       // A one-octet salt size. The value MUST match the value defined
       // for the hash algorithm as specified in Table 23 (Hash algorithm registry).
+      // To allow parsing unknown hash algos, we only check the expected salt length when signing.
       const saltLength = bytes[mypos++];
-      if (saltLength !== saltLengthForHash(this.hashAlgorithm)) {
-        throw new Error('Unexpected salt size for the hash algorithm');
-      }
 
       // The salt; a random value value of the specified size.
       this.salt = bytes.subarray(mypos, mypos + saltLength);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -697,6 +697,11 @@ class SignaturePacket {
   }
 
   async hash(signatureType, data, toHash, detached = false) {
+    if (this.version === 6 && this.salt.length !== saltLengthForHash(this.hashAlgorithm)) {
+      // avoid hashing unexpected salt size
+      throw new Error('Signature salt does not have the expected length');
+    }
+
     if (!toHash) toHash = this.toHash(signatureType, data, detached);
     return crypto.hash.digest(this.hashAlgorithm, toHash);
   }
@@ -719,9 +724,6 @@ class SignaturePacket {
     }
     if (this.publicKeyAlgorithm !== key.algorithm) {
       throw new Error('Public key algorithm used to sign signature does not match issuer key algorithm.');
-    }
-    if (this.version === 6 && this.salt.length !== saltLengthForHash(this.hashAlgorithm)) {
-      throw new Error('Signature salt does not have the expected length');
     }
 
     const isMessageSignature = signatureType === enums.signature.binary || signatureType === enums.signature.text;
@@ -836,6 +838,6 @@ function saltLengthForHash(hashAlgorithm) {
     case enums.hash.sha224: return 16;
     case enums.hash.sha3_256: return 16;
     case enums.hash.sha3_512: return 32;
-    default: throw new Error('Unsupported hash function for V6 signatures');
+    default: throw new Error('Unsupported hash function');
   }
 }

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -812,7 +812,7 @@ OiDfb1DkjT/HJ8vXMGpwWdgFPoqsWzTNhd5VCQ==
 -----END PGP PRIVATE KEY BLOCK-----`;
 
     const key = await openpgp.readKey({ armoredKey });
-    await expect(key.getSigningKey()).to.be.rejectedWith(/Invalid hash function/);
+    await expect(key.getSigningKey()).to.be.rejectedWith(/Unsupported hash function/);
   });
 
   it('Ignores marker packets when verifying signatures', async function () {
@@ -939,9 +939,7 @@ SlcdMBDgwngEGBYIAAkFAmFppjQCGwwAIQkQDmTSjoPv10MWIQRqj/4SGmAk
 ibGeE60OZNKOg+/XQx/EAQCM0UYrObp60YbOCxu07Dm6XjCVylbOcsaxCnE7
 2eMU4AD+OkgajZgbqSIdAR1ud76FW+W+3xlDi/SMFdU7D49SbQI=
 =ASQu
------END PGP PRIVATE KEY BLOCK-----
-
-`;
+-----END PGP PRIVATE KEY BLOCK-----`;
     const armoredMessage = `-----BEGIN PGP MESSAGE-----
 
 xA0DAQoWDmTSjoPv10MByw91AGFpplFwbGFpbnRleHTCdQQBFgoABgUCYWml


### PR DESCRIPTION
Fail on verification rather than parsing, also for unexpected salt size.

Follow up to #1630 , #1656 .