### PR TITLE
Add sha3_256 and sha3_512 to preferred algorithms

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -782,7 +782,7 @@ export namespace enums {
     bzip2 = 3,
   }
 
-  export type hashNames = 'md5' | 'sha1' | 'ripemd' | 'sha256' | 'sha384' | 'sha512' | 'sha224';
+  export type hashNames = 'md5' | 'sha1' | 'ripemd' | 'sha256' | 'sha384' | 'sha512' | 'sha224' | 'sha3_256' | 'sha3_512';
   enum hash {
     md5 = 1,
     sha1 = 2,
@@ -791,6 +791,8 @@ export namespace enums {
     sha384 = 9,
     sha512 = 10,
     sha224 = 11,
+    sha3_256 = 12,
+    sha3_512 = 14
   }
 
   export type packetNames = 'publicKeyEncryptedSessionKey' | 'signature' | 'symEncryptedSessionKey' | 'onePassSignature' | 'secretKey' | 'publicKey'

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -216,7 +216,9 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
     signatureProperties.preferredHashAlgorithms = createPreferredAlgos([
       // prefer fast asm.js implementations (SHA-256)
       enums.hash.sha256,
-      enums.hash.sha512
+      enums.hash.sha512,
+      enums.hash.sha3_256,
+      enums.hash.sha3_512
     ], config.preferredHashAlgorithm);
     signatureProperties.preferredCompressionAlgorithms = createPreferredAlgos([
       enums.compression.uncompressed

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2262,7 +2262,7 @@ function versionSpecificTests() {
         ]);
       }
       const hash = openpgp.enums.hash;
-      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512]);
+      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512, hash.sha3_256, hash.sha3_512]);
       const compr = openpgp.enums.compression;
       expect(selfSignature.preferredCompressionAlgorithms).to.eql([compr.uncompressed]);
 
@@ -2317,7 +2317,7 @@ function versionSpecificTests() {
         ]);
       }
       const hash = openpgp.enums.hash;
-      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha224, hash.sha256, hash.sha512]);
+      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha224, hash.sha256, hash.sha512, hash.sha3_256, hash.sha3_512]);
       const compr = openpgp.enums.compression;
       expect(selfSignature.preferredCompressionAlgorithms).to.eql([compr.zlib, compr.uncompressed]);
 


### PR DESCRIPTION
This change adds sha3_256 and sha3_512 to the preferred algorithm list at the end as I discussed with twiss. According to the [NIST SHA3 publication](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf), both SHA3-256 and SHA3-512 have at the least equivalent security in terms of collision resistance, preimage resistance, and second preimage resistance as their SHA2 counterparts.

![Screenshot_20231028_141844](https://github.com/openpgpjs/openpgpjs/assets/20050820/7cb60068-c21b-4b41-9ab1-a5e4e830b0f3)

However, from my current understanding, I don't believe that there is currently a security reason to switch to using SHA3 as the default algorithm. I personally ran some performance benchmarks comparing the implementations of SHA-256 and SHA3-256  in Noble Hashes and found that SHA2 was faster for small, mid-sized, and large messages. Since SHA2 is also available in WebCrypto whereas SHA3 is currently not, that performance difference could end up becoming even larger in the real world. So, it probably makes sense to stick with SHA2 as the default algorithm for now! However, I think that adding SHA3 as a preferred algorithm is still wise in order to make it easy to switch in the future in case a security problem is ever discovered with SHA2.

Some of my bench-marking results in Chrome:
```
main.js:2 Running noble hashes benchmarks...
main.js:2 Noble_SHA_256_100B_msg x 227,324 ops/sec ±1.32% (64 runs sampled)
main.js:2 Noble_SHA3_256_100B_msg x 99,991 ops/sec ±1.15% (63 runs sampled)
main.js:2 Fastest is Noble_SHA_256_100B_msg

main.js:2 Noble_SHA_256_1kB_msg x 54,951 ops/sec ±1.31% (64 runs sampled)
main.js:2 Noble_SHA3_256_1kB_msg x 14,828 ops/sec ±0.94% (65 runs sampled)
main.js:2 Fastest is Noble_SHA_256_1kB_msg

main.js:2 Noble_SHA_256_1MB_msg x 62.54 ops/sec ±0.50% (55 runs sampled)
main.js:2 Noble_SHA3_256_1MB_msg x 14.55 ops/sec ±5.43% (29 runs sampled)
main.js:2 Fastest is Noble_SHA_256_1MB_msg
```

Also, unit tests are working now. :)

Two questions that I have would be 1. are the changes to openpgp.d.ts adequate? and 2. would any additional unit tests be required for these changes?