### PR TITLE
Update hash algorithm preferences order

### DIFF
--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -214,11 +214,10 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
       });
     }
     signatureProperties.preferredHashAlgorithms = createPreferredAlgos([
-      // prefer fast asm.js implementations (SHA-256)
-      enums.hash.sha256,
       enums.hash.sha512,
-      enums.hash.sha3_256,
-      enums.hash.sha3_512
+      enums.hash.sha256,
+      enums.hash.sha3_512,
+      enums.hash.sha3_256
     ], config.preferredHashAlgorithm);
     signatureProperties.preferredCompressionAlgorithms = createPreferredAlgos([
       enums.compression.uncompressed,

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2261,7 +2261,7 @@ function versionSpecificTests() {
         ]);
       }
       const hash = openpgp.enums.hash;
-      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha512, hash.sha256, hash.sha3_256, hash.sha3_512]);
+      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha512, hash.sha256, hash.sha3_512, hash.sha3_256]);
       const compr = openpgp.enums.compression;
       expect(selfSignature.preferredCompressionAlgorithms).to.eql([compr.uncompressed, compr.zlib, compr.zip]);
 
@@ -2316,7 +2316,7 @@ function versionSpecificTests() {
         ]);
       }
       const hash = openpgp.enums.hash;
-      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha224, hash.sha256, hash.sha512, hash.sha3_256, hash.sha3_512]);
+      expect(selfSignature.preferredHashAlgorithms).to.eql([hash.sha224, hash.sha512, hash.sha256, hash.sha3_512, hash.sha3_256]);
       const compr = openpgp.enums.compression;
       expect(selfSignature.preferredCompressionAlgorithms).to.eql([compr.zlib, compr.uncompressed, compr.zip]);
 


### PR DESCRIPTION
The current default hash algorithm preferences are `[SHA512, SHA256, SHA3_256, SHA3_512]`, which is a bit strange.
This updates it to be `[SHA512, SHA256, SHA3_512, SHA3_256]`.