### PR TITLE
[v6] Determine signature hash prefs based on recipient keys instead of signing key

### DIFF
--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -59,20 +59,22 @@ export class CleartextMessage {
 
   /**
    * Sign the cleartext message
-   * @param {Array<Key>} privateKeys - private keys with decrypted secret key data for signing
+   * @param {Array<Key>} signingKeys - private keys with decrypted secret key data for signing
+   * @param {Array<Key>} recipientKeys - recipient keys to get the signing preferences from
    * @param {Signature} [signature] - Any existing detached signature
    * @param {Array<module:type/keyid~KeyID>} [signingKeyIDs] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to privateKeys[i]
    * @param {Date} [date] - The creation time of the signature that should be created
-   * @param {Array} [userIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param {Array} [signingKeyIDs] - User IDs to sign with, e.g. [{ name:'Steve Sender', email:'steve@openpgp.org' }]
+   * @param {Array} [recipientUserIDs] - User IDs associated with `recipientKeys` to get the signing preferences from
    * @param {Array} [notations] - Notation Data to add to the signatures, e.g. [{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true, critical: false }]
    * @param {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<CleartextMessage>} New cleartext message with signed content.
    * @async
    */
-  async sign(privateKeys, signature = null, signingKeyIDs = [], date = new Date(), userIDs = [], notations = [], config = defaultConfig) {
+  async sign(signingKeys, recipientKeys = [], signature = null, signingKeyIDs = [], date = new Date(), signingUserIDs = [], recipientUserIDs = [], notations = [], config = defaultConfig) {
     const literalDataPacket = new LiteralDataPacket();
     literalDataPacket.setText(this.text);
-    const newSignature = new Signature(await createSignaturePackets(literalDataPacket, privateKeys, signature, signingKeyIDs, date, userIDs, notations, true, config));
+    const newSignature = new Signature(await createSignaturePackets(literalDataPacket, signingKeys, recipientKeys, signature, signingKeyIDs, date, signingUserIDs, recipientUserIDs, notations, true, config));
     return new CleartextMessage(this.text, newSignature);
   }
 

--- a/src/crypto/public_key/elliptic/eddsa.js
+++ b/src/crypto/public_key/elliptic/eddsa.js
@@ -82,6 +82,9 @@ export async function generate(algo) {
  */
 export async function sign(algo, hashAlgo, message, publicKey, privateKey, hashed) {
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(getPreferredHashAlgo(algo))) {
+    // Enforce digest sizes:
+    // - Ed25519: https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.4-4
+    // - Ed448: https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.5-4
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   switch (algo) {
@@ -129,6 +132,9 @@ export async function sign(algo, hashAlgo, message, publicKey, privateKey, hashe
  */
 export async function verify(algo, hashAlgo, { RS }, m, publicKey, hashed) {
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(getPreferredHashAlgo(algo))) {
+    // Enforce digest sizes:
+    // - Ed25519: https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.4-4
+    // - Ed448: https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.5-4
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   switch (algo) {

--- a/src/crypto/public_key/elliptic/eddsa_legacy.js
+++ b/src/crypto/public_key/elliptic/eddsa_legacy.js
@@ -46,7 +46,9 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
   const curve = new CurveWithOID(oid);
   checkPublicPointEnconding(curve, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
+    // Enforce digest sizes, since the constraint was already present in RFC4880bis:
     // see https://tools.ietf.org/id/draft-ietf-openpgp-rfc4880bis-10.html#section-15-7.2
+    // and https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.3-3
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   const { RS: signature } = await eddsaSign(enums.publicKey.ed25519, hashAlgo, message, publicKey.subarray(1), privateKey, hashed);
@@ -73,6 +75,9 @@ export async function verify(oid, hashAlgo, { r, s }, m, publicKey, hashed) {
   const curve = new CurveWithOID(oid);
   checkPublicPointEnconding(curve, publicKey);
   if (hash.getHashByteLength(hashAlgo) < hash.getHashByteLength(enums.hash.sha256)) {
+    // Enforce digest sizes, since the constraint was already present in RFC4880bis:
+    // see https://tools.ietf.org/id/draft-ietf-openpgp-rfc4880bis-10.html#section-15-7.2
+    // and https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.3-3
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   const RS = util.concatUint8Array([r, s]);

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -246,7 +246,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
     const signatureProperties = getKeySignatureProperties();
     signatureProperties.signatureType = enums.signature.key;
 
-    const signaturePacket = await helper.createSignaturePacket(dataToSign, null, secretKeyPacket, signatureProperties, options.date, undefined, undefined, undefined, config);
+    const signaturePacket = await helper.createSignaturePacket(dataToSign, [], secretKeyPacket, signatureProperties, options.date, undefined, undefined, undefined, config);
     packetlist.push(signaturePacket);
   }
 
@@ -262,7 +262,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
       signatureProperties.isPrimaryUserID = true;
     }
 
-    const signaturePacket = await helper.createSignaturePacket(dataToSign, null, secretKeyPacket, signatureProperties, options.date, undefined, undefined, undefined, config);
+    const signaturePacket = await helper.createSignaturePacket(dataToSign, [], secretKeyPacket, signatureProperties, options.date, undefined, undefined, undefined, config);
 
     return { userIDPacket, signaturePacket };
   })).then(list => {
@@ -286,7 +286,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
   // Add revocation signature packet for creating a revocation certificate.
   // This packet should be removed before returning the key.
   const dataToSign = { key: secretKeyPacket };
-  packetlist.push(await helper.createSignaturePacket(dataToSign, null, secretKeyPacket, {
+  packetlist.push(await helper.createSignaturePacket(dataToSign, [], secretKeyPacket, {
     signatureType: enums.signature.keyRevocation,
     reasonForRevocationFlag: enums.reasonForRevocation.noReason,
     reasonForRevocationString: ''

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -206,7 +206,7 @@ class PrivateKey extends PublicKey {
     }
     const dataToSign = { key: this.keyPacket };
     const key = this.clone();
-    key.revocationSignatures.push(await helper.createSignaturePacket(dataToSign, null, this.keyPacket, {
+    key.revocationSignatures.push(await helper.createSignaturePacket(dataToSign, [], this.keyPacket, {
       signatureType: enums.signature.keyRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString

--- a/src/key/subkey.js
+++ b/src/key/subkey.js
@@ -185,7 +185,7 @@ class Subkey {
   ) {
     const dataToSign = { key: primaryKey, bind: this.keyPacket };
     const subkey = new Subkey(this.keyPacket, this.mainKey);
-    subkey.revocationSignatures.push(await helper.createSignaturePacket(dataToSign, null, primaryKey, {
+    subkey.revocationSignatures.push(await helper.createSignaturePacket(dataToSign, [], primaryKey, {
       signatureType: enums.signature.subkeyRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -72,7 +72,7 @@ class User {
         throw new Error("The user's own key can only be used for self-certifications");
       }
       const signingKey = await privateKey.getSigningKey(undefined, date, undefined, config);
-      return createSignaturePacket(dataToSign, privateKey, signingKey.keyPacket, {
+      return createSignaturePacket(dataToSign, [privateKey], signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,
         keyFlags: [enums.keyFlags.certifyKeys | enums.keyFlags.signData]
@@ -260,7 +260,7 @@ class User {
       key: primaryKey
     };
     const user = new User(dataToSign.userID || dataToSign.userAttribute, this.mainKey);
-    user.revocationSignatures.push(await createSignaturePacket(dataToSign, null, primaryKey, {
+    user.revocationSignatures.push(await createSignaturePacket(dataToSign, [], primaryKey, {
       signatureType: enums.signature.certRevocation,
       reasonForRevocationFlag: enums.write(enums.reasonForRevocation, reasonForRevocationFlag),
       reasonForRevocationString

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -392,21 +392,23 @@ export async function decrypt({ message, decryptionKeys, passwords, sessionKeys,
  * @param {Object} options
  * @param {CleartextMessage|Message} options.message - (cleartext) message to be signed
  * @param {PrivateKey|PrivateKey[]} options.signingKeys - Array of keys or single key with decrypted secret key data to sign cleartext
+ * @param {Key|Key[]} options.recipientKeys - Array of keys or single to get the signing preferences from
  * @param {'armored'|'binary'|'object'} [options.format='armored'] - Format of the returned message
  * @param {Boolean} [options.detached=false] - If the return value should contain a detached signature
  * @param {KeyID|KeyID[]} [options.signingKeyIDs=latest-created valid signing (sub)keys] - Array of key IDs to use for signing. Each signingKeyIDs[i] corresponds to signingKeys[i]
  * @param {Date} [options.date=current date] - Override the creation date of the signature
  * @param {Object|Object[]} [options.signingUserIDs=primary user IDs] - Array of user IDs to sign with, one per key in `signingKeys`, e.g. `[{ name: 'Steve Sender', email: 'steve@openpgp.org' }]`
+ * @param {Object|Object[]} [options.recipientUserIDs=primary user IDs] - Array of user IDs to get the signing preferences from, one per key in `recipientKeys`
  * @param {Object|Object[]} [options.signatureNotations=[]] - Array of notations to add to the signatures, e.g. `[{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true, critical: false }]`
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
  * @returns {Promise<MaybeStream<String|Uint8Array>>} Signed message (string if `armor` was true, the default; Uint8Array if `armor` was false).
  * @async
  * @static
  */
-export async function sign({ message, signingKeys, format = 'armored', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], signatureNotations = [], config, ...rest }) {
+export async function sign({ message, signingKeys, recipientKeys = [], format = 'armored', detached = false, signingKeyIDs = [], date = new Date(), signingUserIDs = [], recipientUserIDs = [], signatureNotations = [], config, ...rest }) {
   config = { ...defaultConfig, ...config }; checkConfig(config);
   checkCleartextOrMessage(message); checkOutputMessageFormat(format);
-  signingKeys = toArray(signingKeys); signingKeyIDs = toArray(signingKeyIDs); signingUserIDs = toArray(signingUserIDs); signatureNotations = toArray(signatureNotations);
+  signingKeys = toArray(signingKeys); signingKeyIDs = toArray(signingKeyIDs); signingUserIDs = toArray(signingUserIDs); recipientKeys = toArray(recipientKeys); recipientUserIDs = toArray(recipientUserIDs); signatureNotations = toArray(signatureNotations);
 
   if (rest.privateKeys) throw new Error('The `privateKeys` option has been removed from openpgp.sign, pass `signingKeys` instead');
   if (rest.armor !== undefined) throw new Error('The `armor` option has been removed from openpgp.sign, pass `format` instead.');
@@ -422,9 +424,9 @@ export async function sign({ message, signingKeys, format = 'armored', detached 
   try {
     let signature;
     if (detached) {
-      signature = await message.signDetached(signingKeys, [], undefined, signingKeyIDs, date, signingUserIDs, undefined, signatureNotations, config);
+      signature = await message.signDetached(signingKeys, recipientKeys, undefined, signingKeyIDs, date, signingUserIDs, recipientUserIDs, signatureNotations, config);
     } else {
-      signature = await message.sign(signingKeys, [], undefined, signingKeyIDs, date, signingUserIDs, undefined, signatureNotations, config);
+      signature = await message.sign(signingKeys, recipientKeys, undefined, signingKeyIDs, date, signingUserIDs, recipientUserIDs, signatureNotations, config);
     }
     if (format === 'object') return signature;
 

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -290,7 +290,7 @@ export async function encrypt({ message, encryptionKeys, signingKeys, passwords,
 
   try {
     if (signingKeys.length || signature) { // sign the message only if signing keys or signature is specified
-      message = await message.sign(signingKeys, signature, signingKeyIDs, date, signingUserIDs, signatureNotations, config);
+      message = await message.sign(signingKeys, encryptionKeys, signature, signingKeyIDs, date, signingUserIDs, encryptionKeyIDs, signatureNotations, config);
     }
     message = message.compress(
       await getPreferredCompressionAlgo(encryptionKeys, date, encryptionUserIDs, config),
@@ -422,9 +422,9 @@ export async function sign({ message, signingKeys, format = 'armored', detached 
   try {
     let signature;
     if (detached) {
-      signature = await message.signDetached(signingKeys, undefined, signingKeyIDs, date, signingUserIDs, signatureNotations, config);
+      signature = await message.signDetached(signingKeys, [], undefined, signingKeyIDs, date, signingUserIDs, undefined, signatureNotations, config);
     } else {
-      signature = await message.sign(signingKeys, undefined, signingKeyIDs, date, signingUserIDs, signatureNotations, config);
+      signature = await message.sign(signingKeys, [], undefined, signingKeyIDs, date, signingUserIDs, undefined, signatureNotations, config);
     }
     if (format === 'object') return signature;
 


### PR DESCRIPTION
Changes:
- The signature will be generated using the preferred hash algo from the recipient keys:
  - in `openpgp.encrypt`, when passing `signingKeys`, the `encryptionKeys` are treated as recipient keys
  - in `openpgp.sign`, a `recipientKeys` option has been added

  If no recipient keys are available, the signing key preferences are used (this was also the existing behavior).

- The hash algo selection logic has been reworked as follows:
if `config.preferredHashAlgo` appears in the prefs of all recipients, we pick it;
otherwise, we use the strongest supported algo (note: SHA256 is always implicitly supported by all keys), as long as it is compatible with the signing key (e.g. ECC keys require minimum digest sizes).
With this change, `config.preferredHashAlgo` is picked even if it's weaker than the preferences of the recipient keys.

Previously, only the preferences of the signing key were used to determine the hash algo to use, but this is in contrast to the RFC: https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.16-2 .
Also, an algo stronger than `config.preferredHashAlgo` would be used, if the signing key declared it as first preference.
