### PR TITLE
CI: add reconnection mechanism for Browserstack on `testsStartTimeout`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2761,24 +2761,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/test-runner-commands": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.9.0.tgz",
-      "integrity": "sha512-zeLI6QdH0jzzJMDV5O42Pd8WLJtYqovgdt0JdytgHc0d1EpzXDsc7NTCJSImboc2NcayIsWAvvGGeRF69SMMYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@web/test-runner-core": "^0.13.0",
-        "mkdirp": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@web/test-runner-core": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.3.tgz",
-      "integrity": "sha512-ilDqF/v2sj0sD69FNSIDT7uw4M1yTVedLBt32/lXy3MMi6suCM7m/ZlhsBy8PXhf879WMvzBOl/vhJBpEMB9vA==",
+    "node_modules/@web/test-runner-chrome/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2790,8 +2777,8 @@
         "@types/istanbul-lib-coverage": "^2.0.3",
         "@types/istanbul-reports": "^3.0.0",
         "@web/browser-logs": "^0.4.0",
-        "@web/dev-server-core": "^0.7.2",
-        "chokidar": "^3.4.3",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
         "cli-cursor": "^3.1.0",
         "co-body": "^6.1.0",
         "convert-source-map": "^2.0.0",
@@ -2813,11 +2800,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/@web/dev-server-core/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-      "extraneous": true,
+    "node_modules/@web/test-runner-chrome/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -2829,7 +2816,114 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/source-map": {
+    "node_modules/@web/test-runner-chrome/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-chrome/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@web/test-runner-commands": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.9.0.tgz",
+      "integrity": "sha512-zeLI6QdH0jzzJMDV5O42Pd8WLJtYqovgdt0JdytgHc0d1EpzXDsc7NTCJSImboc2NcayIsWAvvGGeRF69SMMYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "mkdirp": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-commands/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-commands/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-commands/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-commands/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
@@ -2856,6 +2950,85 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/test-runner-coverage-v8/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-coverage-v8/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-coverage-v8/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-coverage-v8/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@web/test-runner-mocha": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.9.0.tgz",
@@ -2867,6 +3040,85 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-mocha/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-mocha/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-mocha/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-mocha/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@web/test-runner-playwright": {
@@ -2884,6 +3136,85 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/test-runner-playwright/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-playwright/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-playwright/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-playwright/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@web/test-runner-webdriver": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@web/test-runner-webdriver/-/test-runner-webdriver-0.8.0.tgz",
@@ -2896,6 +3227,154 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-webdriver/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-webdriver/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-webdriver/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner-webdriver/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/@web/test-runner-core": {
+      "name": "@openpgp/wtr-test-runner-core",
+      "version": "0.13.4-patch.0",
+      "resolved": "https://registry.npmjs.org/@openpgp/wtr-test-runner-core/-/wtr-test-runner-core-0.13.4-patch.0.tgz",
+      "integrity": "sha512-vcQXfDvDyVhQo4IpqHk/ksNayC/hKNjaN7ykXygtrGmOSdsVs1IGopNVzOgjjeISpZUytHnivJNEMtNWNPGgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@web/test-runner/node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "web-streams-polyfill": "^4.0.0"
   },
   "overrides": {
-    "@web/dev-server-core": "npm:@openpgp/wtr-dev-server-core@0.7.3-patch.1"
+    "@web/dev-server-core": "npm:@openpgp/wtr-dev-server-core@0.7.3-patch.1",
+    "@web/test-runner-core": "npm:@openpgp/wtr-test-runner-core@0.13.4-patch.0"
   },
   "repository": {
     "type": "git",

--- a/test/web-test-runner.browserstack.config.js
+++ b/test/web-test-runner.browserstack.config.js
@@ -28,7 +28,7 @@ export default {
     browserstackLauncher({
       capabilities: {
         ...sharedBrowserstackCapabilities,
-        browserName: 'Safari iOS 14',
+        browserName: '[Browserstack] Safari iOS 14',
         device: 'iPhone 12',
         real_mobile: true,
         os: 'ios',
@@ -38,7 +38,7 @@ export default {
     browserstackLauncher({
       capabilities: {
         ...sharedBrowserstackCapabilities,
-        browserName: 'Safari iOS latest',
+        browserName: '[Browserstack] Safari iOS latest',
         device: 'iPhone 16 Pro',
         real_mobile: true,
         os: 'ios',

--- a/test/web-test-runner.browserstack.config.js
+++ b/test/web-test-runner.browserstack.config.js
@@ -39,7 +39,7 @@ export default {
       capabilities: {
         ...sharedBrowserstackCapabilities,
         browserName: 'Safari iOS latest',
-        device: 'iPhone 16',
+        device: 'iPhone 16 Pro',
         real_mobile: true,
         os: 'ios',
         os_version: 'latest'


### PR DESCRIPTION
iOS tests sometimes fail to start due to some "server disconnect" issue on BS side.
This seems more prominent on certain devices (e.g. iPhone 16 with iOS 18).