### PR TITLE
Add workarounds for WebCrypto X25519 bugs on WebKit Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,6 @@ jobs:
           npx playwright install --with-deps firefox
 
       - name: Install WebKit # caching not possible, external shared libraries required
-        if: ${{ matrix.runner == 'macos-latest' }} # do not install on ubuntu, since the X25519 WebCrypto implementation has issues
         run: npx playwright install --with-deps webkit
 
       - name: Run browser tests

--- a/src/crypto/public_key/elliptic/ecdh_x.js
+++ b/src/crypto/public_key/elliptic/ecdh_x.js
@@ -33,6 +33,12 @@ export async function generate(algo) {
         const privateKey = await webCrypto.exportKey('jwk', webCryptoKey.privateKey);
         const publicKey = await webCrypto.exportKey('jwk', webCryptoKey.publicKey);
 
+        if (privateKey.x !== publicKey.x) { // Weird issue with Webkit on Linux: https://bugs.webkit.org/show_bug.cgi?id=289693
+          const err = new Error('Unexpected mismatching public point');
+          err.name = 'NotSupportedError';
+          throw err;
+        }
+
         return {
           A: new Uint8Array(b64ToUint8Array(publicKey.x)),
           k: b64ToUint8Array(privateKey.d)
@@ -190,15 +196,21 @@ export async function generateEphemeralEncryptionMaterial(algo, recipientA) {
     case enums.publicKey.x25519:
       try {
         const webCrypto = util.getWebCrypto();
-        const jwk = publicKeyToJWK(algo, recipientA);
         const ephemeralKeyPair = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits']);
+        const ephemeralPublicKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.publicKey);
+        const ephemeralPrivateKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.privateKey);
+        if (ephemeralPrivateKeyJwt.x !== ephemeralPublicKeyJwt.x) { // Weird issue with Webkit on Linux: https://bugs.webkit.org/show_bug.cgi?id=289693
+          const err = new Error('Unexpected mismatching public point');
+          err.name = 'NotSupportedError';
+          throw err;
+        }
+        const jwk = publicKeyToJWK(algo, recipientA);
         const recipientPublicKey = await webCrypto.importKey('jwk', jwk, 'X25519', false, []);
         const sharedSecretBuffer = await webCrypto.deriveBits(
           { name: 'X25519', public: recipientPublicKey },
           ephemeralKeyPair.privateKey,
           getPayloadSize(algo) * 8 // in bits
         );
-        const ephemeralPublicKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.publicKey);
         return {
           sharedSecret: new Uint8Array(sharedSecretBuffer),
           ephemeralPublicKey: new Uint8Array(b64ToUint8Array(ephemeralPublicKeyJwt.x))

--- a/src/crypto/public_key/elliptic/ecdh_x.js
+++ b/src/crypto/public_key/elliptic/ecdh_x.js
@@ -28,7 +28,15 @@ export async function generate(algo) {
     case enums.publicKey.x25519:
       try {
         const webCrypto = util.getWebCrypto();
-        const webCryptoKey = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits']);
+        const webCryptoKey = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits'])
+          .catch(err => {
+            if (err.name === 'OperationError') { // Temporary (hopefully) fix for WebKit on Linux
+              const newErr = new Error('Unexpected key generation issue');
+              newErr.name = 'NotSupportedError';
+              throw newErr;
+            }
+            throw err;
+          });
 
         const privateKey = await webCrypto.exportKey('jwk', webCryptoKey.privateKey);
         const publicKey = await webCrypto.exportKey('jwk', webCryptoKey.publicKey);
@@ -196,7 +204,15 @@ export async function generateEphemeralEncryptionMaterial(algo, recipientA) {
     case enums.publicKey.x25519:
       try {
         const webCrypto = util.getWebCrypto();
-        const ephemeralKeyPair = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits']);
+        const ephemeralKeyPair = await webCrypto.generateKey('X25519', true, ['deriveKey', 'deriveBits'])
+          .catch(err => {
+            if (err.name === 'OperationError') { // Temporary (hopefully) fix for WebKit on Linux
+              const newErr = new Error('Unexpected key generation issue');
+              newErr.name = 'NotSupportedError';
+              throw newErr;
+            }
+            throw err;
+          });
         const ephemeralPublicKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.publicKey);
         const ephemeralPrivateKeyJwt = await webCrypto.exportKey('jwk', ephemeralKeyPair.privateKey);
         if (ephemeralPrivateKeyJwt.x !== ephemeralPublicKeyJwt.x) { // Weird issue with Webkit on Linux: https://bugs.webkit.org/show_bug.cgi?id=289693

--- a/test/web-test-runner.config.js
+++ b/test/web-test-runner.config.js
@@ -1,10 +1,10 @@
-import { existsSync } from 'fs';
-import { playwrightLauncher, playwright } from '@web/test-runner-playwright';
+import { playwrightLauncher } from '@web/test-runner-playwright';
 
 const sharedPlaywrightCIOptions = {
   // createBrowserContext: ({ browser }) => browser.newContext({ ignoreHTTPSErrors: true }),
   headless: true
 };
+
 export default {
   nodeResolve: true, // to resolve npm module imports in `unittests.html`
   files: './test/unittests.html',
@@ -29,13 +29,11 @@ export default {
           ...sharedPlaywrightCIOptions,
           product: 'firefox'
         }),
-        // try setting up webkit, but ignore if not available
-        // (e.g. on ubuntu, where we don't want to test webkit as the WebCrypto X25519 implementation has issues)
-        existsSync(playwright.webkit.executablePath()) && playwrightLauncher({
+        playwrightLauncher({
           ...sharedPlaywrightCIOptions,
           product: 'webkit'
         })
-      ].filter(Boolean)
+      ]
     }
   ]
 };


### PR DESCRIPTION
Follow up to #1829 .
At least some of the errors were found to also affect Epiphany , not just the playwright built , unlike previously reported (https://github.com/openpgpjs/openpgpjs/pull/1829/commits/4762d2c7623eccaf297a2bf9f4c7aa957aa32c6f) .