### PR TITLE
[v6] `PrivateKey.getDecryptionKeys`: throw if no decryption key is found

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -222,9 +222,6 @@ export class Message {
           } catch (e) {}
 
           await Promise.all(decryptionKeyPackets.map(async function(decryptionKeyPacket) {
-            if (!decryptionKeyPacket || decryptionKeyPacket.isDummy()) {
-              return;
-            }
             if (!decryptionKeyPacket.isDecrypted()) {
               throw new Error('Decryption key is not decrypted.');
             }

--- a/src/message.js
+++ b/src/message.js
@@ -199,6 +199,15 @@ export class Message {
       }
       await Promise.all(pkeskPackets.map(async function(pkeskPacket) {
         await Promise.all(decryptionKeys.map(async function(decryptionKey) {
+          let decryptionKeyPackets;
+          try {
+            // do not check key expiration to allow decryption of old messages
+            decryptionKeyPackets = (await decryptionKey.getDecryptionKeys(pkeskPacket.publicKeyID, null, undefined, config)).map(key => key.keyPacket);
+          } catch (err) {
+            exception = err;
+            return;
+          }
+
           let algos = [
             enums.symmetric.aes256, // Old OpenPGP.js default fallback
             enums.symmetric.aes128, // RFC4880bis fallback
@@ -212,8 +221,6 @@ export class Message {
             }
           } catch (e) {}
 
-          // do not check key expiration to allow decryption of old messages
-          const decryptionKeyPackets = (await decryptionKey.getDecryptionKeys(pkeskPacket.publicKeyID, null, undefined, config)).map(key => key.keyPacket);
           await Promise.all(decryptionKeyPackets.map(async function(decryptionKeyPacket) {
             if (!decryptionKeyPacket || decryptionKeyPacket.isDummy()) {
               return;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3541,13 +3541,18 @@ PzIEeL7UH3trraFmi+Gq8u4kAA==
     await expect(openpgp.decrypt({
       message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
       decryptionKeys: key
-    })).to.be.rejectedWith(/Session key decryption failed/);
+    })).to.be.rejectedWith(/No decryption key packets found/);
 
     await expect(openpgp.decrypt({
       message: await openpgp.readMessage({ armoredMessage: encryptedRsaSignOnly }),
       decryptionKeys: key,
       config: { allowInsecureDecryptionWithSigningKeys: true }
     })).to.be.fulfilled;
+  });
+
+  it('PrivateKey.getDecryptionKeys() - should throw for sign-only key', async function() {
+    const key = await openpgp.readKey({ armoredKey: rsaSignOnly });
+    await expect(key.getDecryptionKeys()).to.be.rejectedWith(/No decryption key packets found/);
   });
 
   it('Key.getExpirationTime()', async function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1768,7 +1768,7 @@ aOU=
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
         decryptionKeys: privateKeyRSA,
         config
-      })).to.be.rejectedWith(/Session key decryption failed/);
+      })).to.be.rejectedWith(/No decryption key packets found/);
       // decryption using ECC key should succeed (PKCS1 is not used, so constant time countermeasures are not applied)
       const { data } = await openpgp.decrypt({
         message: await openpgp.readMessage({ armoredMessage: encrypted }),
@@ -2642,7 +2642,7 @@ XfA3pqV4mTzF
             }).then(() => {
               throw new Error('Should not decrypt with invalid key');
             }).catch(error => {
-              expect(error.message).to.match(/Error decrypting session keys: Session key decryption failed./);
+              expect(error.message).to.match(/Error decrypting session keys: Could not find valid subkey binding signature in key/);
             });
           });
         });
@@ -4174,7 +4174,7 @@ XfA3pqV4mTzF
           decryptionKeys: decryptedKeyDE
         };
         // binding signature is invalid
-        await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith(/Session key decryption failed/);
+        await expect(openpgp.decrypt(decOpt)).to.be.rejectedWith(/Could not find valid subkey binding signature in key/);
       });
 
       it('RSA decryption with PKCS1 padding of wrong length should fail', async function() {


### PR DESCRIPTION
To avoid returning dummy key packets, and improving error reporting. This new behavior is also better aligned with that of `Key.getSigningKey()`.

This is a **breaking change** for apps that call `getDecryptionKeys()` directly. The related error messages returned by `openpgp.decrypt` have also changed, becoming more specific.

This change is also made in preparation of supporting private keys with public key packets (#1787 , to be released in the next minor version, hence we want to avoid breaking changes there).