### PR TITLE
[v6] Fix email address validity check to still allow unicode values, and further relax constraints

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -465,16 +465,19 @@ const util = {
   },
 
   /**
-   * Test email format based on W3C HTML5 specification.
-   * This check is not exaustive, and does not match RFC 5322 exactly
-   * (see https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)),
-   * but is commonly used for email address validation.
+   * Test email format to ensure basic compliance:
+   * - must include a single @
+   * - no control or space unicode chars allowed
+   * - no backslash and square brackets (as the latter can mess with the userID parsing)
+   * - cannot end with a punctuation char
+   * These checks are not meant to be exhaustive; applications are strongly encouraged to implement stricter validation,
+   * e.g. based on the W3C HTML spec (https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)).
    */
   isEmailAddress: function(data) {
     if (!util.isString(data)) {
       return false;
     }
-    const re = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+    const re = /^[^\p{C}\p{Z}@<>\\]+@[^\p{C}\p{Z}@<>\\]+[^\p{C}\p{Z}\p{P}]$/u;
     return re.test(data);
   },
 

--- a/test/general/util.js
+++ b/test/general/util.js
@@ -120,12 +120,28 @@ export default () => describe('Util unit tests', function() {
       const data = 'test@localhost';
       expect(util.isEmailAddress(data)).to.be.true;
     });
+    it('should return true for valid email address (unicode chars)', function() {
+      const data = '🙂@localhost';
+      expect(util.isEmailAddress(data)).to.be.true;
+    });
     it('should return false for invalid email address (full userID)', function() {
       const data = 'Test User <test@example.com>';
       expect(util.isEmailAddress(data)).to.be.false;
     });
     it('should return false for invalid email address (missing @)', function() {
       const data = 'testexamplecom';
+      expect(util.isEmailAddress(data)).to.be.false;
+    });
+    it('should return false for invalid email address (invisible unicode control char)', function() {
+      const data = 'test\u{feff}ctrl@email.it';
+      expect(util.isEmailAddress(data)).to.be.false;
+    });
+    it('should return false for invalid email address (trailing punctuation)', function() {
+      const data = 'test@localhost.';
+      expect(util.isEmailAddress(data)).to.be.false;
+    });
+    it('should return false for invalid email address (including whitespace)', function() {
+      const data = 'test space@email.it';
       expect(util.isEmailAddress(data)).to.be.false;
     });
     it('should return false for empty string', function() {


### PR DESCRIPTION
Fix #1641 to accept unicode chars, which were previously allowed.

We also drop almost all email address constraints, by primarily rejecting control and spaces char classes.
Library users are strongly encouraged to implement additional checks as needed, based on their supported email address format.

NB: the validity checks in question affect the userID inputs accepted by e.g. `generateKey` and `reformatKey`, not the values parsed from existing entities, e.g. using `readKey` (where almost no validation is performed).
