### PR TITLE
[v6] Ensure primary key meets strength and algo requirements when encrypting/verifying/signing using subkeys

### DIFF
--- a/src/key/key.js
+++ b/src/key/key.js
@@ -257,8 +257,8 @@ class Key {
    * @async
    */
   async getSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
-    const primaryKey = this.keyPacket;
     await this.verifyPrimaryKey(date, userID, config);
+    const primaryKey = this.keyPacket;
     try {
       helper.checkKeyRequirements(primaryKey, config);
     } catch (err) {
@@ -316,8 +316,8 @@ class Key {
    * @async
    */
   async getEncryptionKey(keyID, date = new Date(), userID = {}, config = defaultConfig) {
-    const primaryKey = this.keyPacket;
     await this.verifyPrimaryKey(date, userID, config);
+    const primaryKey = this.keyPacket;
     try {
       helper.checkKeyRequirements(primaryKey, config);
     } catch (err) {

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -257,8 +257,13 @@ class Key {
    * @async
    */
   async getSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
-    await this.verifyPrimaryKey(date, userID, config);
     const primaryKey = this.keyPacket;
+    await this.verifyPrimaryKey(date, userID, config);
+    try {
+      helper.checkKeyRequirements(primaryKey, config);
+    } catch (err) {
+      throw util.wrapError('Could not verify primary key', err);
+    }
     const subkeys = this.subkeys.slice().sort((a, b) => b.keyPacket.created - a.keyPacket.created);
     let exception;
     for (const subkey of subkeys) {
@@ -311,8 +316,13 @@ class Key {
    * @async
    */
   async getEncryptionKey(keyID, date = new Date(), userID = {}, config = defaultConfig) {
-    await this.verifyPrimaryKey(date, userID, config);
     const primaryKey = this.keyPacket;
+    await this.verifyPrimaryKey(date, userID, config);
+    try {
+      helper.checkKeyRequirements(primaryKey, config);
+    } catch (err) {
+      throw util.wrapError('Could not verify primary key', err);
+    }
     // V4: by convention subkeys are preferred for encryption service
     const subkeys = this.subkeys.slice().sort((a, b) => b.keyPacket.created - a.keyPacket.created);
     let exception;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4284,11 +4284,9 @@ VYGdb3eNlV8CfoEC
 
   it('Reject encryption with key revoked with appended revocation cert', async function() {
     const key = await openpgp.readKey({ armoredKey: pub_revoked_with_cert });
-    return openpgp.encrypt({ encryptionKeys: [key], message: await openpgp.createMessage({ text: 'random data' }) }).then(() => {
-      throw new Error('encryptSessionKey should not encrypt with revoked public key');
-    }).catch(function(error) {
-      expect(error.message).to.equal('Error encrypting message: Primary key is revoked');
-    });
+    await expect(
+      openpgp.encrypt({ encryptionKeys: [key], message: await openpgp.createMessage({ text: 'random data' }) })
+    ).to.be.rejectedWith(/Primary key is revoked/);
   });
 
   it('Merge key with another key with non-ID user attributes', async function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -3990,7 +3990,7 @@ XfA3pqV4mTzF
           }).then(function() {
             throw new Error('Should not encrypt with revoked key');
           }).catch(function(error) {
-            expect(error.message).to.match(/Error encrypting message: Primary key is revoked/);
+            expect(error.message).to.match(/Primary key is revoked/);
           });
         });
       });

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -895,7 +895,8 @@ DQmhI0SZoTKy4EGhS0bNJ+g2+dJ8Y22fKzLWXwo=
     await expect(openpgp.sign({
       signingKeys: key,
       date: new Date(key.keyPacket.created - 3600),
-      message: await openpgp.createMessage({ text: 'Hello World' })
+      message: await openpgp.createMessage({ text: 'Hello World' }),
+      config: { minRSABits: 1024 }
     })).to.be.rejectedWith(/Signature creation time is in the future/);
   });
 


### PR DESCRIPTION
Fix #1608: the requirements of `config.minRSABits`, `rejectPublicKeyAlgorithms` and `rejectCurves`
are now applied to the primary key, aside from the selected subkey. This is a breaking change.

The motivation is that the subkeys are certified by the primary key, but if the latter is
weak, arbitrary subkeys could potentially be added.

Note that the change does not affect decryption, to allow decrypting older messages.