### PR TITLE
[v7] fix: properly certify when primary key is certify-only

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -79,8 +79,8 @@ export abstract class Key {
   public verifyAllUsers(publicKeys?: PublicKey[], date?: Date, config?: Config): Promise<{ userID: string, keyID: KeyID, valid: boolean | null }[]>;
   public isRevoked(signature?: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public getRevocationCertificate(date?: Date, config?: Config): Promise<MaybeStream<string> | undefined>;
+  public getVerificationKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getEncryptionKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
-  public getSigningKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getKeys(keyID?: KeyID): (this | Subkey)[];
   public getSubkeys(keyID?: KeyID): Subkey[];
   public getFingerprint(): string;
@@ -100,6 +100,7 @@ export class PrivateKey extends PublicKey {
   public revoke(reason?: ReasonForRevocation, date?: Date, config?: Config): Promise<PrivateKey>;
   public isDecrypted(): boolean;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
+  public getSigningKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<(PrivateKey | Subkey)[]>;
   public update(sourceKey: PublicKey, date?: Date, config?: Config): Promise<PrivateKey>;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -360,7 +360,7 @@ declare abstract class BasePublicKeyPacket extends BasePacket<true> {
   public hasSameFingerprintAs(other: BasePublicKeyPacket): boolean;
   public getCreationTime(): Date;
   public getKeyID(): KeyID;
-  public isDecrypted(): boolean;
+  public isDecrypted(): boolean | null;
   public publicParams: object;
   // `isSubkey` is a dummy method to ensure that Subkey packets are not accepted as Key one, and vice versa.
   // The key class hierarchy is already modelled to cover this, but the concrete key packet classes
@@ -371,11 +371,13 @@ declare abstract class BasePublicKeyPacket extends BasePacket<true> {
 export class PublicKeyPacket extends BasePublicKeyPacket {
   static readonly tag: enums.packet.publicKey;
   protected isSubkey(): false;
+  public isDecrypted(): null;
 }
 
 export class PublicSubkeyPacket extends BasePublicKeyPacket {
   static readonly tag: enums.packet.publicSubkey;
   protected isSubkey(): true;
+  public isDecrypted(): null;
 }
 
 declare abstract class BaseSecretKeyPacket extends BasePublicKeyPacket {
@@ -383,6 +385,7 @@ declare abstract class BaseSecretKeyPacket extends BasePublicKeyPacket {
   public encrypt(passphrase: string, config?: Config): Promise<void>; // throws on error
   public decrypt(passphrase: string): Promise<void>; // throws on error
   public validate(): Promise<void>; // throws on error
+  public isDecrypted(): boolean;
   public isDummy(): boolean;
   public isMissingSecretKeyMaterial(): boolean;
   public makeDummy(config?: Config): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -361,6 +361,7 @@ declare abstract class BasePublicKeyPacket extends BasePacket<true> {
   public hasSameFingerprintAs(other: BasePublicKeyPacket): boolean;
   public getCreationTime(): Date;
   public getKeyID(): KeyID;
+  public isPrivate(): this is BaseSecretKeyPacket;
   public isDecrypted(): boolean | null;
   public publicParams: object;
   // `isSubkey` is a dummy method to ensure that Subkey packets are not accepted as Key one, and vice versa.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -80,6 +80,7 @@ export abstract class Key {
   public isRevoked(signature?: SignaturePacket, key?: AnyKeyPacket, date?: Date, config?: Config): Promise<boolean>;
   public getRevocationCertificate(date?: Date, config?: Config): Promise<MaybeStream<string> | undefined>;
   public getVerificationKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
+  public getCertVerificationKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getEncryptionKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getKeys(keyID?: KeyID): (this | Subkey)[];
   public getSubkeys(keyID?: KeyID): Subkey[];
@@ -101,6 +102,7 @@ export class PrivateKey extends PublicKey {
   public isDecrypted(): boolean;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
   public getSigningKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
+  public getCertSigningKey(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<this | Subkey>;
   public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<(PrivateKey | Subkey)[]>;
   public update(sourceKey: PublicKey, date?: Date, config?: Config): Promise<PrivateKey>;
 }

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -56,15 +56,18 @@ const allowedKeyPackets = /*#__PURE__*/ util.constructAllowedPackets([
  * @throws if no key packet was found
  */
 function createKey(packetlist) {
-  for (const packet of packetlist) {
-    switch (packet.constructor.tag) {
-      case enums.packet.secretKey:
-        return new PrivateKey(packetlist);
-      case enums.packet.publicKey:
-        return new PublicKey(packetlist);
+  if (packetlist[0]?.constructor.tag === enums.packet.secretKey) {
+    return new PrivateKey(packetlist);
+  } else if (packetlist[0]?.constructor.tag === enums.packet.publicKey) {
+    if (packetlist.findPacket(enums.packet.secretSubkey)) {
+      return new PrivateKey(packetlist);
+    } else {
+      return new PublicKey(packetlist);
     }
+  } else {
+    throw new Error('No primary key packet found');
   }
-  throw new Error('No key packet found');
+
 }
 
 
@@ -388,10 +391,10 @@ export async function readPrivateKey({ armoredKey, binaryKey, config, ...rest })
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
   const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
   for (let i = 0; i < keyIndex.length; i++) {
-    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey) {
+    const firstPrivateKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
+    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey && !firstPrivateKeyList.findPacket(enums.packet.secretSubkey)) {
       continue;
     }
-    const firstPrivateKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
     return new PrivateKey(firstPrivateKeyList);
   }
   throw new Error('No secret key packet found');
@@ -475,10 +478,10 @@ export async function readPrivateKeys({ armoredKeys, binaryKeys, config }) {
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
   const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
   for (let i = 0; i < keyIndex.length; i++) {
-    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey) {
+    const oneKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
+    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey && !oneKeyList.findPacket(enums.packet.secretSubkey)) {
       continue;
     }
-    const oneKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
     const newKey = new PrivateKey(oneKeyList);
     keys.push(newKey);
   }

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -392,7 +392,7 @@ export async function readPrivateKey({ armoredKey, binaryKey, config, ...rest })
   const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
   for (let i = 0; i < keyIndex.length; i++) {
     const firstPrivateKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
-    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey && !firstPrivateKeyList.findPacket(enums.packet.secretSubkey)) {
+    if (firstPrivateKeyList[0].constructor.tag === enums.packet.publicKey && !firstPrivateKeyList.findPacket(enums.packet.secretSubkey)) {
       continue;
     }
     return new PrivateKey(firstPrivateKeyList);
@@ -479,7 +479,7 @@ export async function readPrivateKeys({ armoredKeys, binaryKeys, config }) {
   const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
   for (let i = 0; i < keyIndex.length; i++) {
     const oneKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
-    if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey && !oneKeyList.findPacket(enums.packet.secretSubkey)) {
+    if (oneKeyList[0].constructor.tag === enums.packet.publicKey && !oneKeyList.findPacket(enums.packet.secretSubkey)) {
       continue;
     }
     const newKey = new PrivateKey(oneKeyList);

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -473,6 +473,25 @@ export function validateSigningKeyPacket(keyPacket, signature, config) {
   }
 }
 
+export function validateCertificationKeyPacket(keyPacket, signature, config) {
+  switch (keyPacket.algorithm) {
+    case enums.publicKey.rsaEncryptSign:
+    case enums.publicKey.rsaSign:
+    case enums.publicKey.dsa:
+    case enums.publicKey.ecdsa:
+    case enums.publicKey.eddsaLegacy:
+    case enums.publicKey.ed25519:
+    case enums.publicKey.ed448:
+      if (!signature.keyFlags && !config.allowMissingKeyFlags) {
+        throw new Error('None of the key flags is set: consider passing `config.allowMissingKeyFlags`');
+      }
+      return !signature.keyFlags ||
+        (signature.keyFlags[0] & enums.keyFlags.certifyKeys) !== 0;
+    default:
+      return false;
+  }
+}
+
 export function validateEncryptionKeyPacket(keyPacket, signature, config) {
   switch (keyPacket.algorithm) {
     case enums.publicKey.rsaEncryptSign:

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -291,8 +291,8 @@ export async function getPreferredCipherSuite(keys = [], date = new Date(), user
  * @returns {Promise<SignaturePacket>} Signature packet.
  */
 export async function createSignaturePacket(dataToSign, recipientKeys, signingKeyPacket, signatureProperties, date, recipientUserIDs, notations = [], detached = false, config) {
-  if (signingKeyPacket.isDummy()) {
-    throw new Error('Cannot sign with a gnu-dummy key.');
+  if (isPublicOrDummyKeyPacket(signingKeyPacket)) {
+    throw new Error('Cannot sign with a public or dummy key.');
   }
   if (!signingKeyPacket.isDecrypted()) {
     throw new Error('Signing key is not decrypted.');

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -554,4 +554,4 @@ export function checkKeyRequirements(keyPacket, config) {
   }
 }
 
-export const isPublicOrDummyKeyPacket = keyPacket => keyPacket.isDecrypted() === null || keyPacket.isDummy();
+export const isPublicOrDummyKeyPacket = keyPacket => !keyPacket.isPrivate() || keyPacket.isDummy();

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -553,3 +553,5 @@ export function checkKeyRequirements(keyPacket, config) {
       break;
   }
 }
+
+export const isPublicOrDummyKeyPacket = keyPacket => keyPacket.isDecrypted() === null || keyPacket.isDummy();

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -257,16 +257,18 @@ class Key {
   }
 
   /**
-   * Returns last created key or key by given keyID that is available for signing and verification
+   * Returns last created key or key by given keyID that is available for signing or verification
+   * @param  {Boolean} [needPrivateKeyMaterial] - whether the key will be used for signing
    * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
    * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
    * @param  {Object} [userID] - filter keys for the given user ID
    * @param  {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Key|Subkey>} signing key
-   * @throws if no valid signing key was found
+   * @throws if no valid signing/verification key was found
    * @async
+   * @private
    */
-  async getSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+  async getSigningOrVerificationKey(needPrivateKeyMaterial = false, keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
     await this.verifyPrimaryKey(date, userID, config);
     const primaryKey = this.keyPacket;
     try {
@@ -284,7 +286,7 @@ class Key {
     for (const subkey of subkeys) {
       if (!keyID || subkey.getKeyID().equals(keyID)) {
         try {
-          if (!keyID && helper.isPublicOrDummyKeyPacket(subkey.keyPacket)) {
+          if (needPrivateKeyMaterial && helper.isPublicOrDummyKeyPacket(subkey.keyPacket)) {
             throw new Error('Cannot sign with a public or dummy key');
           }
           await subkey.verify(date, config);
@@ -314,7 +316,7 @@ class Key {
       const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
           helper.validateSigningKeyPacket(primaryKey, selfCertification, config)) {
-        if (!keyID && helper.isPublicOrDummyKeyPacket(primaryKey)) {
+        if (needPrivateKeyMaterial && helper.isPublicOrDummyKeyPacket(primaryKey)) {
           throw new Error('Cannot sign with a public or dummy key');
         }
         helper.checkKeyRequirements(primaryKey, config);
@@ -324,6 +326,20 @@ class Key {
       exception = e;
     }
     throw util.wrapError('Could not find valid signing key packet in key ' + this.getKeyID().toHex(), exception);
+  }
+
+  /**
+   * Returns last created key or key by given keyID that is available for verification
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} verification key
+   * @throws if no valid verification key was found
+   * @async
+   */
+  async getVerificationKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+    return this.getSigningOrVerificationKey(false, keyID, date, userID, config);
   }
 
   /**

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -261,7 +261,7 @@ class Key {
    * @param  {Boolean} [needPrivateKeyMaterial] - whether the key will be used for signing
    * @param  {Function} [validateKeyPacket] - function to verify the signing/certification key packet
    * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
-   * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
+   * @param  {Date} [date] - use the given date to check key validity instead of the current date
    * @param  {Object} [userID] - filter keys for the given user ID
    * @param  {Object} [config] - Full configuration, defaults to openpgp.config
    * @returns {Promise<Key|Subkey>} signing key

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -274,9 +274,11 @@ class Key {
     } catch (err) {
       throw util.wrapError('Could not verify primary key', err);
     }
-    // Prefer the most recently created valid subkey, or the subkey with
-    // the highest algorithm ID in case of equal creation timestamps.
+    // Prefer the most recently created valid (and non-dummy) secret subkey,
+    // or the subkey with the highest algorithm ID in case of equal creation
+    // timestamps.
     const subkeys = this.subkeys.slice().sort((a, b) => (
+      (b.isDecrypted() !== null && !b.isDummy()) - (a.isDecrypted() !== null && !a.isDummy()) ||
       b.keyPacket.created - a.keyPacket.created ||
       b.keyPacket.algorithm - a.keyPacket.algorithm
     ));

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -278,7 +278,7 @@ class Key {
     // or the subkey with the highest algorithm ID in case of equal creation
     // timestamps.
     const subkeys = this.subkeys.slice().sort((a, b) => (
-      (b.isDecrypted() !== null && !b.isDummy()) - (a.isDecrypted() !== null && !a.isDummy()) ||
+      !helper.isPublicOrDummyKeyPacket(b.keyPacket) - !helper.isPublicOrDummyKeyPacket(a.keyPacket) ||
       b.keyPacket.created - a.keyPacket.created ||
       b.keyPacket.algorithm - a.keyPacket.algorithm
     ));

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -259,6 +259,7 @@ class Key {
   /**
    * Returns last created key or key by given keyID that is available for signing or verification
    * @param  {Boolean} [needPrivateKeyMaterial] - whether the key will be used for signing
+   * @param  {Function} [validateKeyPacket] - function to verify the signing/certification key packet
    * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
    * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
    * @param  {Object} [userID] - filter keys for the given user ID
@@ -268,7 +269,7 @@ class Key {
    * @async
    * @private
    */
-  async getSigningOrVerificationKey(needPrivateKeyMaterial = false, keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+  async getSigningOrVerificationKey(needPrivateKeyMaterial = false, validateKeyPacket, keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
     await this.verifyPrimaryKey(date, userID, config);
     const primaryKey = this.keyPacket;
     try {
@@ -294,7 +295,7 @@ class Key {
           const bindingSignature = await helper.getLatestValidSignature(
             subkey.bindingSignatures, primaryKey, enums.signature.subkeyBinding, dataToVerify, date, config
           );
-          if (!helper.validateSigningKeyPacket(subkey.keyPacket, bindingSignature, config)) {
+          if (!validateKeyPacket(subkey.keyPacket, bindingSignature, config)) {
             continue;
           }
           if (!bindingSignature.embeddedSignature) {
@@ -315,7 +316,7 @@ class Key {
     try {
       const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
-          helper.validateSigningKeyPacket(primaryKey, selfCertification, config)) {
+          validateKeyPacket(primaryKey, selfCertification, config)) {
         if (needPrivateKeyMaterial && helper.isPublicOrDummyKeyPacket(primaryKey)) {
           throw new Error('Cannot sign with a public or dummy key');
         }
@@ -339,7 +340,21 @@ class Key {
    * @async
    */
   async getVerificationKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
-    return this.getSigningOrVerificationKey(false, keyID, date, userID, config);
+    return this.getSigningOrVerificationKey(false, helper.validateSigningKeyPacket, keyID, date, userID, config);
+  }
+
+  /**
+   * Returns last created key or key by given keyID that is available for certification verification
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date} [date] - use the given date to check key validity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} certification verification key
+   * @throws if no valid certification verification key was found
+   * @async
+   */
+  async getCertVerificationKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+    return this.getSigningOrVerificationKey(false, helper.validateCertificationKeyPacket, keyID, date, userID, config);
   }
 
   /**

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -50,13 +50,14 @@ class Key {
   /**
    * Transforms packetlist to structured key data
    * @param {PacketList} packetlist - The packets that form a key
-   * @param {Set<enums.packet>} disallowedPackets - disallowed packet tags
+   * @param {Boolean} expectPrivateKey - if a private key is expected, a SecretKeyPacket or SecretKeySubpacket must be present.
    */
-  packetListToStructure(packetlist, disallowedPackets = new Set()) {
+  packetListToStructure(packetlist, expectPrivateKey) {
     let user;
     let primaryKeyID;
     let subkey;
     let ignoreUntil;
+    let isPrivateKey;
 
     for (const packet of packetlist) {
 
@@ -79,7 +80,8 @@ class Key {
         if (!ignoreUntil.has(tag)) continue;
         ignoreUntil = null;
       }
-      if (disallowedPackets.has(tag)) {
+      isPrivateKey = isPrivateKey || tag === enums.packet.secretKey || tag === enums.packet.secretSubkey;
+      if (!expectPrivateKey && isPrivateKey) {
         throw new Error(`Unexpected packet type: ${tag}`);
       }
       switch (tag) {
@@ -151,6 +153,13 @@ class Key {
           }
           break;
       }
+    }
+
+    if (!this.keyPacket) {
+      throw new Error('Invalid key: missing primary key packet');
+    }
+    if (expectPrivateKey && !isPrivateKey) {
+      throw new Error('No secret key packet found');
     }
   }
 

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -274,11 +274,9 @@ class Key {
     } catch (err) {
       throw util.wrapError('Could not verify primary key', err);
     }
-    // Prefer the most recently created valid (and non-dummy) secret subkey,
-    // or the subkey with the highest algorithm ID in case of equal creation
-    // timestamps.
+    // Prefer the most recently created valid subkey, or the subkey with
+    // the highest algorithm ID in case of equal creation timestamps.
     const subkeys = this.subkeys.slice().sort((a, b) => (
-      !helper.isPublicOrDummyKeyPacket(b.keyPacket) - !helper.isPublicOrDummyKeyPacket(a.keyPacket) ||
       b.keyPacket.created - a.keyPacket.created ||
       b.keyPacket.algorithm - a.keyPacket.algorithm
     ));
@@ -286,6 +284,9 @@ class Key {
     for (const subkey of subkeys) {
       if (!keyID || subkey.getKeyID().equals(keyID)) {
         try {
+          if (!keyID && helper.isPublicOrDummyKeyPacket(subkey.keyPacket)) {
+            throw new Error('Cannot sign with a public or dummy key');
+          }
           await subkey.verify(date, config);
           const dataToVerify = { key: primaryKey, bind: subkey.keyPacket };
           const bindingSignature = await helper.getLatestValidSignature(
@@ -313,6 +314,9 @@ class Key {
       const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
       if ((!keyID || primaryKey.getKeyID().equals(keyID)) &&
           helper.validateSigningKeyPacket(primaryKey, selfCertification, config)) {
+        if (!keyID && helper.isPublicOrDummyKeyPacket(primaryKey)) {
+          throw new Error('Cannot sign with a public or dummy key');
+        }
         helper.checkKeyRequirements(primaryKey, config);
         return this;
       }

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -69,6 +69,20 @@ class PrivateKey extends PublicKey {
   }
 
   /**
+   * Returns last created key or key by given keyID that is available for signing
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} signing key
+   * @throws if no valid signing key was found
+   * @async
+   */
+  async getSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+    return this.getSigningOrVerificationKey(true, keyID, date, userID, config);
+  }
+
+  /**
    * Returns all keys that are available for decryption, matching the keyID when given
    * This is useful to retrieve keys for session key decryption
    * @param  {module:type/keyid~KeyID} keyID, optional
@@ -143,6 +157,12 @@ class PrivateKey extends PublicKey {
       throw new Error('Cannot validate a public key');
     }
 
+    const keys = this.getKeys();
+    const allPublicOrDummies = keys.map(key => helper.isPublicOrDummyKeyPacket(key.keyPacket)).every(Boolean);
+    if (allPublicOrDummies) {
+      throw new Error('Cannot validate key without secret key material');
+    }
+
     let signingKeyPacket;
     if (!helper.isPublicOrDummyKeyPacket(this.keyPacket)) {
       signingKeyPacket = this.keyPacket;
@@ -151,9 +171,8 @@ class PrivateKey extends PublicKey {
        * It is enough to validate any signing keys
        * since its binding signatures are also checked
        */
-      const signingKey = await this.getSigningKey(null, null, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRSABits: 0 });
-      // This could again be a dummy key
-      if (signingKey && !helper.isPublicOrDummyKeyPacket(signingKey.keyPacket)) {
+      const signingKey = await this.getSigningKey(null, null, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRSABits: 0 }).catch(() => {});
+      if (signingKey) {
         signingKeyPacket = signingKey.keyPacket;
       }
     }
@@ -161,12 +180,6 @@ class PrivateKey extends PublicKey {
     if (signingKeyPacket) {
       return signingKeyPacket.validate();
     } else {
-      const keys = this.getKeys();
-      const allPublicOrDummies = keys.map(key => helper.isPublicOrDummyKeyPacket(key.keyPacket)).every(Boolean);
-      if (allPublicOrDummies) {
-        throw new Error('Cannot validate key without secret key material');
-      }
-
       return Promise.all(keys.map(key => helper.isPublicOrDummyKeyPacket(key.keyPacket) || key.keyPacket.validate()));
     }
   }

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -144,7 +144,7 @@ class PrivateKey extends PublicKey {
     }
 
     let signingKeyPacket;
-    if (!this.keyPacket.isDummy()) {
+    if (!helper.isPublicOrDummyKeyPacket(this.keyPacket)) {
       signingKeyPacket = this.keyPacket;
     } else {
       /**
@@ -153,7 +153,7 @@ class PrivateKey extends PublicKey {
        */
       const signingKey = await this.getSigningKey(null, null, undefined, { ...config, rejectPublicKeyAlgorithms: new Set(), minRSABits: 0 });
       // This could again be a dummy key
-      if (signingKey && !signingKey.keyPacket.isDummy()) {
+      if (signingKey && !helper.isPublicOrDummyKeyPacket(signingKey.keyPacket)) {
         signingKeyPacket = signingKey.keyPacket;
       }
     }
@@ -162,12 +162,12 @@ class PrivateKey extends PublicKey {
       return signingKeyPacket.validate();
     } else {
       const keys = this.getKeys();
-      const allDummies = keys.map(key => key.keyPacket.isDummy()).every(Boolean);
-      if (allDummies) {
-        throw new Error('Cannot validate an all-gnu-dummy key');
+      const allPublicOrDummies = keys.map(key => helper.isPublicOrDummyKeyPacket(key.keyPacket)).every(Boolean);
+      if (allPublicOrDummies) {
+        throw new Error('Cannot validate key without secret key material');
       }
 
-      return Promise.all(keys.map(key => key.keyPacket.validate()));
+      return Promise.all(keys.map(key => helper.isPublicOrDummyKeyPacket(key.keyPacket) || key.keyPacket.validate()));
     }
   }
 
@@ -237,14 +237,14 @@ class PrivateKey extends PublicKey {
     if (options.rsaBits < config.minRSABits) {
       throw new Error(`rsaBits should be at least ${config.minRSABits}, got: ${options.rsaBits}`);
     }
-    const secretKeyPacket = this.keyPacket;
-    if (secretKeyPacket.isDummy()) {
-      throw new Error('Cannot add subkey to gnu-dummy primary key');
+    const primaryKeyPacket = this.keyPacket;
+    if (helper.isPublicOrDummyKeyPacket(primaryKeyPacket)) {
+      throw new Error('Cannot add subkey to gnu-dummy or public primary key');
     }
-    if (!secretKeyPacket.isDecrypted()) {
+    if (!primaryKeyPacket.isDecrypted()) {
       throw new Error('Key is not decrypted');
     }
-    const defaultOptions = secretKeyPacket.getAlgorithmInfo();
+    const defaultOptions = primaryKeyPacket.getAlgorithmInfo();
     defaultOptions.type = getDefaultSubkeyType(defaultOptions.algorithm);
     defaultOptions.rsaBits = defaultOptions.bits || 4096;
     defaultOptions.curve = defaultOptions.curve || 'curve25519Legacy';
@@ -255,7 +255,7 @@ class PrivateKey extends PublicKey {
     // The config is always overwritten since we cannot tell if the defaultConfig was changed by the user.
     const keyPacket = await helper.generateSecretSubkey(options, { ...config, v6Keys: this.keyPacket.version === 6 });
     helper.checkKeyRequirements(keyPacket, config);
-    const bindingSignature = await helper.createBindingSignature(keyPacket, secretKeyPacket, options, config);
+    const bindingSignature = await helper.createBindingSignature(keyPacket, primaryKeyPacket, options, config);
     const packetList = this.toPacketList();
     packetList.push(keyPacket, bindingSignature);
     return new PrivateKey(packetList);

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -85,8 +85,8 @@ class PrivateKey extends PublicKey {
     let exception = null;
     for (let i = 0; i < this.subkeys.length; i++) {
       if (!keyID || this.subkeys[i].getKeyID().equals(keyID, true)) {
-        if (this.subkeys[i].keyPacket.isDummy()) {
-          exception = exception || new Error('Gnu-dummy key packets cannot be used for decryption');
+        if (helper.isPublicOrDummyKeyPacket(this.subkeys[i].keyPacket)) {
+          exception = exception || new Error('Public or gnu-dummy key packets cannot be used for decryption');
           continue;
         }
 
@@ -105,8 +105,8 @@ class PrivateKey extends PublicKey {
     // evaluate primary key
     const selfCertification = await this.getPrimarySelfSignature(date, userID, config);
     if ((!keyID || primaryKey.getKeyID().equals(keyID, true)) && helper.validateDecryptionKeyPacket(primaryKey, selfCertification, config)) {
-      if (primaryKey.isDummy()) {
-        exception = exception || new Error('Gnu-dummy key packets cannot be used for decryption');
+      if (helper.isPublicOrDummyKeyPacket(primaryKey)) {
+        exception = exception || new Error('Public or gnu-dummy key packets cannot be used for decryption');
       } else {
         keys.push(this);
       }

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -79,7 +79,21 @@ class PrivateKey extends PublicKey {
    * @async
    */
   async getSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
-    return this.getSigningOrVerificationKey(true, keyID, date, userID, config);
+    return this.getSigningOrVerificationKey(true, helper.validateSigningKeyPacket, keyID, date, userID, config);
+  }
+
+  /**
+   * Returns last created key or key by given keyID that is available for certification signing
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date} [date] - use the given date to check key validity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} certification signing key
+   * @throws if no valid certification signing key was found
+   * @async
+   */
+  async getCertSigningKey(keyID = null, date = new Date(), userID = {}, config = defaultConfig) {
+    return this.getSigningOrVerificationKey(true, helper.validateCertificationKeyPacket, keyID, date, userID, config);
   }
 
   /**

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -20,10 +20,7 @@ class PrivateKey extends PublicKey {
  */
   constructor(packetlist) {
     super();
-    this.packetListToStructure(packetlist, new Set([enums.packet.publicKey, enums.packet.publicSubkey]));
-    if (!this.keyPacket) {
-      throw new Error('Invalid key: missing private-key packet');
-    }
+    this.packetListToStructure(packetlist, true);
   }
 
   /**

--- a/src/key/public_key.js
+++ b/src/key/public_key.js
@@ -34,10 +34,7 @@ class PublicKey extends Key {
     this.users = [];
     this.subkeys = [];
     if (packetlist) {
-      this.packetListToStructure(packetlist, new Set([enums.packet.secretKey, enums.packet.secretSubkey]));
-      if (!this.keyPacket) {
-        throw new Error('Invalid key: missing public-key packet');
-      }
+      this.packetListToStructure(packetlist, false);
     }
   }
 

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -128,7 +128,7 @@ class User {
       return null;
     }
     await Promise.all(issuerKeys.map(async key => {
-      const signingKey = await key.getSigningKey(issuerKeyID, certificate.created, undefined, config);
+      const signingKey = await key.getVerificationKey(issuerKeyID, certificate.created, undefined, config);
       if (certificate.revoked || await that.isRevoked(certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -128,7 +128,7 @@ class User {
       return null;
     }
     await Promise.all(issuerKeys.map(async key => {
-      const signingKey = await key.getVerificationKey(issuerKeyID, certificate.created, undefined, config);
+      const signingKey = await key.getCertVerificationKey(issuerKeyID, certificate.created, undefined, config);
       if (certificate.revoked || await that.isRevoked(certificate, signingKey.keyPacket, date, config)) {
         throw new Error('User certificate is revoked');
       }

--- a/src/key/user.js
+++ b/src/key/user.js
@@ -72,7 +72,7 @@ class User {
       if (privateKey.hasSameFingerprintAs(primaryKey)) {
         throw new Error("The user's own key can only be used for self-certifications");
       }
-      const signingKey = await privateKey.getSigningKey(undefined, date, undefined, config);
+      const signingKey = await privateKey.getCertSigningKey(undefined, date, undefined, config);
       return createSignaturePacket(dataToSign, [privateKey], signingKey.keyPacket, {
         // Most OpenPGP implementations use generic certification (0x10)
         signatureType: enums.signature.certGeneric,

--- a/src/message.js
+++ b/src/message.js
@@ -793,14 +793,14 @@ function createVerificationObject(signature, literalDataList, verificationKeys, 
       // We pass the signature creation time to check whether the key was expired at the time of signing.
       // We check this after signature verification because for streamed one-pass signatures, the creation time is not available before
       try {
-        await primaryKey.getSigningKey(unverifiedSigningKey.getKeyID(), signaturePacket.created, undefined, config);
+        await primaryKey.getVerificationKey(unverifiedSigningKey.getKeyID(), signaturePacket.created, undefined, config);
       } catch (e) {
         // If a key was reformatted then the self-signatures of the signing key might be in the future compared to the message signature,
         // making the key invalid at the time of signing.
         // However, if the key is valid at the given `date`, we still allow using it provided the relevant `config` setting is enabled.
         // Note: we do not support the edge case of a key that was reformatted and it has expired.
         if (config.allowInsecureVerificationWithReformattedKeys && e.message.match(/Signature creation time is in the future/)) {
-          await primaryKey.getSigningKey(unverifiedSigningKey.getKeyID(), date, undefined, config);
+          await primaryKey.getVerificationKey(unverifiedSigningKey.getKeyID(), date, undefined, config);
         } else {
           throw e;
         }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -22,7 +22,7 @@ import { CleartextMessage } from './cleartext.js';
 import { generate, reformat, getPreferredCompressionAlgo } from './key/index.js';
 import defaultConfig from './config.ts';
 import util from './util.js';
-import { checkKeyRequirements } from './key/helper.js';
+import { checkKeyRequirements, isPublicOrDummyKeyPacket } from './key/helper.js';
 
 
 //////////////////////
@@ -193,10 +193,13 @@ export async function decryptKey({ privateKey, passphrase, config, ...rest }) {
   const passphrases = util.isArray(passphrase) ? passphrase : [passphrase];
 
   try {
-    await Promise.all(clonedPrivateKey.getKeys().map(key => (
+    await Promise.all(clonedPrivateKey.getKeys().map(key => {
+      if (isPublicOrDummyKeyPacket(key.keyPacket)) {
+        return;
+      }
       // try to decrypt each key with any of the given passphrases
-      util.anyPromise(passphrases.map(passphrase => key.keyPacket.decrypt(passphrase, config)))
-    )));
+      return util.anyPromise(passphrases.map(passphrase => key.keyPacket.decrypt(passphrase, config)));
+    }));
 
     await clonedPrivateKey.validate(config);
     return clonedPrivateKey;
@@ -234,6 +237,9 @@ export async function encryptKey({ privateKey, passphrase, config, ...rest }) {
   try {
     await Promise.all(keys.map(async (key, i) => {
       const { keyPacket } = key;
+      if (isPublicOrDummyKeyPacket(keyPacket)) {
+        return;
+      }
       await keyPacket.encrypt(passphrases[i], config);
       keyPacket.clearPrivateParams();
     }));

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -189,6 +189,14 @@ class PublicKeyPacket {
   }
 
   /**
+   * Check whether the key is a secret-key or secret-subkey packet.
+   * @returns {Boolean}
+   */
+  isPrivate() {
+    return false;
+  }
+
+  /**
    * Check whether secret-key data is available in decrypted form. Returns null for public keys.
    * @returns {Boolean|null}
    */

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -308,6 +308,14 @@ class SecretKeyPacket extends PublicKeyPacket {
   }
 
   /**
+   * Check whether the key is a secret-key or secret-subkey packet.
+   * @returns {Boolean}
+   */
+  isPrivate() {
+    return true;
+  }
+
+  /**
    * Check whether secret-key data is available in decrypted form.
    * Returns false for gnu-dummy keys and null for public keys.
    * @returns {Boolean|null}

--- a/test/crypto/postQuantum.js
+++ b/test/crypto/postQuantum.js
@@ -855,7 +855,7 @@ Fy70NCeqH2b6JeETZ1xFQEiEInk6B9WE558S9Mi6yjeSXdV65yNK2km5
 
     // `getSigningKey()` internally verifies the ML-DSA binding sigs
     const signingKey1 = await privateKey.getSigningKey();
-    const signingKey2 = await publicKey.getSigningKey();
+    const signingKey2 = await publicKey.getVerificationKey();
 
     expect(signingKey1.getKeyID().equals(signingKey2.getKeyID())).to.be.true;
   });

--- a/test/general/config.js
+++ b/test/general/config.js
@@ -241,15 +241,15 @@ n9/quqtmyOtYOA6gXNCw0Fal3iANKBmsPmYI
     const userIDs = { name: 'Test User', email: 'text2@example.com' };
     const passphrase = '12345678';
 
-    const { privateKey: key } = await openpgp.generateKey({ userIDs, passphrase, format: 'object' });
+    const { privateKey: key } = await openpgp.generateKey({ userIDs, passphrase, format: 'object', config: { aeadProtect: true, s2kType: openpgp.enums.s2k.argon2 } });
     key.keyPacket.makeDummy();
 
     const opt = {
       privateKey: await openpgp.readKey({ armoredKey: key.armor() }),
       passphrase,
-      config: { rejectHashAlgorithms: new Set([openpgp.enums.hash.sha256, openpgp.enums.hash.sha512]) }
+      config: { maxArgon2MemoryExponent: 0 }
     };
-    await expect(openpgp.decryptKey(opt)).to.be.rejectedWith(/Insecure hash algorithm/);
+    await expect(openpgp.decryptKey(opt)).to.be.rejectedWith(/Argon2 required memory exceeds `config\.maxArgon2MemoryExponent`/);
   });
 
   it('openpgp.encryptKey', async function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1858,51 +1858,50 @@ S2rSjQ4JF0Ktgdr9585haknpGwr31t486KxXOY4AEsiBmRyvTbaQegwKaQ+C
 `;
 
 // public primary key with:
-// - one signing private subkey
 // - one signing public subkey
-// - one encryption private subkey
+// - one signing private subkey
 // - one encryption public subkey
+// - one encryption private subkey
 const privateKeyWithPublicKeyPackets = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
-xjMEZr9cyxYJKwYBBAHaRw8BAQdAlC7g7Q4UZmN5zNhFynWuEXYn1KV8Jfp4
-DMiKf8ZQ5oDNDzx0ZXN0QHRlc3QuY29tPsLAEwQTFgoAhQWCZr9cywMLCQcJ
-kPhnPZ0LDe1wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
-cmeWobLLkXmgpg9Pet9xOLiKvUAGKchlrMxBubhvTpBGygUVCAoMDgQWAAIB
-AhkBApsDAh4BFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAAAHGyAP9URiF2uq/O
-8PJkjoehixMx9h9a8L+lPd56ymbdxUb/swEA0tNWA9alk/m3rml0aTPNucuG
-Aj/FLBixvbva+SWEkgrOMwRmv1zLFgkrBgEEAdpHDwEBB0DdyjGHiVCA0Cbr
-5u5pcuZmYZylLDURujjhEWYcLKIg0MLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN
-7XBFFAAAAAAAHAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ5UtjGIA
-N+2fOlsIv9vwi5MaTUxoXXc+Mw6ETjRvW3fUApsCvKAEGRYKAG0Fgma/XMsJ
-kHC3NLlxFk7wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
-cme74M+JTJ/Clb0bApLqL/QGKOZbaXdL3Y/p02QX2o6AgRYhBFFraL50hRm3
-RC4PZHC3NLlxFk7wAABAgwEAhQ+EgvirBcabNlmHV6nEbqyTz85oBj8SKNM2
-d+tDQ3YBAN3jXoPGx22sVoy5rAMerwq1lhnlgCh4xfdTw1jtr2QEFiEEYmvn
-2jb9uzAG41Ql+Gc9nQsN7XAAALGsAQCCDkhWJRgiCoHIvjWwRqVWU1BsVaj5
-dr6fxkK9yaOv6QEA+JjqAgPcRo/LGHpO0dZS9qi1Zpy4u5bT2FunXqvNDQ7O
-MwRmv1zLFgkrBgEEAdpHDwEBB0A4CyxR5ZSvF8FrEhjzFO8W6paAtqm92p7k
-+HQC7TRhKcLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAAHAAgc2Fs
-dEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ8eA420LE1oqZm9UQ2mAl0VpYysv
-9w9FhamakpSbum0jApsCvKAEGRYKAG0Fgma/XMsJkMrApZFFMT1MRRQAAAAA
-ABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5vcmcyU0rvMw4GVCasfsGO
-ke8VBnf9DX73KF4Fuw5HRwy65BYhBPmjv8j7/15Fu3bvL8rApZFFMT1MAADv
-OgEAp2P/olg/8frAKhZNhBNNcnZ3mBPgw+jnVB2q3lJR3G4A/Az8kxPmyhmf
-vaorTRswb2d7xes3ubunWLvHBcU+LSAIFiEEYmvn2jb9uzAG41Ql+Gc9nQsN
-7XAAAO9CAP4y3wh7tKf5QkWhz18Lo2Zjqv4S+rCVJZWe9SDRFJq4rwD/eJTb
-wFTiP1x1KHQY+bnZQUll10A9c/G9yMrOC0qR8gHHXQRmv1zLEgorBgEEAZdV
-AQUBAQdAdWmLtTwhcOH7tlr+2FEysYY3Z6gPpP6EalQnbXEHKRsDAQgHAAD/
-ROS5zCtNP0O2t9U7T/Cs2+n1snTVW+RBTbESM+hjWfgTIcK+BBgWCgBwBYJm
-v1zLCZD4Zz2dCw3tcEUUAAAAAAAcACBzYWx0QG5vdGF0aW9ucy5vcGVucGdw
-anMub3JniqUd+21Sxr5oHb+ctdQKLEpRYCSR1I0Ap/Z5o3XfqRACmwwWIQRi
-a+faNv27MAbjVCX4Zz2dCw3tcAAABPQBAK7S2Izm3D4dEkoJb869wOqtK4be
-zdP4cdQMfO/4hsLRAPwMxCX51Okaj/SvwEzjI/RCPmfv9l441PmzQheQ4Gqr
-BM44BGa/XMsSCisGAQQBl1UBBQEBB0CqHCGPBZg8ioGvjV4nKteCFs4hAzLn
-nFHyv2RF+YdFJgMBCAfCvgQYFgoAcAWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAA
-HAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZw1hBEkI2dXfJXMVH/ha
-uCz6Opp4tu616/VBZWGParIfApsMFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAA
-ABWvAQDZznAKuYpaWKklOVw2z8fgLP6sL9ai+zBjlWogKoswNgEAoXTZ1SOJ
-bWGFbTrrvSBYui/idHvj8Tax0EDVVw6W1Qc=
-=OKHa
+xjMEZr9cyxYJKwYBBAHaRw8BAQdAmT0UuqJK5GuUrHdRGgSQt0LgUKbMAmyV84ys
+zQESNGPNEjx0ZXN0QGV4YW1wbGUuY29tPsLAEwQTFgoAhQWCZr9cywMLCQcJEHqi
+iRQ1J8JJRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5vcmfkiWAH
+dTH3c8qajXF9lDZUn2SzRxSQtrJyRq9l5+dYiwUVCggODAQWAAIBAhkBApsDAh4B
+FiEEnMHl2SgesB9tXaF7eqKJFDUnwkkAANSZAQDB3QS0GUdxEMDl/YqkOhhl7Y/z
+nyvnXSgP6PbkmePqkgD/XHl7NV0fwh8UfwlCn54oUgmBS4/NjNNyCSmd7/rkMg3O
+MwRmv1zLFgkrBgEEAdpHDwEBB0BU0ID2iXSPWL2XPlZUpaUnXgRD11Z8aHeUlqAV
+vwPu38LAuwQYFgoBLQWCZr9cywkQeqKJFDUnwklFFAAAAAAAHAAgc2FsdEBub3Rh
+dGlvbnMub3BlbnBncGpzLm9yZ37ouQERPoW/rj7tJdnOAo3fU24c+gfeGOssTy6o
+OHdhApsCvKAEGRYKAG0Fgma/XMsJEMcxOgWUdeD5RRQAAAAAABwAIHNhbHRAbm90
+YXRpb25zLm9wZW5wZ3Bqcy5vcmcy8S0+qNzXNjQXwK+q+cV2Lvkq0ZthSe2VfTfu
+iWJ59xYhBCM2aEShYzzwbCL77McxOgWUdeD5AABVmAD9Fijo5bsPtDwbePwzf0nd
+B3uhOHah5GqbU8FBZ5m2XMsA/AuqnQde1LU47HKXqEzee3L576OpPpKGDrvM0sPe
+dZwBFiEEnMHl2SgesB9tXaF7eqKJFDUnwkkAAINoAQDd5pqu3DXoSfkbit78wtca
+niXra3MknljqqcUpQTxRqgD9E2dZT1x1DyiUG+LB3SvjTYgS6APfypmQCvvrBPsb
+dATHWARmv1zLFgkrBgEEAdpHDwEBB0DLQXwQM+BqmXxvQWzJaOJVp4wVdXDac067
+oA0xlzNqmAAA/iPfDsSoHuUY0ZvXwZ2ZNz26DEbFh57QGm721nDHHhElEOjCwLsE
+GBYKAS0Fgma/XMsJEHqiiRQ1J8JJRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9w
+ZW5wZ3Bqcy5vcmcBXrrxmf4NE2ELlnWOqQdE4xbt8Hax29mWoO5EXpzJGQKbAryg
+BBkWCgBtBYJmv1zLCRBpyHZJP5k0MUUUAAAAAAAcACBzYWx0QG5vdGF0aW9ucy5v
+cGVucGdwanMub3Jnqy4cS+Zx0aSxmO7NLa3J/kMnQELByyxOc+wUH1hrHBIWIQTK
+PEavJcRqHYq+zARpyHZJP5k0MQAAJ4EA/1hPfNiNfpMykSFQix5VHn2VW7KtqF6c
+FYmilleN393FAP42daMl60zyDACCZ56rh11kkppvoBbSdIq3qju2iT0XABYhBJzB
+5dkoHrAfbV2he3qiiRQ1J8JJAAAfdQD/dVwavO7ryJFITCbqDkWJZbSs3CfDoUXh
+LycMYCOLNZYBAJadrq3+NhvDUfElmh6CeMb/LLgWSHSXYuVMayHPw0EAzjgEZr9c
+yxIKKwYBBAGXVQEFAQEHQHAv1G/m/MRCSnbK+xIt+SmdefEpQWee71ugIUxmGUJZ
+AwEIB8K+BBgWCgBwBYJmv1zLCRB6ookUNSfCSUUUAAAAAAAcACBzYWx0QG5vdGF0
+aW9ucy5vcGVucGdwanMub3Jni7M3ur9WpIB7yp/KNV6i7qPzZGKppk4kYHikQUIk
+uvQCmwwWIQScweXZKB6wH21doXt6ookUNSfCSQAAeboA/itWe3tD/ZF9eQxBsp9K
+HJk6MeUIGDwcIl2MHqQitxZOAP94Cv9eQEx9wwheVEzhL9vKZH48C3UC4i4Cdncp
+yBqIDsddBGa/XMsSCisGAQQBl1UBBQEBB0C8X1LsJimfh8SsmOWpgL8EfSaS5q6t
+4eOBmQi3I1zmfQMBCAcAAP9y6Bl3TZHs5UcQl4DAsWLy323kSUt2gwt2sdVf1upu
+CBIkwr4EGBYKAHAFgma/XMsJEHqiiRQ1J8JJRRQAAAAAABwAIHNhbHRAbm90YXRp
+b25zLm9wZW5wZ3Bqcy5vcmeN9CFr1FIt97pc+FpyxQsSwMtLo7ZOvgM0rF945/la
+EgKbDBYhBJzB5dkoHrAfbV2he3qiiRQ1J8JJAADXwQD+OZNr9MsHyv3R3dC9ucf7
+4qqQZYTHd1PGDCptsw0Md5kBAIvXFpYc++B/BhRIlfhxtRDNbXxVPoqIFSnsFv3M
+zYIC
+=Rt2E
 -----END PGP PRIVATE KEY BLOCK-----`;
 
 const eddsaKeyAsEcdsa = `
@@ -2696,7 +2695,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signPrimaryUser([privateKey]);
       const signatures = await publicKey.verifyPrimaryUser([privateKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(2);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
@@ -2721,7 +2720,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signPrimaryUser([privateKey]);
       const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(2);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
@@ -2745,7 +2744,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([privateKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
@@ -2778,7 +2777,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([wrongKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
@@ -2810,7 +2809,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([privateKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
@@ -2847,7 +2846,7 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([wrongKey]);
-      const publicSigningKey = await publicKey.getSigningKey();
+      const publicSigningKey = await publicKey.getVerificationKey();
       const privateSigningKey = await privateKey.getSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
@@ -3070,10 +3069,10 @@ export default () => describe('Key', function() {
     expect(key.isDecrypted()).to.be.true;
     expect(key.isPrivate()).to.be.true;
     const signingKey = await key.getSigningKey();
-    expect(signingKey.getKeyID().equals(key.subkeys[0].getKeyID())).to.be.true;
+    expect(signingKey.getKeyID().equals(key.subkeys[1].getKeyID())).to.be.true;
     const decryptedKeys = await key.getDecryptionKeys();
     expect(decryptedKeys.length).to.equal(1);
-    expect(decryptedKeys[0].getKeyID().equals(key.subkeys[2].getKeyID())).to.be.true;
+    expect(decryptedKeys[0].getKeyID().equals(key.subkeys[3].getKeyID())).to.be.true;
   });
 
   it('Parses V5 sample key', async function() {
@@ -3591,15 +3590,15 @@ PzIEeL7UH3trraFmi+Gq8u4kAA==
     try {
       const pubKey = await openpgp.readKey({ armoredKey: key_with_revoked_third_party_cert });
       const [selfCertification] = await pubKey.verifyPrimaryUser();
-      const publicSigningKey = await pubKey.getSigningKey();
-      expect(selfCertification.keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
+      const verificationKey = await pubKey.getVerificationKey();
+      expect(selfCertification.keyID.toHex()).to.equal(verificationKey.getKeyID().toHex());
       expect(selfCertification.valid).to.be.true;
 
       const certifyingKey = await openpgp.readKey({ armoredKey: certifying_key });
-      const certifyingSigningKey = await certifyingKey.getSigningKey(undefined, undefined, undefined, { ...openpgp.config, allowMissingKeyFlags: true });
+      const certifyingSigningKey = await certifyingKey.getVerificationKey(undefined, undefined, undefined, { ...openpgp.config, allowMissingKeyFlags: true });
       const signatures = await pubKey.verifyPrimaryUser([certifyingKey]);
       expect(signatures.length).to.equal(2);
-      expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
+      expect(signatures[0].keyID.toHex()).to.equal(verificationKey.getKeyID().toHex());
       expect(signatures[0].valid).to.be.null;
       expect(signatures[1].keyID.toHex()).to.equal(certifyingSigningKey.getKeyID().toHex());
       expect(signatures[1].valid).to.be.false;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -3016,6 +3016,64 @@ export default () => describe('Key', function() {
     expect(key.write()).to.deep.equal(expectedSerializedKey.data);
   });
 
+  it('Parsing armored key with public primary key and private subkeys', async function() {
+    // public primary key with:
+    // - one signing private subkey
+    // - one signing public subkey
+    // - one encryption private subkey
+    // - one encryption public subkey
+    const privateKeyWithPublicKeyPackets = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xjMEZr9cyxYJKwYBBAHaRw8BAQdAlC7g7Q4UZmN5zNhFynWuEXYn1KV8Jfp4
+DMiKf8ZQ5oDNDzx0ZXN0QHRlc3QuY29tPsLAEwQTFgoAhQWCZr9cywMLCQcJ
+kPhnPZ0LDe1wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
+cmeWobLLkXmgpg9Pet9xOLiKvUAGKchlrMxBubhvTpBGygUVCAoMDgQWAAIB
+AhkBApsDAh4BFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAAAHGyAP9URiF2uq/O
+8PJkjoehixMx9h9a8L+lPd56ymbdxUb/swEA0tNWA9alk/m3rml0aTPNucuG
+Aj/FLBixvbva+SWEkgrOMwRmv1zLFgkrBgEEAdpHDwEBB0DdyjGHiVCA0Cbr
+5u5pcuZmYZylLDURujjhEWYcLKIg0MLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN
+7XBFFAAAAAAAHAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ5UtjGIA
+N+2fOlsIv9vwi5MaTUxoXXc+Mw6ETjRvW3fUApsCvKAEGRYKAG0Fgma/XMsJ
+kHC3NLlxFk7wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
+cme74M+JTJ/Clb0bApLqL/QGKOZbaXdL3Y/p02QX2o6AgRYhBFFraL50hRm3
+RC4PZHC3NLlxFk7wAABAgwEAhQ+EgvirBcabNlmHV6nEbqyTz85oBj8SKNM2
+d+tDQ3YBAN3jXoPGx22sVoy5rAMerwq1lhnlgCh4xfdTw1jtr2QEFiEEYmvn
+2jb9uzAG41Ql+Gc9nQsN7XAAALGsAQCCDkhWJRgiCoHIvjWwRqVWU1BsVaj5
+dr6fxkK9yaOv6QEA+JjqAgPcRo/LGHpO0dZS9qi1Zpy4u5bT2FunXqvNDQ7O
+MwRmv1zLFgkrBgEEAdpHDwEBB0A4CyxR5ZSvF8FrEhjzFO8W6paAtqm92p7k
++HQC7TRhKcLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAAHAAgc2Fs
+dEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ8eA420LE1oqZm9UQ2mAl0VpYysv
+9w9FhamakpSbum0jApsCvKAEGRYKAG0Fgma/XMsJkMrApZFFMT1MRRQAAAAA
+ABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5vcmcyU0rvMw4GVCasfsGO
+ke8VBnf9DX73KF4Fuw5HRwy65BYhBPmjv8j7/15Fu3bvL8rApZFFMT1MAADv
+OgEAp2P/olg/8frAKhZNhBNNcnZ3mBPgw+jnVB2q3lJR3G4A/Az8kxPmyhmf
+vaorTRswb2d7xes3ubunWLvHBcU+LSAIFiEEYmvn2jb9uzAG41Ql+Gc9nQsN
+7XAAAO9CAP4y3wh7tKf5QkWhz18Lo2Zjqv4S+rCVJZWe9SDRFJq4rwD/eJTb
+wFTiP1x1KHQY+bnZQUll10A9c/G9yMrOC0qR8gHHXQRmv1zLEgorBgEEAZdV
+AQUBAQdAdWmLtTwhcOH7tlr+2FEysYY3Z6gPpP6EalQnbXEHKRsDAQgHAAD/
+ROS5zCtNP0O2t9U7T/Cs2+n1snTVW+RBTbESM+hjWfgTIcK+BBgWCgBwBYJm
+v1zLCZD4Zz2dCw3tcEUUAAAAAAAcACBzYWx0QG5vdGF0aW9ucy5vcGVucGdw
+anMub3JniqUd+21Sxr5oHb+ctdQKLEpRYCSR1I0Ap/Z5o3XfqRACmwwWIQRi
+a+faNv27MAbjVCX4Zz2dCw3tcAAABPQBAK7S2Izm3D4dEkoJb869wOqtK4be
+zdP4cdQMfO/4hsLRAPwMxCX51Okaj/SvwEzjI/RCPmfv9l441PmzQheQ4Gqr
+BM44BGa/XMsSCisGAQQBl1UBBQEBB0CqHCGPBZg8ioGvjV4nKteCFs4hAzLn
+nFHyv2RF+YdFJgMBCAfCvgQYFgoAcAWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAA
+HAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZw1hBEkI2dXfJXMVH/ha
+uCz6Opp4tu616/VBZWGParIfApsMFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAA
+ABWvAQDZznAKuYpaWKklOVw2z8fgLP6sL9ai+zBjlWogKoswNgEAoXTZ1SOJ
+bWGFbTrrvSBYui/idHvj8Tax0EDVVw6W1Qc=
+=OKHa
+-----END PGP PRIVATE KEY BLOCK-----` });
+
+    expect(privateKeyWithPublicKeyPackets.isDecrypted()).to.be.true;
+    expect(privateKeyWithPublicKeyPackets.isPrivate()).to.be.true;
+    const signingKey = await privateKeyWithPublicKeyPackets.getSigningKey();
+    expect(signingKey.getKeyID().equals(privateKeyWithPublicKeyPackets.subkeys[0].getKeyID())).to.be.true;
+    const decryptedKeys = await privateKeyWithPublicKeyPackets.getDecryptionKeys();
+    expect(decryptedKeys.length).to.equal(1);
+    expect(decryptedKeys[0].getKeyID().equals(privateKeyWithPublicKeyPackets.subkeys[2].getKeyID())).to.be.true;
+  });
+
   it('Parses V5 sample key', async function() {
     // sec   ed25519 2019-03-20 [SC]
     //       19347BC9872464025F99DF3EC2E0000ED9884892E1F7B3EA4C94009159569B54

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1857,6 +1857,54 @@ S2rSjQ4JF0Ktgdr9585haknpGwr31t486KxXOY4AEsiBmRyvTbaQegwKaQ+C
 -----END PGP PRIVATE KEY BLOCK-----
 `;
 
+// public primary key with:
+// - one signing private subkey
+// - one signing public subkey
+// - one encryption private subkey
+// - one encryption public subkey
+const privateKeyWithPublicKeyPackets = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xjMEZr9cyxYJKwYBBAHaRw8BAQdAlC7g7Q4UZmN5zNhFynWuEXYn1KV8Jfp4
+DMiKf8ZQ5oDNDzx0ZXN0QHRlc3QuY29tPsLAEwQTFgoAhQWCZr9cywMLCQcJ
+kPhnPZ0LDe1wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
+cmeWobLLkXmgpg9Pet9xOLiKvUAGKchlrMxBubhvTpBGygUVCAoMDgQWAAIB
+AhkBApsDAh4BFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAAAHGyAP9URiF2uq/O
+8PJkjoehixMx9h9a8L+lPd56ymbdxUb/swEA0tNWA9alk/m3rml0aTPNucuG
+Aj/FLBixvbva+SWEkgrOMwRmv1zLFgkrBgEEAdpHDwEBB0DdyjGHiVCA0Cbr
+5u5pcuZmYZylLDURujjhEWYcLKIg0MLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN
+7XBFFAAAAAAAHAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ5UtjGIA
+N+2fOlsIv9vwi5MaTUxoXXc+Mw6ETjRvW3fUApsCvKAEGRYKAG0Fgma/XMsJ
+kHC3NLlxFk7wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
+cme74M+JTJ/Clb0bApLqL/QGKOZbaXdL3Y/p02QX2o6AgRYhBFFraL50hRm3
+RC4PZHC3NLlxFk7wAABAgwEAhQ+EgvirBcabNlmHV6nEbqyTz85oBj8SKNM2
+d+tDQ3YBAN3jXoPGx22sVoy5rAMerwq1lhnlgCh4xfdTw1jtr2QEFiEEYmvn
+2jb9uzAG41Ql+Gc9nQsN7XAAALGsAQCCDkhWJRgiCoHIvjWwRqVWU1BsVaj5
+dr6fxkK9yaOv6QEA+JjqAgPcRo/LGHpO0dZS9qi1Zpy4u5bT2FunXqvNDQ7O
+MwRmv1zLFgkrBgEEAdpHDwEBB0A4CyxR5ZSvF8FrEhjzFO8W6paAtqm92p7k
++HQC7TRhKcLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAAHAAgc2Fs
+dEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ8eA420LE1oqZm9UQ2mAl0VpYysv
+9w9FhamakpSbum0jApsCvKAEGRYKAG0Fgma/XMsJkMrApZFFMT1MRRQAAAAA
+ABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5vcmcyU0rvMw4GVCasfsGO
+ke8VBnf9DX73KF4Fuw5HRwy65BYhBPmjv8j7/15Fu3bvL8rApZFFMT1MAADv
+OgEAp2P/olg/8frAKhZNhBNNcnZ3mBPgw+jnVB2q3lJR3G4A/Az8kxPmyhmf
+vaorTRswb2d7xes3ubunWLvHBcU+LSAIFiEEYmvn2jb9uzAG41Ql+Gc9nQsN
+7XAAAO9CAP4y3wh7tKf5QkWhz18Lo2Zjqv4S+rCVJZWe9SDRFJq4rwD/eJTb
+wFTiP1x1KHQY+bnZQUll10A9c/G9yMrOC0qR8gHHXQRmv1zLEgorBgEEAZdV
+AQUBAQdAdWmLtTwhcOH7tlr+2FEysYY3Z6gPpP6EalQnbXEHKRsDAQgHAAD/
+ROS5zCtNP0O2t9U7T/Cs2+n1snTVW+RBTbESM+hjWfgTIcK+BBgWCgBwBYJm
+v1zLCZD4Zz2dCw3tcEUUAAAAAAAcACBzYWx0QG5vdGF0aW9ucy5vcGVucGdw
+anMub3JniqUd+21Sxr5oHb+ctdQKLEpRYCSR1I0Ap/Z5o3XfqRACmwwWIQRi
+a+faNv27MAbjVCX4Zz2dCw3tcAAABPQBAK7S2Izm3D4dEkoJb869wOqtK4be
+zdP4cdQMfO/4hsLRAPwMxCX51Okaj/SvwEzjI/RCPmfv9l441PmzQheQ4Gqr
+BM44BGa/XMsSCisGAQQBl1UBBQEBB0CqHCGPBZg8ioGvjV4nKteCFs4hAzLn
+nFHyv2RF+YdFJgMBCAfCvgQYFgoAcAWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAA
+HAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZw1hBEkI2dXfJXMVH/ha
+uCz6Opp4tu616/VBZWGParIfApsMFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAA
+ABWvAQDZznAKuYpaWKklOVw2z8fgLP6sL9ai+zBjlWogKoswNgEAoXTZ1SOJ
+bWGFbTrrvSBYui/idHvj8Tax0EDVVw6W1Qc=
+=OKHa
+-----END PGP PRIVATE KEY BLOCK-----`;
+
 const eddsaKeyAsEcdsa = `
 -----BEGIN PGP PRIVATE KEY BLOCK-----
 Version: OpenPGP.js VERSION
@@ -3017,61 +3065,15 @@ export default () => describe('Key', function() {
   });
 
   it('Parsing armored key with public primary key and private subkeys', async function() {
-    // public primary key with:
-    // - one signing private subkey
-    // - one signing public subkey
-    // - one encryption private subkey
-    // - one encryption public subkey
-    const privateKeyWithPublicKeyPackets = await openpgp.readKey({ armoredKey: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+    const key = await openpgp.readKey({ armoredKey: privateKeyWithPublicKeyPackets });
 
-xjMEZr9cyxYJKwYBBAHaRw8BAQdAlC7g7Q4UZmN5zNhFynWuEXYn1KV8Jfp4
-DMiKf8ZQ5oDNDzx0ZXN0QHRlc3QuY29tPsLAEwQTFgoAhQWCZr9cywMLCQcJ
-kPhnPZ0LDe1wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
-cmeWobLLkXmgpg9Pet9xOLiKvUAGKchlrMxBubhvTpBGygUVCAoMDgQWAAIB
-AhkBApsDAh4BFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAAAHGyAP9URiF2uq/O
-8PJkjoehixMx9h9a8L+lPd56ymbdxUb/swEA0tNWA9alk/m3rml0aTPNucuG
-Aj/FLBixvbva+SWEkgrOMwRmv1zLFgkrBgEEAdpHDwEBB0DdyjGHiVCA0Cbr
-5u5pcuZmYZylLDURujjhEWYcLKIg0MLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN
-7XBFFAAAAAAAHAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ5UtjGIA
-N+2fOlsIv9vwi5MaTUxoXXc+Mw6ETjRvW3fUApsCvKAEGRYKAG0Fgma/XMsJ
-kHC3NLlxFk7wRRQAAAAAABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5v
-cme74M+JTJ/Clb0bApLqL/QGKOZbaXdL3Y/p02QX2o6AgRYhBFFraL50hRm3
-RC4PZHC3NLlxFk7wAABAgwEAhQ+EgvirBcabNlmHV6nEbqyTz85oBj8SKNM2
-d+tDQ3YBAN3jXoPGx22sVoy5rAMerwq1lhnlgCh4xfdTw1jtr2QEFiEEYmvn
-2jb9uzAG41Ql+Gc9nQsN7XAAALGsAQCCDkhWJRgiCoHIvjWwRqVWU1BsVaj5
-dr6fxkK9yaOv6QEA+JjqAgPcRo/LGHpO0dZS9qi1Zpy4u5bT2FunXqvNDQ7O
-MwRmv1zLFgkrBgEEAdpHDwEBB0A4CyxR5ZSvF8FrEhjzFO8W6paAtqm92p7k
-+HQC7TRhKcLAuwQYFgoBLQWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAAHAAgc2Fs
-dEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ8eA420LE1oqZm9UQ2mAl0VpYysv
-9w9FhamakpSbum0jApsCvKAEGRYKAG0Fgma/XMsJkMrApZFFMT1MRRQAAAAA
-ABwAIHNhbHRAbm90YXRpb25zLm9wZW5wZ3Bqcy5vcmcyU0rvMw4GVCasfsGO
-ke8VBnf9DX73KF4Fuw5HRwy65BYhBPmjv8j7/15Fu3bvL8rApZFFMT1MAADv
-OgEAp2P/olg/8frAKhZNhBNNcnZ3mBPgw+jnVB2q3lJR3G4A/Az8kxPmyhmf
-vaorTRswb2d7xes3ubunWLvHBcU+LSAIFiEEYmvn2jb9uzAG41Ql+Gc9nQsN
-7XAAAO9CAP4y3wh7tKf5QkWhz18Lo2Zjqv4S+rCVJZWe9SDRFJq4rwD/eJTb
-wFTiP1x1KHQY+bnZQUll10A9c/G9yMrOC0qR8gHHXQRmv1zLEgorBgEEAZdV
-AQUBAQdAdWmLtTwhcOH7tlr+2FEysYY3Z6gPpP6EalQnbXEHKRsDAQgHAAD/
-ROS5zCtNP0O2t9U7T/Cs2+n1snTVW+RBTbESM+hjWfgTIcK+BBgWCgBwBYJm
-v1zLCZD4Zz2dCw3tcEUUAAAAAAAcACBzYWx0QG5vdGF0aW9ucy5vcGVucGdw
-anMub3JniqUd+21Sxr5oHb+ctdQKLEpRYCSR1I0Ap/Z5o3XfqRACmwwWIQRi
-a+faNv27MAbjVCX4Zz2dCw3tcAAABPQBAK7S2Izm3D4dEkoJb869wOqtK4be
-zdP4cdQMfO/4hsLRAPwMxCX51Okaj/SvwEzjI/RCPmfv9l441PmzQheQ4Gqr
-BM44BGa/XMsSCisGAQQBl1UBBQEBB0CqHCGPBZg8ioGvjV4nKteCFs4hAzLn
-nFHyv2RF+YdFJgMBCAfCvgQYFgoAcAWCZr9cywmQ+Gc9nQsN7XBFFAAAAAAA
-HAAgc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZw1hBEkI2dXfJXMVH/ha
-uCz6Opp4tu616/VBZWGParIfApsMFiEEYmvn2jb9uzAG41Ql+Gc9nQsN7XAA
-ABWvAQDZznAKuYpaWKklOVw2z8fgLP6sL9ai+zBjlWogKoswNgEAoXTZ1SOJ
-bWGFbTrrvSBYui/idHvj8Tax0EDVVw6W1Qc=
-=OKHa
------END PGP PRIVATE KEY BLOCK-----` });
-
-    expect(privateKeyWithPublicKeyPackets.isDecrypted()).to.be.true;
-    expect(privateKeyWithPublicKeyPackets.isPrivate()).to.be.true;
-    const signingKey = await privateKeyWithPublicKeyPackets.getSigningKey();
-    expect(signingKey.getKeyID().equals(privateKeyWithPublicKeyPackets.subkeys[0].getKeyID())).to.be.true;
-    const decryptedKeys = await privateKeyWithPublicKeyPackets.getDecryptionKeys();
+    expect(key.isDecrypted()).to.be.true;
+    expect(key.isPrivate()).to.be.true;
+    const signingKey = await key.getSigningKey();
+    expect(signingKey.getKeyID().equals(key.subkeys[0].getKeyID())).to.be.true;
+    const decryptedKeys = await key.getDecryptionKeys();
     expect(decryptedKeys.length).to.equal(1);
-    expect(decryptedKeys[0].getKeyID().equals(privateKeyWithPublicKeyPackets.subkeys[2].getKeyID())).to.be.true;
+    expect(decryptedKeys[0].getKeyID().equals(key.subkeys[2].getKeyID())).to.be.true;
   });
 
   it('Parses V5 sample key', async function() {
@@ -3715,7 +3717,7 @@ PzIEeL7UH3trraFmi+Gq8u4kAA==
 
   it('validate() - throw if all-gnu-dummy key', async function() {
     const key = await openpgp.readKey({ armoredKey: gnuDummyKey });
-    await expect(key.validate()).to.be.rejectedWith('Cannot validate an all-gnu-dummy key');
+    await expect(key.validate()).to.be.rejectedWith('Cannot validate key without secret key material');
   });
 
   it('validate() - gnu-dummy primary key with signing subkey', async function() {
@@ -3725,6 +3727,11 @@ PzIEeL7UH3trraFmi+Gq8u4kAA==
 
   it('validate() - gnu-dummy primary key with encryption subkey', async function() {
     const key = await openpgp.readKey({ armoredKey: dsaGnuDummyKeyWithElGamalSubkey });
+    await expect(key.validate()).to.not.be.rejected;
+  });
+
+  it('validate() - key with public key packets', async function() {
+    const key = await openpgp.readKey({ armoredKey: privateKeyWithPublicKeyPackets });
     await expect(key.validate()).to.not.be.rejected;
   });
 
@@ -4530,6 +4537,14 @@ VYGdb3eNlV8CfoEC
     const decryptedKey = await openpgp.decryptKey({ privateKey: key, passphrase });
     const encryptedKey = await openpgp.encryptKey({ privateKey: decryptedKey, passphrase });
     await expect(openpgp.encryptKey({ privateKey: encryptedKey, passphrase })).to.be.eventually.rejectedWith(/Key packet is already encrypted/);
+  });
+
+  it('Should support encrypting a private key which includes public key packets', async function() {
+    const passphrase = 'hello world';
+    const key = await openpgp.readKey({ armoredKey: privateKeyWithPublicKeyPackets });
+    const encryptedKey = await openpgp.encryptKey({ privateKey: key, passphrase });
+    const decryptedKey = await openpgp.decryptKey({ privateKey: encryptedKey, passphrase });
+    await expect(decryptedKey.write()).to.deep.equal(key.write());
   });
 
   describe('addSubkey functionality testing', function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4994,6 +4994,47 @@ I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
       expect(decrypted).to.exist;
       expect(decrypted.data).to.be.equal(vData);
     });
+
+    it("Certifies keys with a certify-only primary key", async function () {
+      const { privateKey: certifyingKey } = await openpgp.generateKey({
+        userIDs: { name: "Certifying Key" },
+        format: "object",
+        subkeys: [{ sign: true }],
+      });
+      const { privateKey: keyToCertify } = await openpgp.generateKey({
+        userIDs: { name: "Key To Certify" },
+        format: "object",
+      });
+
+      // Set certify-only flag
+      const primaryUser = await certifyingKey.getPrimaryUser();
+      primaryUser.selfCertification.keyFlags = [
+        openpgp.enums.keyFlags.certifyKeys,
+      ];
+
+      const signingSubkey = await certifyingKey.getSigningKey();
+      expect(signingSubkey.getKeyID().equals(certifyingKey.getKeyID())).to.be
+        .false;
+      const certificationKey = await certifyingKey.getCertificationKey();
+      expect(certificationKey.getKeyID().equals(certifyingKey.getKeyID())).to.be
+        .true;
+
+      // Sign and verify
+      const certifiedKey = await keyToCertify
+        .toPublic()
+        .signPrimaryUser([certifyingKey]);
+      const certifications = await certifiedKey.verifyPrimaryUser([
+        certifyingKey.toPublic(),
+      ]);
+      expect(certifications.length).to.equal(2);
+      expect(certifications[1].keyID.toHex()).to.equal(
+        certifyingKey.getKeyID().toHex(),
+      );
+      expect(certifications[1].keyID.toHex()).to.not.equal(
+        signingSubkey.getKeyID().toHex(),
+      );
+      expect(certifications[1].valid).to.be.true;
+    });
   });
 
   it('Subkey.verify returns the latest valid signature', async function () {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2695,8 +2695,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signPrimaryUser([privateKey]);
       const signatures = await publicKey.verifyPrimaryUser([privateKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(2);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
       expect(signatures[0].valid).to.be.null;
@@ -2720,8 +2720,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signPrimaryUser([privateKey]);
       const signatures = await publicKey.verifyPrimaryUser([wrongKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(2);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
       expect(signatures[0].valid).to.be.null;
@@ -2744,8 +2744,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([privateKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
@@ -2777,8 +2777,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([wrongKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
       expect(signatures[0].keyID.toHex()).to.equal(publicSigningKey.getKeyID().toHex());
@@ -2809,8 +2809,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([privateKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
       expect(signatures[0].userAttribute).to.be.null;
@@ -2846,8 +2846,8 @@ function versionSpecificTests() {
     try {
       publicKey = await publicKey.signAllUsers([privateKey]);
       const signatures = await publicKey.verifyAllUsers([wrongKey]);
-      const publicSigningKey = await publicKey.getVerificationKey();
-      const privateSigningKey = await privateKey.getSigningKey();
+      const publicSigningKey = await publicKey.getCertVerificationKey();
+      const privateSigningKey = await privateKey.getCertSigningKey();
       expect(signatures.length).to.equal(4);
       expect(signatures[0].userID).to.equal(publicKey.users[0].userID.userID);
       expect(signatures[0].userAttribute).to.be.null;
@@ -5015,7 +5015,7 @@ I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
       const signingSubkey = await certifyingKey.getSigningKey();
       expect(signingSubkey.getKeyID().equals(certifyingKey.getKeyID())).to.be
         .false;
-      const certificationKey = await certifyingKey.getCertificationKey();
+      const certificationKey = await certifyingKey.getCertSigningKey();
       expect(certificationKey.getKeyID().equals(certifyingKey.getKeyID())).to.be
         .true;
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4544,7 +4544,7 @@ VYGdb3eNlV8CfoEC
     const key = await openpgp.readKey({ armoredKey: privateKeyWithPublicKeyPackets });
     const encryptedKey = await openpgp.encryptKey({ privateKey: key, passphrase });
     const decryptedKey = await openpgp.decryptKey({ privateKey: encryptedKey, passphrase });
-    await expect(decryptedKey.write()).to.deep.equal(key.write());
+    expect(decryptedKey.write()).to.deep.equal(key.write());
   });
 
   describe('addSubkey functionality testing', function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -4995,21 +4995,21 @@ I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
       expect(decrypted.data).to.be.equal(vData);
     });
 
-    it("Certifies keys with a certify-only primary key", async function () {
+    it('Certifies keys with a certify-only primary key', async function () {
       const { privateKey: certifyingKey } = await openpgp.generateKey({
-        userIDs: { name: "Certifying Key" },
-        format: "object",
-        subkeys: [{ sign: true }],
+        userIDs: { name: 'Certifying Key' },
+        format: 'object',
+        subkeys: [{ sign: true }]
       });
       const { privateKey: keyToCertify } = await openpgp.generateKey({
-        userIDs: { name: "Key To Certify" },
-        format: "object",
+        userIDs: { name: 'Key To Certify' },
+        format: 'object'
       });
 
       // Set certify-only flag
       const primaryUser = await certifyingKey.getPrimaryUser();
       primaryUser.selfCertification.keyFlags = [
-        openpgp.enums.keyFlags.certifyKeys,
+        openpgp.enums.keyFlags.certifyKeys
       ];
 
       const signingSubkey = await certifyingKey.getSigningKey();
@@ -5024,14 +5024,14 @@ I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
         .toPublic()
         .signPrimaryUser([certifyingKey]);
       const certifications = await certifiedKey.verifyPrimaryUser([
-        certifyingKey.toPublic(),
+        certifyingKey.toPublic()
       ]);
       expect(certifications.length).to.equal(2);
       expect(certifications[1].keyID.toHex()).to.equal(
-        certifyingKey.getKeyID().toHex(),
+        certifyingKey.getKeyID().toHex()
       );
       expect(certifications[1].keyID.toHex()).to.not.equal(
-        signingSubkey.getKeyID().toHex(),
+        signingSubkey.getKeyID().toHex()
       );
       expect(certifications[1].valid).to.be.true;
     });

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -1701,7 +1701,7 @@ aOU=
         // secret key operations involving the primary key should fail
         await expect(openpgp.sign({
           message: await openpgp.createMessage({ text: 'test' }), signingKeys: decryptedDummyKey, config: { rejectPublicKeyAlgorithms: new Set() }
-        })).to.eventually.be.rejectedWith(/Cannot sign with a gnu-dummy key/);
+        })).to.eventually.be.rejectedWith(/Cannot sign with a public or dummy key/);
         await expect(
           openpgp.reformatKey({ userIDs: { name: 'test' }, privateKey: decryptedDummyKey })
         ).to.eventually.be.rejectedWith(/Cannot reformat a gnu-dummy primary key/);


### PR DESCRIPTION
Fixes #1974 by adding `getCertSigningKey` and `getCertVerificationKey` functions to mirror `getSigningKey` and `getVerificationKey` (but for certification keys).

To be merged after https://github.com/openpgpjs/openpgpjs/pull/1787.