### PR TITLE
[v6] Use Compression Stream API when available, drop `config.deflateLevel`

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -323,7 +323,6 @@ interface Config {
   preferredCompressionAlgorithm: enums.compression;
   showVersion: boolean;
   showComment: boolean;
-  deflateLevel: number;
   aeadProtect: boolean;
   allowUnauthenticatedMessages: boolean;
   allowUnauthenticatedStream: boolean;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -38,11 +38,6 @@ export default {
    */
   preferredCompressionAlgorithm: enums.compression.uncompressed,
   /**
-   * @memberof module:config
-   * @property {Integer} deflateLevel Default zip/zlib compression level, between 1 and 9
-   */
-  deflateLevel: 6,
-  /**
    * Use Authenticated Encryption with Additional Data (AEAD) protection for symmetric encryption.
    * This option is applicable to:
    * - key generation (encryption key preferences),

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -278,8 +278,7 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
 
       const config = {
         aeadProtect: true,
-        preferredCompressionAlgorithm: openpgp.enums.compression.zip,
-        deflateLevel: 1
+        preferredCompressionAlgorithm: openpgp.enums.compression.zip
       };
       const armored2 = await openpgp.encrypt({ message, passwords, config });
       const encrypted2 = await openpgp.readMessage({ armoredMessage: armored2 });


### PR DESCRIPTION
The Compression Stream API is now implemented on all platforms: https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API .

Breaking change: `config.deflateLevel` has been dropped. The Compression Stream API does not accept a deflate level in input, and since using compression is now discouraged on security grounds, we drop the config option altogether.

- [x] merge after #1716 