### PR TITLE
[v6] Drop asmcrypto.js for AES fallbacks in favor of noble-ciphers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@noble/ciphers": "^0.6.0",
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.4.0",
-        "@openpgp/asmcrypto.js": "^3.1.0",
         "@openpgp/jsdoc": "^3.6.11",
         "@openpgp/seek-bzip": "^1.0.5-git",
         "@openpgp/tweetnacl": "^1.0.4-1",
@@ -869,12 +868,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@openpgp/asmcrypto.js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@openpgp/asmcrypto.js/-/asmcrypto.js-3.1.0.tgz",
-      "integrity": "sha512-LlQZE/Vtkx/KFnJxg7BB0iwD7oYKDeC8eRECHxKLhYyL2Ad0+xT137VZwv8SZTJB2euPqpx7xkj04ieV0Q665w==",
-      "dev": true
     },
     "node_modules/@openpgp/jsdoc": {
       "version": "3.6.11",
@@ -9097,12 +9090,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@openpgp/asmcrypto.js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@openpgp/asmcrypto.js/-/asmcrypto.js-3.1.0.tgz",
-      "integrity": "sha512-LlQZE/Vtkx/KFnJxg7BB0iwD7oYKDeC8eRECHxKLhYyL2Ad0+xT137VZwv8SZTJB2euPqpx7xkj04ieV0Q665w==",
-      "dev": true
     },
     "@openpgp/jsdoc": {
       "version": "3.6.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.0.0-beta.2",
       "license": "LGPL-3.0+",
       "devDependencies": {
+        "@noble/ciphers": "^0.6.0",
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.4.0",
         "@openpgp/asmcrypto.js": "^3.1.0",
@@ -799,6 +800,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -9040,6 +9050,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@noble/ciphers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
+      "dev": true
     },
     "@noble/curves": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@noble/ciphers": "^0.6.0",
     "@noble/curves": "^1.4.0",
     "@noble/hashes": "^1.4.0",
-    "@openpgp/asmcrypto.js": "^3.1.0",
     "@openpgp/jsdoc": "^3.6.11",
     "@openpgp/seek-bzip": "^1.0.5-git",
     "@openpgp/tweetnacl": "^1.0.4-1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "devDependencies": {
+    "@noble/ciphers": "^0.6.0",
     "@noble/curves": "^1.4.0",
     "@noble/hashes": "^1.4.0",
     "@openpgp/asmcrypto.js": "^3.1.0",

--- a/src/crypto/cmac.js
+++ b/src/crypto/cmac.js
@@ -4,7 +4,7 @@
  * @module crypto/cmac
  */
 
-import { AES_CBC } from '@openpgp/asmcrypto.js/aes/cbc.js';
+import { cbc as nobleAesCbc } from '@noble/ciphers/aes';
 import util from '../util';
 
 const webCrypto = util.getWebCrypto();
@@ -97,8 +97,7 @@ async function CBC(key) {
     }
   }
 
-  // asm.js fallback
   return async function(pt) {
-    return AES_CBC.encrypt(pt, key, false, zeroBlock);
+    return nobleAesCbc(key, zeroBlock, { disablePadding: true }).encrypt(pt);
   };
 }

--- a/src/crypto/mode/eax.js
+++ b/src/crypto/mode/eax.js
@@ -21,7 +21,7 @@
  * @module crypto/mode/eax
  */
 
-import { AES_CTR } from '@openpgp/asmcrypto.js/aes/ctr.js';
+import { ctr as nobleAesCtr } from '@noble/ciphers/aes';
 import CMAC from '../cmac';
 import util from '../../util';
 import enums from '../../enums';
@@ -72,9 +72,8 @@ async function CTR(key) {
     }
   }
 
-  // asm.js fallback
   return async function(pt, iv) {
-    return AES_CTR.encrypt(pt, key, iv);
+    return nobleAesCtr(key, iv).encrypt(pt);
   };
 }
 

--- a/src/crypto/mode/gcm.js
+++ b/src/crypto/mode/gcm.js
@@ -21,7 +21,7 @@
  * @module crypto/mode/gcm
  */
 
-import { AES_GCM } from '@openpgp/asmcrypto.js/aes/gcm.js';
+import { gcm as nobleAesGcm } from '@noble/ciphers/aes';
 import util from '../../util';
 import enums from '../../enums';
 
@@ -74,7 +74,7 @@ async function GCM(cipher, key) {
       return {
         encrypt: async function(pt, iv, adata = new Uint8Array()) {
           if (webcryptoEmptyMessagesUnsupported && !pt.length) {
-            return AES_GCM.encrypt(pt, key, iv, adata);
+            return nobleAesGcm(key, iv, adata).encrypt(pt);
           }
           const ct = await webCrypto.encrypt({ name: ALGO, iv, additionalData: adata, tagLength: tagLength * 8 }, _key, pt);
           return new Uint8Array(ct);
@@ -82,7 +82,7 @@ async function GCM(cipher, key) {
 
         decrypt: async function(ct, iv, adata = new Uint8Array()) {
           if (webcryptoEmptyMessagesUnsupported && ct.length === tagLength) {
-            return AES_GCM.decrypt(ct, key, iv, adata);
+            return nobleAesGcm(key, iv, adata).decrypt(ct);
           }
           try {
             const pt = await webCrypto.decrypt({ name: ALGO, iv, additionalData: adata, tagLength: tagLength * 8 }, _key, ct);
@@ -106,11 +106,11 @@ async function GCM(cipher, key) {
 
   return {
     encrypt: async function(pt, iv, adata) {
-      return AES_GCM.encrypt(pt, key, iv, adata);
+      return nobleAesGcm(key, iv, adata).encrypt(pt);
     },
 
     decrypt: async function(ct, iv, adata) {
-      return AES_GCM.decrypt(ct, key, iv, adata);
+      return nobleAesGcm(key, iv, adata).decrypt(ct);
     }
   };
 }

--- a/src/crypto/mode/ocb.js
+++ b/src/crypto/mode/ocb.js
@@ -20,7 +20,7 @@
  * @module crypto/mode/ocb
  */
 
-import { AES_CBC } from '@openpgp/asmcrypto.js/aes/cbc.js';
+import { cbc as nobleAesCbc } from '@noble/ciphers/aes';
 import { getCipherParams } from '../cipher';
 import util from '../../util';
 
@@ -73,8 +73,9 @@ async function OCB(cipher, key) {
   // `encipher` and `decipher` cannot be async, since `crypt` shares state across calls,
   // hence its execution cannot be broken up.
   // As a result, WebCrypto cannot currently be used for `encipher`.
-  const encipher = block => AES_CBC.encrypt(block, key, false);
-  const decipher = block => AES_CBC.decrypt(block, key, false);
+  const aes = nobleAesCbc(key, zeroBlock, { disablePadding: true });
+  const encipher = block => aes.encrypt(block);
+  const decipher = block => aes.decrypt(block);
   let mask;
 
   constructKeyVariables(cipher, key);


### PR DESCRIPTION
Asm.js has now been deprecated for many years, and no performance gain is recorded for AES compared to vanilla JS.
The relevant AES fallback code is only used if the WebCrypto (resp. NodeCrypto) implementation is not available.