### PR TITLE
[v6] Drop `config.revocationsExpire`, always honour revocation expiration instead

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -328,7 +328,6 @@ interface Config {
   allowUnauthenticatedStream: boolean;
   minRSABits: number;
   passwordCollisionCheck: boolean;
-  revocationsExpire: boolean;
   ignoreUnsupportedPackets: boolean;
   ignoreMalformedPackets: boolean;
   versionString: string;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -156,11 +156,6 @@ export default {
    */
   passwordCollisionCheck: false,
   /**
-   * @memberof module:config
-   * @property {Boolean} revocationsExpire If true, expired revocation signatures are ignored
-   */
-  revocationsExpire: false,
-  /**
    * Allow decryption using RSA keys without `encrypt` flag.
    * This setting is potentially insecure, but it is needed to get around an old openpgpjs bug
    * where key flags were ignored when selecting a key for encryption.

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -282,7 +282,7 @@ export async function isDataRevoked(primaryKey, signatureType, dataToVerify, rev
         !signature || revocationSignature.issuerKeyID.equals(signature.issuerKeyID)
       ) {
         await revocationSignature.verify(
-          key, signatureType, dataToVerify, config.revocationsExpire ? date : null, false, config
+          key, signatureType, dataToVerify, date, false, config
         );
 
         // TODO get an identifier of the revoked object instead

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4275,7 +4275,8 @@ VYGdb3eNlV8CfoEC
     const key = await openpgp.readKey({ armoredKey: pub_revoked_subkeys });
     key.revocationSignatures = [];
     key.users[0].revocationSignatures = [];
-    return openpgp.encrypt({ encryptionKeys: [key], message: await openpgp.createMessage({ text: 'random data' }), date: new Date(1386842743000) }).then(() => {
+    const subkeyRevocationTime = key.subkeys[0].revocationSignatures[0].created;
+    return openpgp.encrypt({ encryptionKeys: [key], message: await openpgp.createMessage({ text: 'random data' }), date: subkeyRevocationTime }).then(() => {
       throw new Error('encryptSessionKey should not encrypt with revoked public key');
     }).catch(error => {
       expect(error.message).to.equal('Error encrypting message: Could not find valid encryption key packet in key ' + key.getKeyID().toHex() + ': Subkey is revoked');


### PR DESCRIPTION
Unclear motivation for adding the original config option; if an expiration is there, it should be honoured.

Breaking change:
the option used to default to `false`, and ignore revocation expirations. We now honour those expirations, namely match the behaviour resulting from setting the option to `true`.