### PR TITLE
[v7] RSA: drop non-native code for key generation

### DIFF
--- a/src/crypto/public_key/dsa.js
+++ b/src/crypto/public_key/dsa.js
@@ -177,7 +177,7 @@ export async function validateParams(pBytes, qBytes, gBytes, yBytes, xBytes) {
    */
   const qSize = BigInt(bitLength(q));
   const _150n = BigInt(150);
-  if (qSize < _150n || !isProbablePrime(q, null, 32)) {
+  if (qSize < _150n || !isProbablePrime(q, 32)) {
     return false;
   }
 

--- a/src/crypto/public_key/prime.ts
+++ b/src/crypto/public_key/prime.ts
@@ -20,42 +20,10 @@
  * @module crypto/public_key/prime
  * @access private
  */
-import { bigIntToNumber, bitLength, gcd, getBit, mod, modExp } from '../biginteger';
+import { bitLength, gcd, getBit, mod, modExp } from '../biginteger';
 import { getRandomBigInteger } from '../random';
 
 const _1n = BigInt(1);
-
-/**
- * Generate a probably prime random number
- * @param bits - Bit length of the prime
- * @param e - Optional RSA exponent to check against the prime
- * @param k - Optional number of iterations of Miller-Rabin test
- */
-export function randomProbablePrime(bits: number, e: bigint, k: number) {
-  const _30n = BigInt(30);
-  const min = _1n << BigInt(bits - 1);
-  /*
-   * We can avoid any multiples of 3 and 5 by looking at n mod 30
-   * n mod 30 = 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
-   * the next possible prime is mod 30:
-   *            1  7  7  7  7  7  7 11 11 11 11 13 13 17 17 17 17 19 19 23 23 23 23 29 29 29 29 29 29 1
-   */
-  const adds = [1, 6, 5, 4, 3, 2, 1, 4, 3, 2, 1, 2, 1, 4, 3, 2, 1, 2, 1, 4, 3, 2, 1, 6, 5, 4, 3, 2, 1, 2];
-
-  let n = getRandomBigInteger(min, min << _1n);
-  let i = bigIntToNumber(mod(n, _30n));
-
-  do {
-    n += BigInt(adds[i]);
-    i = (i + adds[i]) % adds.length;
-    // If reached the maximum, go back to the minimum.
-    if (bitLength(n) > bits) {
-      n = mod(n, min << _1n); n += min;
-      i = bigIntToNumber(mod(n, _30n));
-    }
-  } while (!isProbablePrime(n, e, k));
-  return n;
-}
 
 /**
  * Probabilistic primality testing

--- a/src/crypto/public_key/prime.ts
+++ b/src/crypto/public_key/prime.ts
@@ -16,57 +16,21 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /**
- * @fileoverview Algorithms for probabilistic random prime generation
+ * @fileoverview Algorithms for probabilistic random prime testing
  * @module crypto/public_key/prime
  * @access private
  */
-import { bigIntToNumber, bitLength, gcd, getBit, mod, modExp } from '../biginteger.ts';
+import { bitLength, getBit, mod, modExp } from '../biginteger.ts';
 import { getRandomBigInteger } from '../random.js';
 
 const _1n = BigInt(1);
 
 /**
- * Generate a probably prime random number
- * @param bits - Bit length of the prime
- * @param e - Optional RSA exponent to check against the prime
- * @param k - Optional number of iterations of Miller-Rabin test
- */
-export function randomProbablePrime(bits: number, e: bigint, k: number) {
-  const _30n = BigInt(30);
-  const min = _1n << BigInt(bits - 1);
-  /*
-   * We can avoid any multiples of 3 and 5 by looking at n mod 30
-   * n mod 30 = 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
-   * the next possible prime is mod 30:
-   *            1  7  7  7  7  7  7 11 11 11 11 13 13 17 17 17 17 19 19 23 23 23 23 29 29 29 29 29 29 1
-   */
-  const adds = [1, 6, 5, 4, 3, 2, 1, 4, 3, 2, 1, 2, 1, 4, 3, 2, 1, 2, 1, 4, 3, 2, 1, 6, 5, 4, 3, 2, 1, 2];
-
-  let n = getRandomBigInteger(min, min << _1n);
-  let i = bigIntToNumber(mod(n, _30n));
-
-  do {
-    n += BigInt(adds[i]);
-    i = (i + adds[i]) % adds.length;
-    // If reached the maximum, go back to the minimum.
-    if (bitLength(n) > bits) {
-      n = mod(n, min << _1n); n += min;
-      i = bigIntToNumber(mod(n, _30n));
-    }
-  } while (!isProbablePrime(n, e, k));
-  return n;
-}
-
-/**
  * Probabilistic primality testing
  * @param n - Number to test
- * @param e - Optional RSA exponent to check against the prime
  * @param k - Optional number of iterations of Miller-Rabin test
  */
-export function isProbablePrime(n: bigint, e: bigint, k: number) {
-  if (e && gcd(n - _1n, e) !== _1n) {
-    return false;
-  }
+export function isProbablePrime(n: bigint, k: number) {
   if (!divisionTest(n)) {
     return false;
   }
@@ -87,11 +51,11 @@ export function isProbablePrime(n: bigint, e: bigint, k: number) {
  * @param n - Number to test
  * @param b - Optional Fermat test base
  */
-export function fermat(n: bigint, b = BigInt(2)) {
+function fermat(n: bigint, b = BigInt(2)) {
   return modExp(b, n - _1n, n) === _1n;
 }
 
-export function divisionTest(n: bigint) {
+function divisionTest(n: bigint) {
   const _0n = BigInt(0);
   return smallPrimes.every(m => mod(n, m) !== _0n);
 }
@@ -218,7 +182,7 @@ const smallPrimes = [
  * @returns {boolean}
  * @async
  */
-export function millerRabin(n: bigint, k: number, rand?: () => bigint) {
+function millerRabin(n: bigint, k: number, rand?: () => bigint) {
   const len = bitLength(n);
 
   if (!k) {

--- a/src/crypto/public_key/rsa.js
+++ b/src/crypto/public_key/rsa.js
@@ -20,7 +20,6 @@
  * @module crypto/public_key/rsa
  * @access private
  */
-import { randomProbablePrime } from './prime';
 import { getRandomBigInteger } from '../random';
 import util from '../../util';
 import { uint8ArrayToB64, b64ToUint8Array } from '../../encoding/base64';
@@ -192,35 +191,7 @@ export async function generate(bits, e) {
     });
     return jwkToPrivate(jwk, e);
   }
-
-  // RSA keygen fallback using 40 iterations of the Miller-Rabin test
-  // See https://stackoverflow.com/a/6330138 for justification
-  // Also see section C.3 here: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST
-  let p;
-  let q;
-  let n;
-  do {
-    q = randomProbablePrime(bits - (bits >> 1), e, 40);
-    p = randomProbablePrime(bits >> 1, e, 40);
-    n = p * q;
-  } while (bitLength(n) !== bits);
-
-  const phi = (p - _1n) * (q - _1n);
-
-  if (q < p) {
-    [p, q] = [q, p];
-  }
-
-  return {
-    n: bigIntToUint8Array(n),
-    e: bigIntToUint8Array(e),
-    d: bigIntToUint8Array(modInv(e, phi)),
-    p: bigIntToUint8Array(p),
-    q: bigIntToUint8Array(q),
-    // dp: d.mod(p.subn(1)),
-    // dq: d.mod(q.subn(1)),
-    u: bigIntToUint8Array(modInv(p, q))
-  };
+  throw new Error('Native API support is required for RSA key generation')
 }
 
 /**

--- a/src/crypto/public_key/rsa.js
+++ b/src/crypto/public_key/rsa.js
@@ -20,7 +20,6 @@
  * @module crypto/public_key/rsa
  * @access private
  */
-import { randomProbablePrime } from './prime.ts';
 import { getRandomBigInteger } from '../random.js';
 import util from '../../util.js';
 import { uint8ArrayToB64, b64ToUint8Array } from '../../encoding/base64.js';
@@ -192,35 +191,7 @@ export async function generate(bits, e) {
     });
     return jwkToPrivate(jwk, e);
   }
-
-  // RSA keygen fallback using 40 iterations of the Miller-Rabin test
-  // See https://stackoverflow.com/a/6330138 for justification
-  // Also see section C.3 here: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST
-  let p;
-  let q;
-  let n;
-  do {
-    q = randomProbablePrime(bits - (bits >> 1), e, 40);
-    p = randomProbablePrime(bits >> 1, e, 40);
-    n = p * q;
-  } while (bitLength(n) !== bits);
-
-  const phi = (p - _1n) * (q - _1n);
-
-  if (q < p) {
-    [p, q] = [q, p];
-  }
-
-  return {
-    n: bigIntToUint8Array(n),
-    e: bigIntToUint8Array(e),
-    d: bigIntToUint8Array(modInv(e, phi)),
-    p: bigIntToUint8Array(p),
-    q: bigIntToUint8Array(q),
-    // dp: d.mod(p.subn(1)),
-    // dq: d.mod(q.subn(1)),
-    u: bigIntToUint8Array(modInv(p, q))
-  };
+  throw new Error('Web Crypto or Node Crypto support is required for RSA key generation')
 }
 
 /**

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -143,11 +143,6 @@ export default () => describe('Symmetric AES-EAX', function() {
   };
 
   describe('Symmetric AES-EAX (native)', function() {
-    before(function () {
-      const detectNative = () => !!(util.getWebCrypto() || util.getNodeCrypto());
-      if (!detectNative()) { this.skip(); }
-    });
-
     beforeEach(function () {
       sinonSandbox = sinon.createSandbox();
       enableNative();

--- a/test/crypto/rsa.js
+++ b/test/crypto/rsa.js
@@ -23,8 +23,6 @@ export default () => describe('basic RSA cryptography', function () {
     sinonSandbox.restore();
   });
 
-  const detectNative = () => !!(util.getWebCrypto() || util.getNodeCrypto());
-
   const disableNative = () => {
     enableNative();
     // stubbed functions return undefined
@@ -91,8 +89,6 @@ export default () => describe('basic RSA cryptography', function () {
   });
 
   it('compare native crypto and bnSign', async function() {
-    if (!detectNative()) { this.skip(); }
-
     const bits = 1024;
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);
     const { n, e, d, p, q, u } = { ...publicParams, ...privateParams };
@@ -108,8 +104,6 @@ export default () => describe('basic RSA cryptography', function () {
   });
 
   it('compare native crypto and bnSign: throw on key size shorter than digest size', async function() {
-    if (!detectNative()) { this.skip(); }
-
     const bits = 512;
     const hashName = 'sha512'; // digest too long for a 512-bit key
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);
@@ -124,8 +118,6 @@ export default () => describe('basic RSA cryptography', function () {
   });
 
   it('compare native crypto and bnVerify', async function() {
-    if (!detectNative()) { this.skip(); }
-
     const bits = 1024;
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);
     const { n, e, d, p, q, u } = { ...publicParams, ...privateParams };

--- a/test/crypto/rsa.js
+++ b/test/crypto/rsa.js
@@ -48,20 +48,6 @@ export default () => describe('basic RSA cryptography', function () {
     expect(util.uint8ArrayBitLength(keyObject.n)).to.equal(bits);
   });
 
-  it('generate rsa key - without native crypto', async function() {
-    const bits = 1024;
-    disableNative();
-    const keyObject = await crypto.publicKey.rsa.generate(bits, 65537);
-    enableNative();
-    expect(keyObject.n).to.exist;
-    expect(keyObject.e).to.exist;
-    expect(keyObject.d).to.exist;
-    expect(keyObject.p).to.exist;
-    expect(keyObject.q).to.exist;
-    expect(keyObject.u).to.exist;
-    expect(util.uint8ArrayBitLength(keyObject.n)).to.equal(bits);
-  });
-
   it('sign and verify using generated key params', async function() {
     const bits = 1024;
     const { publicParams, privateParams } = await crypto.generateParams(openpgp.enums.publicKey.rsaSign, bits);


### PR DESCRIPTION
Since WebCrypto API support has been required since v6, this is not expected to be a breaking change, as RSA key generation should be implemented by all platforms providing the WebCrypto or NodeCrypto API.

The fallback code for signing and verifying needs to remain in place as WebCrypto does not support streamed data.
