### PR TITLE
[v6] Use noble-ed25519 instead of tweetnacl for signature verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "LGPL-3.0+",
       "devDependencies": {
         "@noble/curves": "^1.4.0",
+        "@noble/ed25519": "^1.7.3",
         "@noble/hashes": "^1.4.0",
         "@openpgp/asmcrypto.js": "^3.1.0",
         "@openpgp/jsdoc": "^3.6.11",
@@ -812,6 +813,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -9049,6 +9062,12 @@
       "requires": {
         "@noble/hashes": "1.4.0"
       }
+    },
+    "@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true
     },
     "@noble/hashes": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@noble/curves": "^1.4.0",
+    "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.4.0",
     "@openpgp/asmcrypto.js": "^3.1.0",
     "@openpgp/jsdoc": "^3.6.11",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,6 +71,13 @@ export default Object.assign([
         ignore: nodeBuiltinModules.concat(nodeDependencies)
       }),
       replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
+      }),
+      replace({
         'OpenPGP.js VERSION': `OpenPGP.js ${pkg.version}`,
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',
         delimiters: ['', '']
@@ -120,6 +127,13 @@ export default Object.assign([
         ignore: nodeBuiltinModules.concat(nodeDependencies)
       }),
       replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
+      }),
+      replace({
         'OpenPGP.js VERSION': `OpenPGP.js ${pkg.version}`,
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',
         delimiters: ['', '']
@@ -148,6 +162,13 @@ export default Object.assign([
       commonjs({
         ignore: nodeBuiltinModules.concat(nodeDependencies),
         requireReturnsDefault: 'preferred'
+      }),
+      replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
       }),
       replace({
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',


### PR DESCRIPTION
Faster than tweetnacl, and no constant-timeness required.

We are not using v2 for now, despite it being smaller, because it relies on bigint literals, and it requires polyfilling the WebCrypto lib manually in Node < 19.