### PR TITLE
Make Issuer Key ID signature subpackets non-critical

### DIFF
--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -315,7 +315,9 @@ class SignaturePacket {
     if (!this.issuerKeyID.isNull() && this.issuerKeyVersion < 5) {
       // If the version of [the] key is greater than 4, this subpacket
       // MUST NOT be included in the signature.
-      arr.push(writeSubPacket(sub.issuerKeyID, true, this.issuerKeyID.write()));
+      // XXX: making this critical breaks RPM <=4.16.
+		  // See: https://github.com/ProtonMail/go-crypto/issues/263
+      arr.push(writeSubPacket(sub.issuerKeyID, false, this.issuerKeyID.write()));
     }
     this.rawNotations.forEach(({ name, value, humanReadable, critical }) => {
       bytes = [new Uint8Array([humanReadable ? 0x80 : 0, 0, 0, 0])];

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -315,8 +315,8 @@ class SignaturePacket {
     if (!this.issuerKeyID.isNull() && this.issuerKeyVersion < 5) {
       // If the version of [the] key is greater than 4, this subpacket
       // MUST NOT be included in the signature.
-      // XXX: making this critical breaks RPM <=4.16.
-		  // See: https://github.com/ProtonMail/go-crypto/issues/263
+      // Note: making this critical breaks RPM <=4.16.
+      // See: https://github.com/ProtonMail/go-crypto/issues/263
       arr.push(writeSubPacket(sub.issuerKeyID, false, this.issuerKeyID.write()));
     }
     this.rawNotations.forEach(({ name, value, humanReadable, critical }) => {


### PR DESCRIPTION
RPM 4.16 (used in centos 9, fedora 34, ...) does not support it. Seems to be fixed in 4.17+. FWIW Centos 9 EOL is set to 2027-05-31.

More context:
- https://github.com/ProtonMail/go-crypto/pull/175
- https://github.com/ProtonMail/go-crypto/issues/263