### PR TITLE
[v6] Use preferred AEAD mode for secret key encryption

### DIFF
--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -392,7 +392,7 @@ class SecretKeyPacket extends PublicKeyPacket {
 
     if (config.aeadProtect) {
       this.s2kUsage = 253;
-      this.aead = enums.aead.eax;
+      this.aead = config.preferredAEADAlgorithm;
       const mode = crypto.getAEADMode(this.aead);
       this.isLegacyAEAD = this.version === 5; // v4 is always re-encrypted with standard format instead.
       this.usedModernAEAD = !this.isLegacyAEAD; // legacy AEAD does not guarantee integrity of public key material


### PR DESCRIPTION
When `config.aeadProtect` is enabled, use `config.preferredAEADAlgorithm` to decide the AEAD mode when encrypting secret keys.