### PR TITLE
[v6] Disallow using forbidden S2K modes

### DIFF
--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -568,6 +568,9 @@ class SecretKeyPacket extends PublicKeyPacket {
  * @returns encryption key
  */
 async function produceEncryptionKey(keyVersion, s2k, passphrase, cipherAlgo, aeadMode, serializedPacketTag, isLegacyAEAD) {
+  if (s2k.type === 'argon2' && !aeadMode) {
+    throw new Error('Using Argon2 S2K without AEAD is not allowed');
+  }
   const { keySize } = crypto.getCipherParams(cipherAlgo);
   const derivedKey = await s2k.produceKey(passphrase, keySize);
   if (!aeadMode || keyVersion === 5 || isLegacyAEAD) {

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -571,6 +571,9 @@ async function produceEncryptionKey(keyVersion, s2k, passphrase, cipherAlgo, aea
   if (s2k.type === 'argon2' && !aeadMode) {
     throw new Error('Using Argon2 S2K without AEAD is not allowed');
   }
+  if (s2k.type === 'simple' && keyVersion === 6) {
+    throw new Error('Using Simple S2K with version 6 keys is not allowed');
+  }
   const { keySize } = crypto.getCipherParams(cipherAlgo);
   const derivedKey = await s2k.produceKey(passphrase, keySize);
   if (!aeadMode || keyVersion === 5 || isLegacyAEAD) {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1416,7 +1416,10 @@ VFBLG8uc9IiaKann/DYBAJcZNZHRSfpDoV2pUA5EAEi2MdjxkRysFQnYPRAu
       const locked = await openpgp.encryptKey({
         privateKey: key,
         passphrase: passphrase,
-        config: { s2kType: openpgp.enums.s2k.argon2 }
+        config: {
+          s2kType: openpgp.enums.s2k.argon2,
+          aeadProtect: true
+        }
       });
       expect(key.isDecrypted()).to.be.true;
       expect(locked.isDecrypted()).to.be.false;


### PR DESCRIPTION
RFC9580 says that:

    Argon2 is only used with AEAD (S2K usage octet 253).  An
    implementation MUST NOT create and MUST reject as malformed any
    secret key packet where the S2K usage octet is not AEAD (253) and
    the S2K specifier type is Argon2.

and:

    [The Simple S2K method] is used only for reading in
    backwards compatibility mode.
    
Since V6 keys don't need backwards compatibility, disallow using Simple S2K there.