### PR TITLE
[v6] Use WebCrypto for ed25519 and x25519 when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,18 @@ library to convert back and forth between them.
 
     | Curve           | Encryption | Signature | NodeCrypto | WebCrypto | Constant-Time     |
     |:---------------:|:----------:|:---------:|:----------:|:---------:|:-----------------:|
-    | curve25519      | ECDH       | N/A       | No         | No        | Algorithmically** |
-    | ed25519         | N/A        | EdDSA     | No         | No        | Algorithmically** |
-    | nistP256        | ECDH       | ECDSA     | Yes*       | Yes*      | If native***      |
-    | nistP384        | ECDH       | ECDSA     | Yes*       | Yes*      | If native***      |
-    | nistP521        | ECDH       | ECDSA     | Yes*       | Yes*      | If native***      |
-    | brainpoolP256r1 | ECDH       | ECDSA     | Yes*       | No        | If native***      |
-    | brainpoolP384r1 | ECDH       | ECDSA     | Yes*       | No        | If native***      |
-    | brainpoolP512r1 | ECDH       | ECDSA     | Yes*       | No        | If native***      |
-    | secp256k1       | ECDH       | ECDSA     | Yes*       | No        | If native***      |
+    | curve25519      | ECDH       | N/A       | No         | Yes*      | If native**      |
+    | ed25519         | N/A        | EdDSA     | No         | Yes*      | If native**      |
+    | nistP256        | ECDH       | ECDSA     | Yes*       | Yes*      | If native**      |
+    | nistP384        | ECDH       | ECDSA     | Yes*       | Yes*      | If native**      |
+    | nistP521        | ECDH       | ECDSA     | Yes*       | Yes*      | If native**      |
+    | brainpoolP256r1 | ECDH       | ECDSA     | Yes*       | No        | If native**      |
+    | brainpoolP384r1 | ECDH       | ECDSA     | Yes*       | No        | If native**      |
+    | brainpoolP512r1 | ECDH       | ECDSA     | Yes*       | No        | If native**      |
+    | secp256k1       | ECDH       | ECDSA     | Yes*       | No        | If native**      |
 
-   \* when available  
-   \** the curve25519 and ed25519 implementations are algorithmically constant-time, but may not be constant-time after optimizations of the JavaScript compiler  
-   \*** these curves are only constant-time if the underlying native implementation is available and constant-time
+   \* when available
+   \** these curves are only constant-time if the underlying native implementation is available and constant-time
 
 * If the user's browser supports [native WebCrypto](https://caniuse.com/#feat=cryptography) via the `window.crypto.subtle` API, this will be used. Under Node.js the native [crypto module](https://nodejs.org/api/crypto.html#crypto_crypto) is used.
 

--- a/src/crypto/public_key/elliptic/ecdh_x.js
+++ b/src/crypto/public_key/elliptic/ecdh_x.js
@@ -11,6 +11,7 @@ import enums from '../../../enums';
 import util from '../../../util';
 import computeHKDF from '../../hkdf';
 import { getCipherParams } from '../../cipher';
+import { b64ToUint8Array, uint8ArrayToB64 } from '../../../encoding/base64';
 
 const HKDF_INFO = {
   x25519: util.encodeUTF8('OpenPGP X25519'),
@@ -24,12 +25,28 @@ const HKDF_INFO = {
  */
 export async function generate(algo) {
   switch (algo) {
-    case enums.publicKey.x25519: {
-      // k stays in little-endian, unlike legacy ECDH over curve25519
-      const k = getRandomBytes(32);
-      const { publicKey: A } = x25519.box.keyPair.fromSecretKey(k);
-      return { A, k };
-    }
+    case enums.publicKey.x25519:
+      try {
+        const webCrypto = util.getWebCrypto();
+        const webCryptoKey = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits']);
+
+        const privateKey = await webCrypto.exportKey('jwk', webCryptoKey.privateKey);
+        const publicKey = await webCrypto.exportKey('jwk', webCryptoKey.publicKey);
+
+        return {
+          A: new Uint8Array(b64ToUint8Array(publicKey.x)),
+          k: b64ToUint8Array(privateKey.d, true)
+        };
+      } catch (err) {
+        if (err.name !== 'NotSupportedError') {
+          throw err;
+        }
+        // k stays in little-endian, unlike legacy ECDH over curve25519
+        const k = getRandomBytes(32);
+        const { publicKey: A } = x25519.box.keyPair.fromSecretKey(k);
+        return { A, k };
+      }
+
     case enums.publicKey.x448: {
       const x448 = await util.getNobleCurve(enums.publicKey.x448);
       const k = x448.utils.randomPrivateKey();
@@ -87,16 +104,14 @@ export async function validateParams(algo, A, k) {
  * @async
  */
 export async function encrypt(algo, data, recipientA) {
+  const { ephemeralPublicKey, sharedSecret } = await generateEphemeralEncryptionMaterial(algo, recipientA);
+  const hkdfInput = util.concatUint8Array([
+    ephemeralPublicKey,
+    recipientA,
+    sharedSecret
+  ]);
   switch (algo) {
     case enums.publicKey.x25519: {
-      const ephemeralSecretKey = getRandomBytes(32);
-      const sharedSecret = x25519.scalarMult(ephemeralSecretKey, recipientA);
-      const { publicKey: ephemeralPublicKey } = x25519.box.keyPair.fromSecretKey(ephemeralSecretKey);
-      const hkdfInput = util.concatUint8Array([
-        ephemeralPublicKey,
-        recipientA,
-        sharedSecret
-      ]);
       const cipherAlgo = enums.symmetric.aes128;
       const { keySize } = getCipherParams(cipherAlgo);
       const encryptionKey = await computeHKDF(enums.hash.sha256, hkdfInput, new Uint8Array(), HKDF_INFO.x25519, keySize);
@@ -104,15 +119,6 @@ export async function encrypt(algo, data, recipientA) {
       return { ephemeralPublicKey, wrappedKey };
     }
     case enums.publicKey.x448: {
-      const x448 = await util.getNobleCurve(enums.publicKey.x448);
-      const ephemeralSecretKey = x448.utils.randomPrivateKey();
-      const sharedSecret = x448.getSharedSecret(ephemeralSecretKey, recipientA);
-      const ephemeralPublicKey = x448.getPublicKey(ephemeralSecretKey);
-      const hkdfInput = util.concatUint8Array([
-        ephemeralPublicKey,
-        recipientA,
-        sharedSecret
-      ]);
       const cipherAlgo = enums.symmetric.aes256;
       const { keySize } = getCipherParams(enums.symmetric.aes256);
       const encryptionKey = await computeHKDF(enums.hash.sha512, hkdfInput, new Uint8Array(), HKDF_INFO.x448, keySize);
@@ -137,27 +143,20 @@ export async function encrypt(algo, data, recipientA) {
  * @async
  */
 export async function decrypt(algo, ephemeralPublicKey, wrappedKey, A, k) {
+  const sharedSecret = await recomputeSharedSecret(algo, ephemeralPublicKey, A, k);
+  const hkdfInput = util.concatUint8Array([
+    ephemeralPublicKey,
+    A,
+    sharedSecret
+  ]);
   switch (algo) {
     case enums.publicKey.x25519: {
-      const sharedSecret = x25519.scalarMult(k, ephemeralPublicKey);
-      const hkdfInput = util.concatUint8Array([
-        ephemeralPublicKey,
-        A,
-        sharedSecret
-      ]);
       const cipherAlgo = enums.symmetric.aes128;
       const { keySize } = getCipherParams(cipherAlgo);
       const encryptionKey = await computeHKDF(enums.hash.sha256, hkdfInput, new Uint8Array(), HKDF_INFO.x25519, keySize);
       return aesKW.unwrap(cipherAlgo, encryptionKey, wrappedKey);
     }
     case enums.publicKey.x448: {
-      const x448 = await util.getNobleCurve(enums.publicKey.x448);
-      const sharedSecret = x448.getSharedSecret(k, ephemeralPublicKey);
-      const hkdfInput = util.concatUint8Array([
-        ephemeralPublicKey,
-        A,
-        sharedSecret
-      ]);
       const cipherAlgo = enums.symmetric.aes256;
       const { keySize } = getCipherParams(enums.symmetric.aes256);
       const encryptionKey = await computeHKDF(enums.hash.sha512, hkdfInput, new Uint8Array(), HKDF_INFO.x448, keySize);
@@ -176,6 +175,111 @@ export function getPayloadSize(algo) {
     case enums.publicKey.x448:
       return 56;
 
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+/**
+ * Generate shared secret and ephemeral public key for encryption
+ * @returns {Promise<{ ephemeralPublicKey: Uint8Array, sharedSecret: Uint8Array }>} ephemeral public key (K_A) and shared secret
+ * @async
+ */
+export async function generateEphemeralEncryptionMaterial(algo, recipientA) {
+  switch (algo) {
+    case enums.publicKey.x25519:
+      try {
+        const webCrypto = util.getWebCrypto();
+        const jwk = publicKeyToJWK(algo, recipientA);
+        const ephemeralKeyPair = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits']);
+        const recipientPublicKey = await webCrypto.importKey('jwk', jwk, 'X25519', false, []);
+        const sharedSecretBuffer = await webCrypto.deriveBits(
+          { name: 'X25519', public: recipientPublicKey },
+          ephemeralKeyPair.privateKey,
+          getPayloadSize(algo) * 8 // in bits
+        );
+        const ephemeralPublicKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.publicKey);
+        return {
+          sharedSecret: new Uint8Array(sharedSecretBuffer),
+          ephemeralPublicKey: new Uint8Array(b64ToUint8Array(ephemeralPublicKeyJwt.x))
+        };
+      } catch (err) {
+        if (err.name !== 'NotSupportedError') {
+          throw err;
+        }
+        const ephemeralSecretKey = getRandomBytes(getPayloadSize(algo));
+        const sharedSecret = x25519.scalarMult(ephemeralSecretKey, recipientA);
+        const { publicKey: ephemeralPublicKey } = x25519.box.keyPair.fromSecretKey(ephemeralSecretKey);
+
+        return { ephemeralPublicKey, sharedSecret };
+      }
+    case enums.publicKey.x448: {
+      const x448 = await util.getNobleCurve(enums.publicKey.x448);
+      const ephemeralSecretKey = x448.utils.randomPrivateKey();
+      const sharedSecret = x448.getSharedSecret(ephemeralSecretKey, recipientA);
+      const ephemeralPublicKey = x448.getPublicKey(ephemeralSecretKey);
+      return { ephemeralPublicKey, sharedSecret };
+    }
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+export async function recomputeSharedSecret(algo, ephemeralPublicKey, A, k) {
+  switch (algo) {
+    case enums.publicKey.x25519:
+      try {
+        const webCrypto = util.getWebCrypto();
+        const privateKeyJWK = privateKeyToJWK(algo, A, k);
+        const ephemeralPublicKeyJWK = publicKeyToJWK(algo, ephemeralPublicKey);
+        const privateKey = await webCrypto.importKey('jwk', privateKeyJWK, 'X25519', false, ['deriveKey', 'deriveBits']);
+        const ephemeralPublicKeyReference = await webCrypto.importKey('jwk', ephemeralPublicKeyJWK, 'X25519', false, []);
+        const sharedSecretBuffer = await webCrypto.deriveBits(
+          { name: 'X25519', public: ephemeralPublicKeyReference },
+          privateKey,
+          getPayloadSize(algo) * 8 // in bits
+        );
+        return new Uint8Array(sharedSecretBuffer);
+      } catch (err) {
+        if (err.name !== 'NotSupportedError') {
+          throw err;
+        }
+        return x25519.scalarMult(k, ephemeralPublicKey);
+      }
+    case enums.publicKey.x448: {
+      const x448 = await util.getNobleCurve(enums.publicKey.x448);
+      const sharedSecret = x448.getSharedSecret(k, ephemeralPublicKey);
+      return sharedSecret;
+    }
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+
+function publicKeyToJWK(algo, publicKey) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      const jwk = {
+        kty: 'OKP',
+        crv: 'X25519',
+        x: uint8ArrayToB64(publicKey, true),
+        ext: true
+      };
+      return jwk;
+    }
+    default:
+      throw new Error('Unsupported ECDH algorithm');
+  }
+}
+
+function privateKeyToJWK(algo, publicKey, privateKey) {
+  switch (algo) {
+    case enums.publicKey.x25519: {
+      const jwk = publicKeyToJWK(algo, publicKey);
+      jwk.d = uint8ArrayToB64(privateKey, true);
+      return jwk;
+    }
     default:
       throw new Error('Unsupported ECDH algorithm');
   }

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -26,6 +26,8 @@ import util from '../../../util';
 import { uint8ArrayToB64, b64ToUint8Array } from '../../../encoding/base64';
 import OID from '../../../type/oid';
 import { UnsupportedError } from '../../../packet/packet';
+import { generate as eddsaGenerate } from './eddsa';
+import { generate as ecdhXGenerate } from './ecdh_x';
 
 const webCrypto = util.getWebCrypto();
 const nodeCrypto = util.getNodeCrypto();
@@ -190,9 +192,8 @@ class CurveWithOID {
         return { publicKey, privateKey };
       }
       case 'ed25519Legacy': {
-        const privateKey = getRandomBytes(32);
-        const keyPair = nacl.sign.keyPair.fromSeed(privateKey);
-        const publicKey = util.concatUint8Array([new Uint8Array([this.wireFormatLeadingByte]), keyPair.publicKey]);
+        const { seed: privateKey, A } = await eddsaGenerate(enums.publicKey.ed25519);
+        const publicKey = util.concatUint8Array([new Uint8Array([this.wireFormatLeadingByte]), A]);
         return { publicKey, privateKey };
       }
       default:

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -20,7 +20,6 @@
  * @module crypto/public_key/elliptic/curve
  */
 import nacl from '@openpgp/tweetnacl';
-import { getRandomBytes } from '../../random';
 import enums from '../../../enums';
 import util from '../../../util';
 import { uint8ArrayToB64, b64ToUint8Array } from '../../../encoding/base64';
@@ -183,12 +182,9 @@ class CurveWithOID {
       case 'node':
         return nodeGenKeyPair(this.name);
       case 'curve25519Legacy': {
-        const privateKey = getRandomBytes(32);
-        privateKey[0] = (privateKey[0] & 127) | 64;
-        privateKey[31] &= 248;
-        const secretKey = privateKey.slice().reverse();
-        const { publicKey: rawPublicKey } = nacl.box.keyPair.fromSecretKey(secretKey);
-        const publicKey = util.concatUint8Array([new Uint8Array([this.wireFormatLeadingByte]), rawPublicKey]);
+        const { k, A } = await ecdhXGenerate(enums.publicKey.x25519);
+        const privateKey = k.slice().reverse();
+        const publicKey = util.concatUint8Array([new Uint8Array([this.wireFormatLeadingByte]), A]);
         return { publicKey, privateKey };
       }
       case 'ed25519Legacy': {

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -12,7 +12,9 @@ import util from '../../src/util';
 
 import * as input from './testInputs';
 
-export default () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cryptography (legacy format)', function () {
+const isSafariOrHeadlessWebKit = () => typeof window !== 'undefined' && window.navigator.userAgent.match(/WebKit/) && !window.navigator.userAgent.match(/Chrome/);
+
+export default () => describe('X25519 Cryptography (legacy format)', function () {
   const data = {
     light: {
       id: '1ecdf026c0245830',
@@ -216,7 +218,9 @@ export default () => (openpgp.config.ci ? describe.skip : describe)('X25519 Cryp
     expect(await result.signatures[0].verified).to.be.true;
   });
 
-  describe('Ed25519 Test Vectors from RFC8032', function () {
+  // Safari implements the non-deterministic version of EdDSA (https://cfrg.github.io/draft-irtf-cfrg-det-sigs-with-noise/draft-irtf-cfrg-det-sigs-with-noise.html),
+  // hence these test vectors do not apply.
+  (isSafariOrHeadlessWebKit() ? describe.skip : describe)('Ed25519 Test Vectors from RFC8032', function () {
     // https://tools.ietf.org/html/rfc8032#section-7.1
     function testVector(vector) {
       const curve = new elliptic.CurveWithOID(openpgp.enums.curve.ed25519Legacy);


### PR DESCRIPTION
Support for curve25519 in WebCrypto has shipped by Safari, and is behind experimental flags in other major browsers (see https://wpt.fyi/results/WebCryptoAPI/generateKey?label=master&label=experimental&aligned&q=25519 for support).

The tweetnacl import is still inlined as the library is always used for key validation (until the curve is more widely implemented natively).

- [x] Update README info about curve (native impl. used when available)