### PR TITLE
`openpgp.verify`: fix bug preventing verification of detached signatures over streamed data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@openpgp/pako": "^1.0.12",
         "@openpgp/seek-bzip": "^1.0.5-git",
         "@openpgp/tweetnacl": "^1.0.3",
-        "@openpgp/web-stream-tools": "0.0.11-patch-0",
+        "@openpgp/web-stream-tools": "0.0.11-patch-1",
         "@rollup/plugin-commonjs": "^11.1.0",
         "@rollup/plugin-node-resolve": "^7.1.3",
         "@rollup/plugin-replace": "^2.3.2",
@@ -716,9 +716,9 @@
       "dev": true
     },
     "node_modules/@openpgp/web-stream-tools": {
-      "version": "0.0.11-patch-0",
-      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.11-patch-0.tgz",
-      "integrity": "sha512-NrIF4DkCqC3WDcMDAgz17z+0Iik1fVrKuvdbjZXCnMZgYAWHpIG8CWnbp8yQRahAdF26jqCopA/qXrp8CYI2yw==",
+      "version": "0.0.11-patch-1",
+      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.11-patch-1.tgz",
+      "integrity": "sha512-sZkx4FsHGFPcGrEBmBLvg0PcFBgR7KWe+NXo3SI/e+gpVoK3rPzPgv4TpI3UFKiXrohaJyY/klf24tNbJCutBA==",
       "dev": true,
       "dependencies": {
         "@mattiasbuelens/web-streams-adapter": "~0.1.0",
@@ -8036,9 +8036,9 @@
       "dev": true
     },
     "@openpgp/web-stream-tools": {
-      "version": "0.0.11-patch-0",
-      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.11-patch-0.tgz",
-      "integrity": "sha512-NrIF4DkCqC3WDcMDAgz17z+0Iik1fVrKuvdbjZXCnMZgYAWHpIG8CWnbp8yQRahAdF26jqCopA/qXrp8CYI2yw==",
+      "version": "0.0.11-patch-1",
+      "resolved": "https://registry.npmjs.org/@openpgp/web-stream-tools/-/web-stream-tools-0.0.11-patch-1.tgz",
+      "integrity": "sha512-sZkx4FsHGFPcGrEBmBLvg0PcFBgR7KWe+NXo3SI/e+gpVoK3rPzPgv4TpI3UFKiXrohaJyY/klf24tNbJCutBA==",
       "dev": true,
       "requires": {
         "@mattiasbuelens/web-streams-adapter": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@openpgp/pako": "^1.0.12",
     "@openpgp/seek-bzip": "^1.0.5-git",
     "@openpgp/tweetnacl": "^1.0.3",
-    "@openpgp/web-stream-tools": "0.0.11-patch-0",
+    "@openpgp/web-stream-tools": "0.0.11-patch-1",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -480,7 +480,7 @@ export async function verify({ message, verificationKeys, expectSigned = false, 
       result.signatures = await message.verify(verificationKeys, date, config);
     }
     result.data = format === 'binary' ? message.getLiteralData() : message.getText();
-    if (message.fromStream) linkStreams(result, message);
+    if (message.fromStream && !signature) linkStreams(result, message);
     if (expectSigned) {
       if (result.signatures.length === 0) {
         throw new Error('Message is not signed');


### PR DESCRIPTION
Fix #1706 : when given a streamed `message` and a detached `signature` in input, the function would return an empty array as `data` instead of the input stream, meaning it was not possible to pull it, causing the `verified` promise to hang indefinitely.

The above issue was introduced v5.0.0-2 (side effect of ff8d274b4d5b558c3a50c07f3262cff0527c1683), and thus affects all v5 releases up to v5.11.1 (included).