### PR TITLE
CI: fix "unknown cli/env config" warnings from npm v11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run browser tests (lightweight) # overwrite test/lib
         run: |
-          npm run build-test --lightweight
+          npm run build-test -- --configTestLightweightBuild
           npm run test-browser:ci -- --static-logging
 
   test-browsers-compatibility:
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run browserstack tests (lightweight) # overwrite test/lib
         run: |
-          npm run build-test --lightweight
+          npm run build-test -- --configTestLightweightBuild
           npm run test-browserstack -- --static-logging
         env:
           LIGHTWEIGHT: true

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
-    "build-test": "npm run build --build-only=test",
+    "build-test": "npm run build -- --configBuildOnly=test",
     "prepare": "npm run build",
     "test": "mocha --timeout 120000 test/unittests.js",
     "test-type-definitions": "tsx test/typescript/definitions.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -136,7 +136,7 @@ const lightweightBrowserBuild = {
   ]
 };
 
-const testBuild = {
+const getBrowserTestBuild = useLightweightBuild => ({
   input: 'test/unittests.js',
   output: [
     { file: 'test/lib/unittests-bundle.js', format: 'es', intro, sourcemap: true, inlineDynamicImports: true }
@@ -145,7 +145,7 @@ const testBuild = {
   plugins: [
     alias({
       entries: {
-        openpgp: `./dist/${process.env.npm_config_lightweight ? 'lightweight/' : ''}openpgp.mjs`
+        openpgp: `./dist/${useLightweightBuild ? 'lightweight/' : ''}openpgp.mjs`
       }
     }),
     resolve({
@@ -164,21 +164,31 @@ const testBuild = {
     }),
     wasm(wasmOptions.browser)
   ]
-};
+});
 
-export default Object.assign([
+/**
+ * Rollup CLI supports custom options; their name must start with `config`,
+ * e.g. see `--configDebug` example at
+ * https://rollupjs.org/command-line-interface/#configuration-files
+ *
+ * The custom options we support are:
+ * @param commandLineArgs.configBuildOnly {'dist'|'node'|'lightweight'|'test'} to specify a build target;
+ *    defaults to 'dist', which does not build tests.
+ * @param commandLineArgs.configTestLightweightBuild {Boolean}: in the context of building browser tests,
+ *    whether the lightweight build should be included instead of the standard one
+ */
+export default commandLineArgs => Object.assign([
   nodeBuild,
   fullBrowserBuild,
   lightweightBrowserBuild,
-  testBuild
-].filter(config => {
-  config.output = config.output.filter(output => {
+  getBrowserTestBuild(commandLineArgs.configTestLightweightBuild)
+].filter(rollupConfig => {
+  rollupConfig.output = rollupConfig.output.filter(output => {
     return (output.file || output.dir + '/' + output.entryFileNames).includes(
-      process.env.npm_config_build_only || // E.g. `npm install --build-only=lightweight`.
-      'dist' // Don't build test bundle by default.
+      commandLineArgs.configBuildOnly || 'dist' // Don't build test bundle by default.
     );
   });
-  return config.output.length;
+  return rollupConfig.output.length;
 }), {
   allow_empty: true // Fake option to trick rollup into accepting empty config array when filtered above.
 });


### PR DESCRIPTION
npm v12 will drop support for unknown config options.
Example warning from npm v11:

```
npm warn Unknown cli config "--lightweight". This will stop working in the next major version of npm.
```

