### PR TITLE
Use native CompressionStream/DecompressionStream when not streaming

### DIFF
--- a/src/packet/compressed_data.js
+++ b/src/packet/compressed_data.js
@@ -146,6 +146,9 @@ class CompressedDataPacket {
     const data = this.packets.write();
     let compressed = compressionFn(data);
     if (!isStream(data) || isArrayStream(data)) {
+      // Convert back to an ArrayStream when we weren't streaming before,
+      // even if web streams were used internally while compressing,
+      // so that we don't return a stream from the high-level function.
       compressed = streamFromAsync(() => streamReadToEnd(compressed));
     }
     this.compressed = compressed;


### PR DESCRIPTION
Use the native compression/decompression API even when not streaming.

Fix #1718.

To be merged after #1933.