### PR TITLE
[v6] Try more AEAD ciphersuites for SEIPDv2

### DIFF
--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -178,12 +178,19 @@ export async function getPreferredCipherSuite(keys = [], date = new Date(), user
 
   if (withAEAD) {
     const defaultCipherSuite = { symmetricAlgo: enums.symmetric.aes128, aeadAlgo: enums.aead.ocb };
-    const desiredCipherSuite = { symmetricAlgo: config.preferredSymmetricAlgorithm, aeadAlgo: config.preferredAEADAlgorithm };
-    return selfSigs.every(selfSig => selfSig.preferredCipherSuites && selfSig.preferredCipherSuites.some(
-      cipherSuite => cipherSuite[0] === desiredCipherSuite.symmetricAlgo && cipherSuite[1] === desiredCipherSuite.aeadAlgo
-    )) ?
-      desiredCipherSuite :
-      defaultCipherSuite;
+    const desiredCipherSuites = [
+      { symmetricAlgo: config.preferredSymmetricAlgorithm, aeadAlgo: config.preferredAEADAlgorithm },
+      { symmetricAlgo: config.preferredSymmetricAlgorithm, aeadAlgo: enums.aead.ocb },
+      { symmetricAlgo: enums.symmetric.aes128, aeadAlgo: config.preferredAEADAlgorithm }
+    ];
+    for (const desiredCipherSuite of desiredCipherSuites) {
+      if (selfSigs.every(selfSig => selfSig.preferredCipherSuites && selfSig.preferredCipherSuites.some(
+        cipherSuite => cipherSuite[0] === desiredCipherSuite.symmetricAlgo && cipherSuite[1] === desiredCipherSuite.aeadAlgo
+      ))) {
+        return desiredCipherSuite;
+      }
+    }
+    return defaultCipherSuite;
   }
   const defaultSymAlgo = enums.symmetric.aes128;
   const desiredSymAlgo = config.preferredSymmetricAlgorithm;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4129,6 +4129,34 @@ CNa5yq6lyexhsn2Vs8DsX+SOSUyNJiy5FyIJ
     expect(aeadAlgo).to.equal(openpgp.enums.aead.gcm);
   });
 
+  it('getPreferredCipherSuite with AEAD - one key - AES256-OCB', async function() {
+    const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
+    const primaryUser = await key1.getPrimaryUser();
+    primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    primaryUser.selfCertification.preferredCipherSuites = [[9, 2]];
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
+      ...openpgp.config,
+      aeadProtect: true,
+      preferredAEADAlgorithm: openpgp.enums.aead.gcm
+    });
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes256);
+    expect(aeadAlgo).to.equal(openpgp.enums.aead.ocb);
+  });
+
+  it('getPreferredCipherSuite with AEAD - one key - AES128-GCM', async function() {
+    const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
+    const primaryUser = await key1.getPrimaryUser();
+    primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
+    primaryUser.selfCertification.preferredCipherSuites = [[7, 3]];
+    const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
+      ...openpgp.config,
+      aeadProtect: true,
+      preferredAEADAlgorithm: openpgp.enums.aead.gcm
+    });
+    expect(symmetricAlgo).to.equal(openpgp.enums.symmetric.aes128);
+    expect(aeadAlgo).to.equal(openpgp.enums.aead.gcm);
+  });
+
   it('getPreferredCipherSuite with AEAD - two keys - one without pref', async function() {
     const keys = await openpgp.readKeys({ armoredKeys: twoKeys });
     const key1 = keys[0];

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4133,7 +4133,7 @@ CNa5yq6lyexhsn2Vs8DsX+SOSUyNJiy5FyIJ
     const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
-    primaryUser.selfCertification.preferredCipherSuites = [[9, 2]];
+    primaryUser.selfCertification.preferredCipherSuites = [[openpgp.enums.symmetric.aes256, openpgp.enums.aead.ocb]];
     const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
       ...openpgp.config,
       aeadProtect: true,
@@ -4147,7 +4147,7 @@ CNa5yq6lyexhsn2Vs8DsX+SOSUyNJiy5FyIJ
     const [key1] = await openpgp.readKeys({ armoredKeys: twoKeys });
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [9]; // Monkey-patch SEIPDv2 feature flag
-    primaryUser.selfCertification.preferredCipherSuites = [[7, 3]];
+    primaryUser.selfCertification.preferredCipherSuites = [[openpgp.enums.symmetric.aes128, openpgp.enums.aead.gcm]];
     const { symmetricAlgo, aeadAlgo } = await getPreferredCipherSuite([key1], undefined, undefined, {
       ...openpgp.config,
       aeadProtect: true,


### PR DESCRIPTION
Stick more closely to the algorithm preferences when creating an SEIPDv2 message, by trying additional combinations of the preferred symmetric algorithm and the preferred AEAD algorithm. If one of them is supported but not the other, we still use it (with the mandatory-to-implement algorithm for the other one).

For example, if the key we're encrypting with supports `[(AES-256, OCB)]`, we'll use that now (with the default algorithm preferences of `(AES-256, GCM)`). Before this change, we would use `(AES-128, OCB)` instead (i.e. both mandatory-to-implement algorithms).