### PR TITLE
[v6] Use positive cert for self-signatures

### DIFF
--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -257,7 +257,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
       key: secretKeyPacket
     };
     const signatureProperties = secretKeyPacket.version !== 6 ? getKeySignatureProperties() : {};
-    signatureProperties.signatureType = enums.signature.certGeneric;
+    signatureProperties.signatureType = enums.signature.certPositive;
     if (index === 0) {
       signatureProperties.isPrimaryUserID = true;
     }

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -35,6 +35,8 @@ export async function generateSecretKey(options, config) {
  * Returns the valid and non-expired signature that has the latest creation date, while ignoring signatures created in the future.
  * @param {Array<SignaturePacket>} signatures - List of signatures
  * @param {PublicKeyPacket|PublicSubkeyPacket} publicKey - Public key packet to verify the signature
+ * @param {module:enums.signature} signatureType - Signature type to determine how to hash the data (NB: for userID signatures,
+ *                          `enums.signatures.certGeneric` should be given regardless of the actual trust level)
  * @param {Date} date - Use the given date instead of the current time
  * @param {Object} config - full configuration
  * @returns {Promise<SignaturePacket>} The latest valid signature.


### PR DESCRIPTION
To uniform behaviour with other openpgp libs.

See https://github.com/ProtonMail/go-crypto/pull/208#discussion_r1648659790 .