### PR TITLE
Use JS fallback code for RSA decryption on Node if PKCS#1 is not supported

### DIFF
--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -1188,7 +1188,7 @@ Fk7EflUZzngwY4lBzYAfnNBjEjc30xD/ddo+rwE=
       ],
       config
     });
-    expect(openpgp.decrypt({
+    await expect(openpgp.decrypt({
       message: await openpgp.readMessage({ armoredMessage: message_with_notation }),
       decryptionKeys: privKey,
       verificationKeys: privKey,


### PR DESCRIPTION
Fix for #1727, necessary as Node v18.19.1, 20.11.1 and 21.6.2 have disabled support for PKCS#1 decryption.
