### PR TITLE
[v6] Allow parsing legacy AEAD messages regardless of `config.enableParsingV5Entities`

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -82,10 +82,9 @@ export default {
    */
   v6Keys: false,
   /**
-   * Enable parsing v5 keys, v5 signatures and AEAD-encrypted data packets
-   * (which is different from the AEAD-encrypted SEIPDv2 packet).
+   * Enable parsing v5 keys and v5 signatures (which is different from the AEAD-encrypted SEIPDv2 packet).
    * These are non-standard entities, which in the crypto-refresh have been superseded
-   * by v6 keys, v6 signatures and SEIPDv2 encrypted data, respectively.
+   * by v6 keys and v6 signatures, respectively.
    * However, generation of v5 entities was supported behind config flag in OpenPGP.js v5, and some other libraries,
    * hence parsing them might be necessary in some cases.
    */

--- a/src/packet/aead_encrypted_data.js
+++ b/src/packet/aead_encrypted_data.js
@@ -68,10 +68,7 @@ class AEADEncryptedDataPacket {
    * @param {Uint8Array | ReadableStream<Uint8Array>} bytes
    * @throws {Error} on parsing failure
    */
-  async read(bytes, config = defaultConfig) {
-    if (!config.enableParsingV5Entities) {
-      throw new UnsupportedError('Support for parsing v5 entities is disabled; turn on `config.enableParsingV5Entities` if needed');
-    }
+  async read(bytes) {
     await stream.parse(bytes, async reader => {
       const version = await reader.readByte();
       if (version !== VERSION) { // The only currently defined value is 1.

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -174,7 +174,7 @@ export default () => describe('Packet', function() {
       const msg2 = new openpgp.PacketList();
 
       return enc.encrypt(algo, key, undefined, openpgp.config).then(async function() {
-        await msg2.read(msg.write(), allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+        await msg2.read(msg.write(), allAllowedPackets);
         return msg2[0].decrypt(algo, key);
       }).then(async function() {
         expect(await stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
@@ -229,7 +229,7 @@ export default () => describe('Packet', function() {
 
     try {
       await enc.encrypt(algo, key, { ...openpgp.config, aeadChunkSizeByte: 0 });
-      await msg2.read(msg.write(), allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(msg.write(), allAllowedPackets);
       await msg2[0].decrypt(algo, key);
       expect(await stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
       expect(encryptStub.callCount > 1).to.be.true;
@@ -276,7 +276,7 @@ export default () => describe('Packet', function() {
       await enc.encrypt(algo, key, { ...openpgp.config, aeadChunkSizeByte: 14 });
       const data = msg.write();
       expect(await stream.readToEnd(stream.clone(data))).to.deep.equal(packetBytes);
-      await msg2.read(data, allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(data, allAllowedPackets);
       await msg2[0].decrypt(algo, key);
       expect(await stream.readToEnd(msg2[0].packets[0].data)).to.deep.equal(literal.data);
     } finally {
@@ -706,7 +706,7 @@ export default () => describe('Packet', function() {
       await aeadEnc.encrypt(algo, key, undefined, openpgp.config);
 
       const msg2 = new openpgp.PacketList();
-      await msg2.read(msg.write(), allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(msg.write(), allAllowedPackets);
 
       await msg2[0].decrypt(passphrase);
       const key2 = msg2[0].sessionKey;
@@ -744,7 +744,7 @@ export default () => describe('Packet', function() {
       await aeadEnc.encrypt(algo, key, undefined, openpgp.config);
 
       const msg2 = new openpgp.PacketList();
-      await msg2.read(msg.write(), allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(msg.write(), allAllowedPackets);
 
       await msg2[0].decrypt(passphrase);
       const key2 = msg2[0].sessionKey;
@@ -820,7 +820,7 @@ export default () => describe('Packet', function() {
       expect(await stream.readToEnd(stream.clone(data))).to.deep.equal(packetBytes);
 
       const msg2 = new openpgp.PacketList();
-      await msg2.read(data, allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(data, allAllowedPackets);
 
       await msg2[0].decrypt(passphrase);
       const key2 = msg2[0].sessionKey;
@@ -899,7 +899,7 @@ export default () => describe('Packet', function() {
       expect(await stream.readToEnd(stream.clone(data))).to.deep.equal(packetBytes);
 
       const msg2 = new openpgp.PacketList();
-      await msg2.read(data, allAllowedPackets, { ...openpgp.config, enableParsingV5Entities: true });
+      await msg2.read(data, allAllowedPackets);
 
       await msg2[0].decrypt(passphrase);
       const key2 = msg2[0].sessionKey;


### PR DESCRIPTION
As legacy AEAD messages have been in circulation for longer.

Follow up to #1774 .