### PR TITLE
TS: fix `generateKey` (`options.type`) and `PrivateKey.getDecryptionKeys()` type declarations

### DIFF
--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -702,7 +702,7 @@ export type EllipticCurveName = 'ed25519Legacy' | 'curve25519Legacy' | 'nistP256
 interface GenerateKeyOptions {
   userIDs: MaybeArray<UserID>;
   passphrase?: string;
-  type?: 'ecc' | 'rsa';
+  type?: 'ecc' | 'rsa' | 'curve25519' | 'curve448';
   curve?: EllipticCurveName;
   rsaBits?: number;
   keyExpirationTime?: number;
@@ -713,14 +713,8 @@ interface GenerateKeyOptions {
 }
 export type KeyOptions = GenerateKeyOptions;
 
-export interface SubkeyOptions {
-  type?: 'ecc' | 'rsa';
-  curve?: EllipticCurveName;
-  rsaBits?: number;
-  keyExpirationTime?: number;
-  date?: Date;
+export interface SubkeyOptions extends Pick<GenerateKeyOptions, 'type' | 'curve' | 'rsaBits' | 'keyExpirationTime' | 'date' | 'config'> {
   sign?: boolean;
-  config?: PartialConfig;
 }
 
 export declare class KeyID {

--- a/openpgp.d.ts
+++ b/openpgp.d.ts
@@ -94,7 +94,7 @@ export class PrivateKey extends PublicKey {
   public revoke(reason?: ReasonForRevocation, date?: Date, config?: Config): Promise<PrivateKey>;
   public isDecrypted(): boolean;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
-  public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<PrivateKey | Subkey>;
+  public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<(PrivateKey | Subkey)[]>;
   public update(sourceKey: PublicKey, date?: Date, config?: Config): Promise<PrivateKey>;
 }
 

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -22,7 +22,12 @@ import {
 (async () => {
 
   // Generate keys
-  const keyOptions = { userIDs: [{ email: 'user@corp.co' }], config: { v6Keys: true } };
+  const keyOptions = {
+    type: 'curve25519' as const,
+    userIDs: [{ email: 'user@corp.co' }],
+    subkeys: [{ type: 'rsa' as const, sign: false }],
+    config: { v6Keys: true }
+  };
   const { privateKey: privateKeyArmored, publicKey: publicKeyArmored } = await generateKey(keyOptions);
   const { privateKey: privateKeyBinary } = await generateKey({ ...keyOptions, format: 'binary' });
   const { privateKey, publicKey, revocationCertificate } = await generateKey({ ...keyOptions, format: 'object' });


### PR DESCRIPTION
Fixes TS definitions:
- `generateKey`: update `options.type` definition to accept `'curve25519'` and `'curve448'` (implemented in https://github.com/openpgpjs/openpgpjs/pull/1676)
- `PrivateKey.getDecryptionKeys()`: it returns an array of keys, not just one element (close #1693)