### PR TITLE
Bump timeout for browser tests

### DIFF
--- a/test/unittests.html
+++ b/test/unittests.html
@@ -15,7 +15,7 @@
         // setup mocha
         mocha.setup({
           ui: 'bdd',
-          timeout: 45000
+          timeout: 60000
         });
 
         // Safari 14 does not support top-level await


### PR DESCRIPTION
The Argon2 memory-heavy test takes longer in Firefox.

Follow up fix to:
- [04c59a297a700f27bd0cd79d9f4b86aef3dda278](https://github.com/openpgpjs/openpgpjs/commit/04c59a297a700f27bd0cd79d9f4b86aef3dda278)
- [4aad1d1e34dd9cb6e5846364c0de549d27cc6e64](https://github.com/openpgpjs/openpgpjs/commit/4aad1d1e34dd9cb6e5846364c0de549d27cc6e64)