### PR TITLE
[v6] Better error messages for unexpected ECDSA, EdDSALegacy, ECDH param encodings in keys and PKESK

### DIFF
--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -171,6 +171,9 @@ export function parsePublicKeyParams(algo, bytes) {
     case enums.publicKey.eddsaLegacy: {
       const oid = new OID(); read += oid.read(bytes);
       checkSupportedCurve(oid);
+      if (oid.getName() !== enums.curve.ed25519Legacy) {
+        throw new Error('Unexpected OID for eddsaLegacy');
+      }
       let Q = util.readMPI(bytes.subarray(read)); read += Q.length + 2;
       Q = util.leftPad(Q, 33);
       return { read: read, publicParams: { oid, Q } };
@@ -227,6 +230,9 @@ export function parsePrivateKeyParams(algo, bytes, publicParams) {
     }
     case enums.publicKey.eddsaLegacy: {
       const payloadSize = getCurvePayloadSize(algo, publicParams.oid);
+      if (publicParams.oid.getName() !== enums.curve.ed25519Legacy) {
+        throw new Error('Unexpected OID for eddsaLegacy');
+      }
       let seed = util.readMPI(bytes.subarray(read)); read += seed.length + 2;
       seed = util.leftPad(seed, payloadSize);
       return { read, privateParams: { seed } };

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -95,7 +95,7 @@ async function genPublicEphemeralKey(curve, Q) {
       const d = getRandomBytes(32);
       const { secretKey, sharedKey } = await genPrivateEphemeralKey(curve, Q, null, d);
       let { publicKey } = nacl.box.keyPair.fromSecretKey(secretKey);
-      publicKey = util.concatUint8Array([new Uint8Array([0x40]), publicKey]);
+      publicKey = util.concatUint8Array([new Uint8Array([curve.wireFormatLeadingByte]), publicKey]);
       return { publicKey, sharedKey }; // Note: sharedKey is little-endian here, unlike below
     }
     case 'web':
@@ -327,7 +327,7 @@ async function webPublicEphemeralKey(curve, Q) {
   );
   [s, p] = await Promise.all([s, p]);
   const sharedKey = new Uint8Array(s);
-  const publicKey = new Uint8Array(jwkToRawPublic(p));
+  const publicKey = new Uint8Array(jwkToRawPublic(p, curve.wireFormatLeadingByte));
   return { publicKey, sharedKey };
 }
 

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -131,6 +131,7 @@ export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
   const m = pkcs5.encode(data);
 
   const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(oid, Q);
   const { publicKey, sharedKey } = await genPublicEphemeralKey(curve, Q);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipherParams(kdfParams.cipher);
@@ -193,6 +194,7 @@ async function genPrivateEphemeralKey(curve, V, Q, d) {
  */
 export async function decrypt(oid, kdfParams, V, C, Q, d, fingerprint) {
   const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(oid, Q);
   checkPublicPointEnconding(oid, V);
   const { sharedKey } = await genPrivateEphemeralKey(curve, V, Q, d);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -21,7 +21,7 @@
  */
 
 import nacl from '@openpgp/tweetnacl';
-import { CurveWithOID, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams } from './oid_curves';
+import { CurveWithOID, jwkToRawPublic, rawPublicToJWK, privateToJWK, validateStandardParams, checkPublicPointEnconding } from './oid_curves';
 import * as aesKW from '../../aes_kw';
 import { getRandomBytes } from '../../random';
 import hash from '../../hash';
@@ -193,6 +193,7 @@ async function genPrivateEphemeralKey(curve, V, Q, d) {
  */
 export async function decrypt(oid, kdfParams, V, C, Q, d, fingerprint) {
   const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(oid, V);
   const { sharedKey } = await genPrivateEphemeralKey(curve, V, Q, d);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipherParams(kdfParams.cipher);

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -131,7 +131,7 @@ export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
   const m = pkcs5.encode(data);
 
   const curve = new CurveWithOID(oid);
-  checkPublicPointEnconding(oid, Q);
+  checkPublicPointEnconding(curve, Q);
   const { publicKey, sharedKey } = await genPublicEphemeralKey(curve, Q);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipherParams(kdfParams.cipher);
@@ -194,8 +194,8 @@ async function genPrivateEphemeralKey(curve, V, Q, d) {
  */
 export async function decrypt(oid, kdfParams, V, C, Q, d, fingerprint) {
   const curve = new CurveWithOID(oid);
-  checkPublicPointEnconding(oid, Q);
-  checkPublicPointEnconding(oid, V);
+  checkPublicPointEnconding(curve, Q);
+  checkPublicPointEnconding(curve, V);
   const { sharedKey } = await genPrivateEphemeralKey(curve, V, Q, d);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipherParams(kdfParams.cipher);

--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -46,7 +46,7 @@ const nodeCrypto = util.getNodeCrypto();
  */
 export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed) {
   const curve = new CurveWithOID(oid);
-  checkPublicPointEnconding(oid, publicKey);
+  checkPublicPointEnconding(curve, publicKey);
   if (message && !util.isStream(message)) {
     const keyPair = { publicKey, privateKey };
     switch (curve.type) {
@@ -93,7 +93,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
  */
 export async function verify(oid, hashAlgo, signature, message, publicKey, hashed) {
   const curve = new CurveWithOID(oid);
-  checkPublicPointEnconding(oid, publicKey);
+  checkPublicPointEnconding(curve, publicKey);
   // See https://github.com/openpgpjs/openpgpjs/pull/948.
   // NB: the impact was more likely limited to Brainpool curves, since thanks
   // to WebCrypto availability, NIST curve should not have been affected.

--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -24,7 +24,7 @@ import enums from '../../../enums';
 import util from '../../../util';
 import { getRandomBytes } from '../../random';
 import hash from '../../hash';
-import { CurveWithOID, webCurves, privateToJWK, rawPublicToJWK, validateStandardParams, nodeCurves } from './oid_curves';
+import { CurveWithOID, webCurves, privateToJWK, rawPublicToJWK, validateStandardParams, nodeCurves, checkPublicPointEnconding } from './oid_curves';
 import { bigIntToUint8Array } from '../../biginteger';
 
 const webCrypto = util.getWebCrypto();
@@ -46,6 +46,7 @@ const nodeCrypto = util.getNodeCrypto();
  */
 export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed) {
   const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(oid, publicKey);
   if (message && !util.isStream(message)) {
     const keyPair = { publicKey, privateKey };
     switch (curve.type) {
@@ -92,6 +93,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
  */
 export async function verify(oid, hashAlgo, signature, message, publicKey, hashed) {
   const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(oid, publicKey);
   // See https://github.com/openpgpjs/openpgpjs/pull/948.
   // NB: the impact was more likely limited to Brainpool curves, since thanks
   // to WebCrypto availability, NIST curve should not have been affected.

--- a/src/crypto/public_key/elliptic/eddsa_legacy.js
+++ b/src/crypto/public_key/elliptic/eddsa_legacy.js
@@ -25,7 +25,7 @@ import nacl from '@openpgp/tweetnacl';
 import util from '../../../util';
 import enums from '../../../enums';
 import hash from '../../hash';
-import { checkPublicPointEnconding } from './oid_curves';
+import { CurveWithOID, checkPublicPointEnconding } from './oid_curves';
 
 /**
  * Sign a message using the provided legacy EdDSA key
@@ -42,7 +42,8 @@ import { checkPublicPointEnconding } from './oid_curves';
  * @async
  */
 export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed) {
-  checkPublicPointEnconding(oid, publicKey);
+  const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(curve, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
     // see https://tools.ietf.org/id/draft-ietf-openpgp-rfc4880bis-10.html#section-15-7.2
     throw new Error('Hash algorithm too weak for EdDSA.');
@@ -69,7 +70,8 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
  * @async
  */
 export async function verify(oid, hashAlgo, { r, s }, m, publicKey, hashed) {
-  checkPublicPointEnconding(oid, publicKey);
+  const curve = new CurveWithOID(oid);
+  checkPublicPointEnconding(curve, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
     throw new Error('Hash algorithm too weak for EdDSA.');
   }

--- a/src/crypto/public_key/elliptic/eddsa_legacy.js
+++ b/src/crypto/public_key/elliptic/eddsa_legacy.js
@@ -25,6 +25,7 @@ import nacl from '@openpgp/tweetnacl';
 import util from '../../../util';
 import enums from '../../../enums';
 import hash from '../../hash';
+import { checkPublicPointEnconding } from './oid_curves';
 
 /**
  * Sign a message using the provided legacy EdDSA key
@@ -41,6 +42,7 @@ import hash from '../../hash';
  * @async
  */
 export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed) {
+  checkPublicPointEnconding(oid, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
     // see https://tools.ietf.org/id/draft-ietf-openpgp-rfc4880bis-10.html#section-15-7.2
     throw new Error('Hash algorithm too weak for EdDSA.');
@@ -67,6 +69,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
  * @async
  */
 export async function verify(oid, hashAlgo, { r, s }, m, publicKey, hashed) {
+  checkPublicPointEnconding(oid, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
     throw new Error('Hash algorithm too weak for EdDSA.');
   }

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -282,9 +282,8 @@ async function validateStandardParams(algo, oid, Q, d) {
  * Check whether the public point has a valid encoding.
  * NB: this function does not check e.g. whether the point belongs to the curve.
  */
-function checkPublicPointEnconding(oid, V) {
-  const curveName = oid.getName();
-  const { payloadSize, wireFormatLeadingByte } = curves[curveName];
+function checkPublicPointEnconding(curve, V) {
+  const { payloadSize, wireFormatLeadingByte, name: curveName } = curve;
 
   const pointSize = (curveName === enums.curve.curve25519Legacy || curveName === enums.curve.ed25519Legacy) ? payloadSize : payloadSize * 2;
 


### PR DESCRIPTION
We got a report of a message including a PKESK packet where the ECDH x25519Legacy public point was missing the leading byte (0x40).
While decryption would naturally fail afterwards, this change ensures we fail sooner, with a clearer error message, and do not blindly pass down invalid data to the low-level crypto functions.
Note that such errors involving EC point encoding issues are thrown on usage, not on parsing.

Also, for EdDSALegacy, we now throw on key parsing in case of unexpected OID.

All of the above are technically breaking changes, but only for invalid data malformed in specific ways.
They are not to be considered security fixes, and are primarily aimed at helping debug.