### PR TITLE
CI: re-enable testing Webkit on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,6 @@ jobs:
           npx playwright install --with-deps firefox
 
       - name: Install WebKit # caching not possible, external shared libraries required
-        if: ${{ matrix.runner == 'macos-latest' }} # do not install on ubuntu, since the X25519 WebCrypto implementation has issues
         run: npx playwright install --with-deps webkit
 
       - name: Run browser tests

--- a/test/web-test-runner.config.js
+++ b/test/web-test-runner.config.js
@@ -1,10 +1,10 @@
-import { existsSync } from 'fs';
-import { playwrightLauncher, playwright } from '@web/test-runner-playwright';
+import { playwrightLauncher } from '@web/test-runner-playwright';
 
 const sharedPlaywrightCIOptions = {
   // createBrowserContext: ({ browser }) => browser.newContext({ ignoreHTTPSErrors: true }),
   headless: true
 };
+
 export default {
   nodeResolve: true, // to resolve npm module imports in `unittests.html`
   files: './test/unittests.html',
@@ -29,13 +29,11 @@ export default {
           ...sharedPlaywrightCIOptions,
           product: 'firefox'
         }),
-        // try setting up webkit, but ignore if not available
-        // (e.g. on ubuntu, where we don't want to test webkit as the WebCrypto X25519 implementation has issues)
-        existsSync(playwright.webkit.executablePath()) && playwrightLauncher({
+        playwrightLauncher({
           ...sharedPlaywrightCIOptions,
           product: 'webkit'
         })
-      ].filter(Boolean)
+      ]
     }
   ]
 };


### PR DESCRIPTION
Following release of support for X25519 in Webkit Linux.

TODO:
- [ ] Blocked by another Webkit issue on Linux: https://bugs.webkit.org/show_bug.cgi?id=289693 .