### PR TITLE
[v7] Implement Persistent Symmetric Keys

### DIFF
--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -27,6 +27,8 @@
 import { rsa, elliptic, elgamal, dsa, postQuantum } from './public_key/index.js';
 import { getRandomBytes } from './random.js';
 import { getCipherParams } from './cipher/index.js';
+import { getAEADMode } from './cipherMode/index.js';
+import computeHKDF from './hkdf.js';
 import ECDHSymkey from '../type/ecdh_symkey.js';
 import KDFParams from '../type/kdf_params.js';
 import enums from '../enums.ts';
@@ -40,26 +42,46 @@ import ECDHXSymmetricKey from '../type/ecdh_x_symkey.js';
  * See {@link https://tools.ietf.org/html/rfc4880#section-9.1|RFC 4880 9.1} for public key algorithms.
  * @param {module:enums.publicKey} keyAlgo - Public key algorithm
  * @param {module:enums.symmetric|null} symmetricAlgo - Cipher algorithm (v3 only)
- * @param {Object} publicParams - Algorithm-specific public key parameters
+ * @param {Object} publicKeyParams - Algorithm-specific public key parameters
+ * @param {Object} privateKeyParams - Algorithm-specific private key parameters (for AEAD only)
  * @param {Uint8Array} data - Session key data to be encrypted
  * @param {Uint8Array} fingerprint - Recipient fingerprint
+ * @param {Object} config
  * @returns {Promise<Object>} Encrypted session key parameters.
  * @async
  */
-export async function publicKeyEncrypt(keyAlgo, symmetricAlgo, publicParams, data, fingerprint) {
+export async function publicKeyEncrypt(keyAlgo, symmetricAlgo, publicKeyParams, privateKeyParams, data, fingerprint, config) {
   switch (keyAlgo) {
+    case enums.publicKey.aead: {
+      const { symAlgo } = publicKeyParams;
+      const { key } = privateKeyParams;
+      const { keySize } = getCipherParams(symAlgo);
+      const aeadAlgo = config.preferredAEADAlgorithm;
+      const mode = getAEADMode(aeadAlgo);
+      const { ivLength } = mode;
+      const salt = getRandomBytes(32);
+      const packetID = 0xC0 | enums.packet.publicKeyEncryptedSessionKey;
+      const version = symmetricAlgo ? 3 : 6;
+      const info = new Uint8Array([packetID, version, symAlgo, aeadAlgo]);
+      const hkdf = await computeHKDF(enums.hash.sha512, key, salt, info, keySize + ivLength);
+      const encKey = hkdf.subarray(0, keySize);
+      const iv = hkdf.subarray(keySize);
+      const modeInstance = await mode(symAlgo, encKey);
+      const ciphertext = await modeInstance.encrypt(data, iv, new Uint8Array());
+      return { aeadAlgo, salt, ciphertext };
+    }
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign: {
-      const { n, e } = publicParams;
+      const { n, e } = publicKeyParams;
       const c = await rsa.encrypt(data, n, e);
       return { c };
     }
     case enums.publicKey.elgamal: {
-      const { p, g, y } = publicParams;
+      const { p, g, y } = publicKeyParams;
       return elgamal.encrypt(data, p, g, y);
     }
     case enums.publicKey.ecdh: {
-      const { oid, Q, kdfParams } = publicParams;
+      const { oid, Q, kdfParams } = publicKeyParams;
       const { publicKey: V, wrappedKey: C } = await elliptic.ecdh.encrypt(
         oid, kdfParams, data, Q, fingerprint);
       return { V, C: new ECDHSymkey(C) };
@@ -70,14 +92,14 @@ export async function publicKeyEncrypt(keyAlgo, symmetricAlgo, publicParams, dat
         // see https://gitlab.com/openpgp-wg/rfc4880bis/-/merge_requests/276
         throw new Error('X25519 and X448 keys can only encrypt AES session keys');
       }
-      const { A } = publicParams;
+      const { A } = publicKeyParams;
       const { ephemeralPublicKey, wrappedKey } = await elliptic.ecdhX.encrypt(
         keyAlgo, data, A);
       const C = ECDHXSymmetricKey.fromObject({ algorithm: symmetricAlgo, wrappedKey });
       return { ephemeralPublicKey, C };
     }
     case enums.publicKey.mlkem768X25519: {
-      const { eccPublicKey, mlkemPublicKey } = publicParams;
+      const { eccPublicKey, mlkemPublicKey } = publicKeyParams;
       const { eccCipherText, mlkemCipherText, wrappedKey } = await postQuantum.kem.encrypt(keyAlgo, eccPublicKey, mlkemPublicKey, data);
       const C = ECDHXSymmetricKey.fromObject({ algorithm: symmetricAlgo, wrappedKey });
       return { eccCipherText, mlkemCipherText, C };
@@ -103,6 +125,23 @@ export async function publicKeyEncrypt(keyAlgo, symmetricAlgo, publicParams, dat
  */
 export async function publicKeyDecrypt(keyAlgo, publicKeyParams, privateKeyParams, sessionKeyParams, fingerprint, randomPayload) {
   switch (keyAlgo) {
+    case enums.publicKey.aead: {
+      const { symAlgo } = publicKeyParams;
+      const { key } = privateKeyParams;
+      const { keySize } = getCipherParams(symAlgo);
+      const { aeadAlgo, salt, ciphertext } = sessionKeyParams;
+      const mode = getAEADMode(aeadAlgo);
+      const { ivLength } = mode;
+      const packetID = 0xC0 | enums.packet.publicKeyEncryptedSessionKey;
+      const version = ciphertext.length % 2 ? 3 : 6;
+      const info = new Uint8Array([packetID, version, symAlgo, aeadAlgo]);
+      const hkdf = await computeHKDF(enums.hash.sha512, key, salt, info, keySize + ivLength);
+      const encKey = hkdf.subarray(0, keySize);
+      const iv = hkdf.subarray(keySize);
+      const modeInstance = await mode(symAlgo, encKey);
+      const plaintext = await modeInstance.decrypt(ciphertext, iv, new Uint8Array());
+      return plaintext;
+    }
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaEncrypt: {
       const { c } = sessionKeyParams;
@@ -154,6 +193,14 @@ export async function publicKeyDecrypt(keyAlgo, publicKeyParams, privateKeyParam
 export function parsePublicKeyParams(algo, bytes) {
   let read = 0;
   switch (algo) {
+    case enums.publicKey.aead: {
+      const symAlgo = bytes[read]; read++;
+      if (![enums.symmetric.aes128, enums.symmetric.aes192, enums.symmetric.aes256].includes(symAlgo)) {
+        throw new Error('Persistent Symmetric Key packets cannot be used with weak symmetric algorithms');
+      }
+      const fpSeed = util.readExactSubarray(bytes, read, read + 32); read += fpSeed.length;
+      return { read, publicParams: { symAlgo, fpSeed } };
+    }
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaSign: {
@@ -229,6 +276,12 @@ export function parsePublicKeyParams(algo, bytes) {
 export async function parsePrivateKeyParams(algo, bytes, publicParams) {
   let read = 0;
   switch (algo) {
+    case enums.publicKey.aead: {
+      const { symAlgo } = publicParams;
+      const { keySize } = getCipherParams(symAlgo);
+      const key = util.readExactSubarray(bytes, read, read + keySize); read += key.length;
+      return { read, privateParams: { key } };
+    }
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaSign: {
@@ -296,6 +349,17 @@ export async function parsePrivateKeyParams(algo, bytes, publicParams) {
 export function parseEncSessionKeyParams(algo, bytes) {
   let read = 0;
   switch (algo) {
+    //   Algorithm-Specific Fields for Persistent Symmetric Encryption:
+    //       - A 1-octet AEAD algorithm.
+    //       - 32 octets of salt.
+    //       - A symmetric key encryption of the plaintext value.
+    case enums.publicKey.aead: {
+      const aeadAlgo = bytes[read]; read++;
+      const salt = util.readExactSubarray(bytes, read, read + 32); read += salt.length;
+      let ciphertext = bytes.subarray(read);
+      return { aeadAlgo, salt, ciphertext };
+    }
+
     //   Algorithm-Specific Fields for RSA encrypted session keys:
     //       - MPI of RSA encrypted value m**e mod n.
     case enums.publicKey.rsaEncrypt:
@@ -357,7 +421,8 @@ export function serializeParams(algo, params) {
     enums.publicKey.ed448,
     enums.publicKey.x448,
     enums.publicKey.mlkem768X25519,
-    enums.publicKey.mldsa65Ed25519
+    enums.publicKey.mldsa65Ed25519,
+    enums.publicKey.aead
   ]);
 
   const excludedFields = {
@@ -371,6 +436,7 @@ export function serializeParams(algo, params) {
     }
 
     const param = params[name];
+    if (typeof param === 'number') return new Uint8Array([param]); // Enum value.
     if (!util.isUint8Array(param)) return param.write();
     return algosWithNativeRepresentation.has(algo) ? param : util.uint8ArrayToMPI(param);
   });
@@ -380,13 +446,27 @@ export function serializeParams(algo, params) {
 /**
  * Generate algorithm-specific key parameters
  * @param {module:enums.publicKey} algo - The public key algorithm
- * @param {Integer} bits - Bit length for RSA keys
+ * @param {Integer} bits - Bit length for RSA and symmetric keys
  * @param {module:type/oid} oid - Object identifier for ECC keys
+ * @param {Object} config
  * @returns {Promise<{ publicParams: {Object}, privateParams: {Object} }>} The parameters referenced by name.
  * @async
  */
-export function generateParams(algo, bits, oid) {
+export async function generateParams(algo, bits, oid, config) {
   switch (algo) {
+    case enums.publicKey.aead: {
+      const symAlgo = config.preferredSymmetricAlgorithm;
+      if (![enums.symmetric.aes128, enums.symmetric.aes192, enums.symmetric.aes256].includes(symAlgo)) {
+        throw new Error('Persistent Symmetric Key packets cannot be used with weak symmetric algorithms');
+      }
+      const { keySize } = getCipherParams(symAlgo);
+      const key = getRandomBytes(keySize);
+      const fpSeed = getRandomBytes(32);
+      return {
+        privateParams: { key },
+        publicParams: { symAlgo, fpSeed }
+      };
+    }
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaSign:

--- a/src/crypto/signature.js
+++ b/src/crypto/signature.js
@@ -5,6 +5,10 @@
  */
 
 import { elliptic, rsa, dsa, postQuantum } from './public_key/index.js';
+import { getCipherParams } from './cipher/index.js';
+import { getAEADMode } from './cipherMode/index.js';
+import { getRandomBytes } from './random.js';
+import computeHKDF from './hkdf.js';
 import enums from '../enums.ts';
 import util from '../util.js';
 import { UnsupportedError } from '../packet/packet.js';
@@ -24,6 +28,17 @@ import { getHashByteLength } from './hash/index.js';
 export function parseSignatureParams(algo, signature) {
   let read = 0;
   switch (algo) {
+    // Algorithm-Specific Fields for AEAD signatures:
+    // -  A 1-octet AEAD algorithm (see section 9.6 of [RFC9580]).
+    // -  32 octets of salt.
+    // -  An authentication tag of the size specified by the AEAD mode.
+    case enums.publicKey.aead: {
+      const aeadAlgo = signature[read]; read++;
+      const salt = util.readExactSubarray(signature, read, read + 32); read += salt.length;
+      const { tagLength } = getAEADMode(aeadAlgo);
+      const authTag = util.readExactSubarray(signature, read, read + tagLength); read += authTag.length;
+      return { read, signatureParams: { aeadAlgo, salt, authTag } };
+    }
     // Algorithm-Specific Fields for RSA signatures:
     // -  MPI of RSA signature value m**d mod n.
     case enums.publicKey.rsaEncryptSign:
@@ -86,28 +101,52 @@ export function parseSignatureParams(algo, signature) {
  * @param {module:enums.publicKey} algo - Public key algorithm
  * @param {module:enums.hash} hashAlgo - Hash algorithm
  * @param {Object} signature - Named algorithm-specific signature parameters
- * @param {Object} publicParams - Algorithm-specific public key parameters
+ * @param {Object} publicKeyParams - Algorithm-specific public and private key parameters
+ * @param {Object} privateKeyParams - Algorithm-specific public and private key parameters (for AEAD only)
  * @param {Uint8Array} data - Data for which the signature was created
  * @param {Uint8Array} hashed - The hashed data
  * @returns {Promise<Boolean>} True if signature is valid.
  * @async
  */
-export async function verify(algo, hashAlgo, signature, publicParams, data, hashed) {
+export async function verify(algo, hashAlgo, signature, publicKeyParams, privateKeyParams, data, hashed) {
   switch (algo) {
+    case enums.publicKey.aead: {
+      const { aeadAlgo, salt, authTag } = signature;
+      const { symAlgo } = publicKeyParams;
+      const { key } = privateKeyParams;
+      const { keySize } = getCipherParams(symAlgo);
+      const mode = getAEADMode(aeadAlgo);
+      const { ivLength } = mode;
+      const packetID = 0xC0 | enums.packet.signature;
+      const version = 6;
+      const info = new Uint8Array([packetID, version, symAlgo, aeadAlgo]);
+      const hkdf = await computeHKDF(enums.hash.sha512, key, salt, info, keySize + ivLength);
+      const authKey = hkdf.subarray(0, keySize);
+      const iv = hkdf.subarray(keySize);
+      const modeInstance = await mode(symAlgo, authKey);
+      try {
+        return util.equalsUint8Array(
+          await modeInstance.decrypt(authTag, iv, hashed),
+          new Uint8Array()
+        );
+      } catch {
+        return false;
+      }
+    }
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaSign: {
-      const { n, e } = publicParams;
+      const { n, e } = publicKeyParams;
       const s = util.leftPad(signature.s, n.length); // padding needed for webcrypto and node crypto
       return rsa.verify(hashAlgo, data, s, n, e, hashed);
     }
     case enums.publicKey.dsa: {
-      const { g, p, q, y } = publicParams;
+      const { g, p, q, y } = publicKeyParams;
       const { r, s } = signature; // no need to pad, since we always handle them as BigIntegers
       return dsa.verify(hashAlgo, r, s, hashed, g, p, q, y);
     }
     case enums.publicKey.ecdsa: {
-      const { oid, Q } = publicParams;
+      const { oid, Q } = publicKeyParams;
       const curveSize = new elliptic.CurveWithOID(oid).payloadSize;
       // padding needed for webcrypto
       const r = util.leftPad(signature.r, curveSize);
@@ -121,7 +160,7 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
         // and https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.3-3
         throw new Error('Hash algorithm too weak for EdDSALegacy.');
       }
-      const { oid, Q } = publicParams;
+      const { oid, Q } = publicKeyParams;
       const curveSize = new elliptic.CurveWithOID(oid).payloadSize;
       // When dealing little-endian MPI data, we always need to left-pad it, as done with big-endian values:
       // https://www.ietf.org/archive/id/draft-ietf-openpgp-rfc4880bis-10.html#section-3.2-9
@@ -138,7 +177,7 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
         throw new Error('Hash algorithm too weak for EdDSA.');
       }
 
-      const { A } = publicParams;
+      const { A } = publicKeyParams;
       return elliptic.eddsa.verify(algo, hashAlgo, signature, data, A, hashed);
     }
     case enums.publicKey.mldsa65Ed25519: {
@@ -147,7 +186,7 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
         // https://www.rfc-editor.org/rfc/rfc9980.html#section-9.4
         throw new Error('Unexpected hash algorithm for PQC signature: digest size too short');
       }
-      const { eccPublicKey, mldsaPublicKey } = publicParams;
+      const { eccPublicKey, mldsaPublicKey } = publicKeyParams;
       return postQuantum.signature.verify(algo, hashAlgo, eccPublicKey, mldsaPublicKey, hashed, signature);
     }
     default:
@@ -166,14 +205,33 @@ export async function verify(algo, hashAlgo, signature, publicParams, data, hash
  * @param {Object} privateKeyParams - Algorithm-specific public and private key parameters
  * @param {Uint8Array} data - Data to be signed
  * @param {Uint8Array} hashed - The hashed data
+ * @param {Object} config
  * @returns {Promise<Object>} Signature                      Object containing named signature parameters.
  * @async
  */
-export async function sign(algo, hashAlgo, publicKeyParams, privateKeyParams, data, hashed) {
+export async function sign(algo, hashAlgo, publicKeyParams, privateKeyParams, data, hashed, config) {
   if (!publicKeyParams || !privateKeyParams) {
     throw new Error('Missing key parameters');
   }
   switch (algo) {
+    case enums.publicKey.aead: {
+      const { symAlgo } = publicKeyParams;
+      const { key } = privateKeyParams;
+      const { keySize } = getCipherParams(symAlgo);
+      const aeadAlgo = config.preferredAEADAlgorithm;
+      const mode = getAEADMode(aeadAlgo);
+      const { ivLength } = mode;
+      const salt = getRandomBytes(32);
+      const packetID = 0xC0 | enums.packet.signature;
+      const version = 6;
+      const info = new Uint8Array([packetID, version, symAlgo, aeadAlgo]);
+      const hkdf = await computeHKDF(enums.hash.sha512, key, salt, info, keySize + ivLength);
+      const authKey = hkdf.subarray(0, keySize);
+      const iv = hkdf.subarray(keySize);
+      const modeInstance = await mode(symAlgo, authKey);
+      const authTag = await modeInstance.encrypt(new Uint8Array(), iv, hashed);
+      return { aeadAlgo, salt, authTag };
+    }
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaSign: {

--- a/src/enums.d.ts
+++ b/src/enums.d.ts
@@ -71,11 +71,13 @@ declare namespace enums {
     symEncryptedIntegrityProtectedData = 18,
     modificationDetectionCode = 19,
     aeadEncryptedData = 20,
-    padding = 21
+    padding = 21,
+    persistentSymmetricKey = 40
   }
 
-  export type publicKeyNames = 'rsaEncryptSign' | 'rsaEncrypt' | 'rsaSign' | 'elgamal' | 'dsa' | 'ecdh' | 'ecdsa' | 'eddsaLegacy' | 'aedh' | 'aedsa' | 'ed25519' | 'x25519' | 'ed448' | 'x448' | 'mlkem768X25519' | 'mldsa65Ed25519';
+  export type publicKeyNames = 'aead' | 'rsaEncryptSign' | 'rsaEncrypt' | 'rsaSign' | 'elgamal' | 'dsa' | 'ecdh' | 'ecdsa' | 'eddsaLegacy' | 'aedh' | 'aedsa' | 'x25519' | 'x448' | 'ed25519' | 'ed448' | 'mldsa65Ed25519' | 'mlkem768X25519';
   export enum publicKey {
+    aead = 0,
     rsaEncryptSign = 1,
     rsaEncrypt = 2,
     rsaSign = 3,

--- a/src/enums.js
+++ b/src/enums.js
@@ -68,6 +68,8 @@ export default {
    * @readonly
    */
   publicKey: {
+    /** AEAD (symmetric, for Persistent Symmetric Key Packets only) */
+    aead: 0,
     /** RSA (Encrypt or Sign) [HAC] */
     rsaEncryptSign: 1,
     /** RSA (Encrypt only) [HAC] */
@@ -194,7 +196,8 @@ export default {
     symEncryptedIntegrityProtectedData: 18,
     modificationDetectionCode: 19,
     aeadEncryptedData: 20, // see IETF draft: https://tools.ietf.org/html/draft-ford-openpgp-format-00#section-2.1
-    padding: 21
+    padding: 21,
+    persistentSymmetricKey: 40
   },
 
   /** Data types in the literal packet

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,6 +104,10 @@ export class PrivateKey extends PublicKey {
   public update(sourceKey: PublicKey, date?: Date, config?: Config): Promise<PrivateKey>;
 }
 
+export class PersistentSymmetricKey extends PrivateKey {
+  constructor(packetlist: PacketList<AnyPacket>);
+}
+
 export class Subkey {
   constructor(subkeyPacket: SecretSubkeyPacket | PublicSubkeyPacket, mainKey: PublicKey);
   public readonly keyPacket: SecretSubkeyPacket | PublicSubkeyPacket;
@@ -398,6 +402,11 @@ export class SecretSubkeyPacket extends BaseSecretKeyPacket {
   protected isSubkey(): true;
 }
 
+export class PersistentSymmetricKeyPacket extends BaseSecretKeyPacket {
+  static readonly tag: enums.packet.persistentSymmetricKey;
+  protected isSubkey(): false;
+}
+
 export class CompressedDataPacket extends BasePacket<true> {
   static readonly tag: enums.packet.compressedData;
   private compress(): void;
@@ -543,7 +552,7 @@ export class UnparseablePacket {
 }
 
 export type AnyPacket = BasePacket<boolean> | UnparseablePacket;
-export type AnySecretKeyPacket = SecretKeyPacket | SecretSubkeyPacket;
+export type AnySecretKeyPacket = BaseSecretKeyPacket;
 export type AnyKeyPacket = BasePublicKeyPacket;
 
 type AllowedPackets = Map<enums.packet, object>; // mapping to Packet classes (i.e. typeof LiteralDataPacket etc.)
@@ -679,7 +688,7 @@ export type EllipticCurveName = 'ed25519Legacy' | 'curve25519Legacy' | 'nistP256
 interface GenerateKeyOptions {
   userIDs: MaybeArray<UserID>;
   passphrase?: string;
-  type?: 'ecc' | 'rsa' | 'curve25519' | 'curve448' | 'pqc';
+  type?: 'ecc' | 'rsa' | 'curve25519' | 'curve448' | 'pqc' | 'symmetric';
   curve?: EllipticCurveName;
   rsaBits?: number;
   keyExpirationTime?: number;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export {
   generateSessionKey, encryptSessionKey, decryptSessionKeys
 } from './openpgp.js';
 
-export { PrivateKey, PublicKey, Subkey, readKey, readKeys, readPrivateKey, readPrivateKeys } from './key/index.js';
+export { PublicKey, PrivateKey, Subkey, PersistentSymmetricKey, readKey, readKeys, readPrivateKey, readPrivateKeys } from './key/index.js';
 
 export { Signature, readSignature } from './signature.js';
 

--- a/src/key/factory.js
+++ b/src/key/factory.js
@@ -28,10 +28,12 @@ import {
   PublicSubkeyPacket,
   SecretKeyPacket,
   SecretSubkeyPacket,
+  PersistentSymmetricKeyPacket,
   UserAttributePacket
 } from '../packet/index.js';
-import PrivateKey from './private_key.js';
 import PublicKey from './public_key.js';
+import PrivateKey from './private_key.js';
+import PersistentSymmetricKey from './persistent_symmetric_key.js';
 import * as helper from './helper.js';
 import enums from '../enums.ts';
 import util from '../util.js';
@@ -44,6 +46,7 @@ const allowedKeyPackets = /*#__PURE__*/ util.constructAllowedPackets([
   PublicSubkeyPacket,
   SecretKeyPacket,
   SecretSubkeyPacket,
+  PersistentSymmetricKeyPacket,
   UserIDPacket,
   UserAttributePacket,
   SignaturePacket
@@ -58,10 +61,12 @@ const allowedKeyPackets = /*#__PURE__*/ util.constructAllowedPackets([
 function createKey(packetlist) {
   for (const packet of packetlist) {
     switch (packet.constructor.tag) {
-      case enums.packet.secretKey:
-        return new PrivateKey(packetlist);
       case enums.packet.publicKey:
         return new PublicKey(packetlist);
+      case enums.packet.secretKey:
+        return new PrivateKey(packetlist);
+      case enums.packet.persistentSymmetricKey:
+        return new PersistentSymmetricKey(packetlist);
     }
   }
   throw new Error('No key packet found');
@@ -71,7 +76,7 @@ function createKey(packetlist) {
 /**
  * Generates a new OpenPGP key. Supports RSA and ECC keys, as well as the newer Curve448 and Curve25519 keys.
  * By default, primary and subkeys will be of same type.
- * @param {ecc|rsa|curve448|curve25519} options.type                  The primary key algorithm type: ECC, RSA, Curve448 or Curve25519 (new format).
+ * @param {ecc|rsa|curve25519|curve448|aead} options.type                  The primary key algorithm type: ECC, RSA, Curve25519/Curve448 (new format) or AEAD.
  * @param {String}  options.curve                 Elliptic curve for ECC keys
  * @param {Integer} options.rsaBits               Number of bits for RSA keys
  * @param {Array<String|Object>} options.userIDs  User IDs as strings or objects: 'Jo Doe <info@jo.com>' or { name:'Jo Doe', email:'info@jo.com' }
@@ -93,8 +98,11 @@ export async function generate(options, config) {
   let promises = [helper.generateSecretKey(options, config)];
   promises = promises.concat(options.subkeys.map(options => helper.generateSecretSubkey(options, config)));
   const packets = await Promise.all(promises);
-
   const key = await wrapKeyObject(packets[0], packets.slice(1), options, config);
+  if (key instanceof PersistentSymmetricKey) {
+    // Persistent Symmetric Keys cannot be revoked.
+    return { key };
+  }
   const revocationCertificate = await key.getRevocationCertificate(options.date, config);
   key.revocationSignatures = [];
   return { key, revocationCertificate };
@@ -155,6 +163,10 @@ export async function reformat(options, config) {
   options.subkeys = options.subkeys.map(subkeyOptions => sanitize(subkeyOptions, options));
 
   const key = await wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, config);
+  if (key instanceof PersistentSymmetricKey) {
+    // Persistent Symmetric Keys cannot be revoked.
+    return { key };
+  }
   const revocationCertificate = await key.getRevocationCertificate(options.date, config);
   key.revocationSignatures = [];
   return { key, revocationCertificate };
@@ -192,6 +204,14 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options, conf
 
   const packetlist = new PacketList();
   packetlist.push(secretKeyPacket);
+
+  if (secretKeyPacket.algorithm === enums.publicKey.aead) {
+    if (options.passphrase) {
+      secretKeyPacket.clearPrivateParams();
+    }
+    // Persistent Symmetric Keys don't have any other components.
+    return new PersistentSymmetricKey(packetlist);
+  }
 
   function createPreferredAlgos(algos, preferredAlgo) {
     return [preferredAlgo, ...algos.filter(algo => algo !== preferredAlgo)];
@@ -344,7 +364,7 @@ export async function readKey({ armoredKey, binaryKey, config, ...rest }) {
     input = binaryKey;
   }
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
-  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
+  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey, enums.packet.persistentSymmetricKey);
   if (keyIndex.length === 0) {
     throw new Error('No key packet found');
   }
@@ -386,13 +406,13 @@ export async function readPrivateKey({ armoredKey, binaryKey, config, ...rest })
     input = binaryKey;
   }
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
-  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
+  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey, enums.packet.persistentSymmetricKey);
   for (let i = 0; i < keyIndex.length; i++) {
     if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey) {
       continue;
     }
     const firstPrivateKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
-    return new PrivateKey(firstPrivateKeyList);
+    return createKey(firstPrivateKeyList);
   }
   throw new Error('No secret key packet found');
 }
@@ -430,7 +450,7 @@ export async function readKeys({ armoredKeys, binaryKeys, config, ...rest }) {
   }
   const keys = [];
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
-  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
+  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey, enums.packet.persistentSymmetricKey);
   if (keyIndex.length === 0) {
     throw new Error('No key packet found');
   }
@@ -473,13 +493,13 @@ export async function readPrivateKeys({ armoredKeys, binaryKeys, config }) {
   }
   const keys = [];
   const packetlist = await PacketList.fromBinary(input, allowedKeyPackets, config);
-  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey);
+  const keyIndex = packetlist.indexOfTag(enums.packet.publicKey, enums.packet.secretKey, enums.packet.persistentSymmetricKey);
   for (let i = 0; i < keyIndex.length; i++) {
     if (packetlist[keyIndex[i]].constructor.tag === enums.packet.publicKey) {
       continue;
     }
     const oneKeyList = packetlist.slice(keyIndex[i], keyIndex[i + 1]);
-    const newKey = new PrivateKey(oneKeyList);
+    const newKey = createKey(oneKeyList);
     keys.push(newKey);
   }
   if (keys.length === 0) {

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -7,6 +7,7 @@
 import {
   SecretKeyPacket,
   SecretSubkeyPacket,
+  PersistentSymmetricKeyPacket,
   SignaturePacket
 } from '../packet/index.js';
 import enums from '../enums.ts';
@@ -24,10 +25,11 @@ export async function generateSecretSubkey(options, config) {
 }
 
 export async function generateSecretKey(options, config) {
-  const secretKeyPacket = new SecretKeyPacket(options.date, config);
+  const KeyPacket = options.algorithm === enums.publicKey.aead ? PersistentSymmetricKeyPacket : SecretKeyPacket;
+  const secretKeyPacket = new KeyPacket(options.date, config);
   secretKeyPacket.packets = null;
   secretKeyPacket.algorithm = enums.write(enums.publicKey, options.algorithm);
-  await secretKeyPacket.generate(options.rsaBits, options.curve, options.config);
+  await secretKeyPacket.generate(options.rsaBits, options.curve, config);
   await secretKeyPacket.computeFingerprintAndKeyID();
   return secretKeyPacket;
 }
@@ -124,6 +126,9 @@ export async function getPreferredHashAlgo(targetKeys, signingKeyPacket, date = 
    */
   const defaultAlgo = enums.hash.sha256; // MUST implement
   const preferredSenderAlgo = config.preferredHashAlgorithm;
+
+  // Ignore Persistent Symmetric Keys
+  targetKeys = targetKeys.filter(key => !(key.keyPacket instanceof PersistentSymmetricKeyPacket));
 
   const supportedAlgosPerTarget = await Promise.all(targetKeys.map(async (key, i) => {
     const selfCertification = await key.getPrimarySelfSignature(date, targetUserIDs[i], config);
@@ -224,6 +229,9 @@ export async function getPreferredCompressionAlgo(keys = [], date = new Date(), 
   const defaultAlgo = enums.compression.uncompressed;
   const preferredSenderAlgo = config.preferredCompressionAlgorithm;
 
+  // Ignore Persistent Symmetric Keys
+  keys = keys.filter(key => !(key.keyPacket instanceof PersistentSymmetricKeyPacket));
+
   // if preferredSenderAlgo appears in the prefs of all recipients, we pick it
   // otherwise we use the default algo
   // if no keys are available, preferredSenderAlgo is returned
@@ -245,6 +253,9 @@ export async function getPreferredCompressionAlgo(keys = [], date = new Date(), 
  * @async
  */
 export async function getPreferredCipherSuite(keys = [], date = new Date(), userIDs = [], config = defaultConfig) {
+  // Ignore Persistent Symmetric Keys
+  keys = keys.filter(key => !(key.keyPacket instanceof PersistentSymmetricKeyPacket));
+
   const selfSigs = await Promise.all(keys.map((key, i) => key.getPrimarySelfSignature(date, userIDs[i], config)));
   const withAEAD = keys.length ?
     selfSigs.every(selfSig => selfSig.features && (selfSig.features[0] & enums.features.seipdv2)) :
@@ -415,6 +426,10 @@ export function sanitizeKeyOptions(options, subkeyDefaults = {}) {
   options.sign = options.sign || false;
 
   switch (options.type) {
+    case 'symmetric':
+      options.algorithm = enums.publicKey.aead;
+      options.subkeys = []; // Persistent Symmetric Keys can't have subkeys.
+      break;
     case 'pqc':
       if (options.sign) {
         options.algorithm = enums.publicKey.mldsa65Ed25519;

--- a/src/key/index.js
+++ b/src/key/index.js
@@ -15,9 +15,10 @@ import {
   createSignaturePacket
 } from './helper.js';
 
-import PrivateKey from './private_key.js';
 import PublicKey from './public_key.js';
+import PrivateKey from './private_key.js';
 import Subkey from './subkey.js';
+import PersistentSymmetricKey from './persistent_symmetric_key.js';
 
 export {
   readKey,
@@ -30,7 +31,8 @@ export {
   getPreferredCompressionAlgo,
   getPreferredCipherSuite,
   createSignaturePacket,
-  PrivateKey,
   PublicKey,
-  Subkey
+  PrivateKey,
+  Subkey,
+  PersistentSymmetricKey
 };

--- a/src/key/key.js
+++ b/src/key/key.js
@@ -85,6 +85,7 @@ class Key {
       switch (tag) {
         case enums.packet.publicKey:
         case enums.packet.secretKey:
+        case enums.packet.persistentSymmetricKey:
           if (this.keyPacket) {
             throw new Error('Key block contains multiple keys');
           }

--- a/src/key/persistent_symmetric_key.js
+++ b/src/key/persistent_symmetric_key.js
@@ -1,0 +1,118 @@
+/** @access public */
+
+import PrivateKey from './private_key.js';
+
+/**
+ * Class that represents a persistent symmetric key
+ */
+class PersistentSymmetricKey extends PrivateKey {
+  /**
+   * Verify primary key. Checks for revocation signatures, expiration time
+   * and valid self signature. Throws if the primary key is invalid.
+   * @param {Date} [date] - Use the given date for verification instead of the current time
+   * @param {Object} [userID] - User ID
+   * @param {Object} [config] - Full configuration, defaults to openpgp.config
+   * @throws {Error} If key verification failed
+   * @async
+   */
+  async verifyPrimaryKey(_date, _userID, _config) {
+    // Nothing to do as a persistent symmetric key can't be revoked or expired.
+  }
+
+  /**
+   * Returns last created key or key by given keyID that is available for signing and verification
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date} [date] - use the fiven date date to  to check key validity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} signing key
+   * @throws if no valid signing key was found
+   * @async
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getSigningKey(keyID = null, _date, _userID, _config) {
+    const primaryKey = this.keyPacket;
+    if (!keyID || primaryKey.getKeyID().equals(keyID)) {
+      if (!this.isDecrypted()) {
+        // Persistent Symmetric Keys need to be decrypted even for verifying
+        throw new Error('Persistent Symmetric Key is not decrypted');
+      }
+      return this;
+    }
+    throw new Error('Could not find matching signing key packet in key ' + this.getKeyID().toHex());
+  }
+
+  /**
+   * Returns last created key or key by given keyID that is available for encryption or decryption
+   * @param  {module:type/keyid~KeyID} [keyID] - key ID of a specific key to retrieve
+   * @param  {Date}   [date] - use the fiven date date to  to check key matchingity instead of the current date
+   * @param  {Object} [userID] - filter keys for the given user ID
+   * @param  {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Key|Subkey>} encryption key
+   * @throws if no valid encryption key was found
+   * @async
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getEncryptionKey(keyID = null, _date, _userID, _config) {
+    const primaryKey = this.keyPacket;
+    if (!keyID || primaryKey.getKeyID().equals(keyID)) {
+      if (!this.isDecrypted()) {
+        // Persistent Symmetric Keys need to be decrypted even for encrypting
+        throw new Error('Persistent Symmetric Key is not decrypted');
+      }
+      return this;
+    }
+    throw new Error('Could not find matching encryption key packet in key ' + this.getKeyID().toHex());
+  }
+
+  /**
+   * Returns all keys that are available for decryption, matching the keyID when given
+   * This is useful to retrieve keys for session key decryption
+   * @param  {module:type/keyid~KeyID} keyID, optional
+   * @param  {Date}              date, optional
+   * @param  {String}            userID, optional
+   * @param {Object} [config] - Full configuration, defaults to openpgp.config
+   * @returns {Promise<Array<Key|Subkey>>} Array of decryption keys.
+   * @throws {Error} if no decryption key is found
+   * @async
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getDecryptionKeys(keyID = null, _date, _userID, _config) {
+    const primaryKey = this.keyPacket;
+    if (!keyID || primaryKey.getKeyID().equals(keyID, true)) {
+      if (primaryKey.isDummy()) {
+        throw new Error('Gnu-dummy key packets cannot be used for decryption');
+      } else {
+        return [this];
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Check whether the private and public primary key parameters correspond
+   * @param {Object} [config] - Full configuration, defaults to openpgp.config
+   * @throws {Error} if validation was not successful and the key cannot be trusted
+   * @async
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async validate(_config) {
+    // Nothing to do as a persistent symmetric key must use modern AEAD.
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async revoke(_reasonForRevocation, _date, _config) {
+    throw new Error('Persistent Symmetric Keys cannot be revoked');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async addSubkey(_options = {}) {
+    throw new Error('Persistent Symmetric Keys cannot have subkeys');
+  }
+
+  toPublic() {
+    throw new Error('Persistent Symmetric Keys do not have a public key');
+  }
+}
+
+export default PersistentSymmetricKey;

--- a/src/key/private_key.js
+++ b/src/key/private_key.js
@@ -240,6 +240,9 @@ class PrivateKey extends PublicKey {
     if (options.rsaBits < config.minRSABits) {
       throw new Error(`rsaBits should be at least ${config.minRSABits}, got: ${options.rsaBits}`);
     }
+    if (options.type === 'symmetric') {
+      throw new Error('Cannot add persistent symmetric subkey');
+    }
     const secretKeyPacket = this.keyPacket;
     if (secretKeyPacket.isDummy()) {
       throw new Error('Cannot add subkey to gnu-dummy primary key');

--- a/src/message.js
+++ b/src/message.js
@@ -451,7 +451,7 @@ export class Message {
           sessionKeyAlgorithm: symmetricAlgorithm
         });
 
-        await pkESKeyPacket.encrypt(encryptionKey.keyPacket);
+        await pkESKeyPacket.encrypt(encryptionKey.keyPacket, config);
         delete pkESKeyPacket.sessionKey; // delete plaintext session key after encryption
         return pkESKeyPacket;
       }));

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -38,23 +38,28 @@ import { checkKeyRequirements } from './key/helper.js';
  * The generated primary key will have signing capabilities. By default, one subkey with encryption capabilities is also generated.
  * @param {Object} options
  * @param {Object|Array<Object>} options.userIDs - User IDs as objects: `{ name: 'Jo Doe', email: 'info@jo.com' }`
- * @param {'rsa'|'ecc'|'curve25519'|'curve448'|'pqc'} [options.type='ecc'] - The key algorithm type: RSA, ECC (default for v4 keys), Curve25519 (new format, default for v6 keys), Curve448 or PQC.
- *                                                                           When PQC is selected, an ML-DSA-65+Ed25519 & ML-KEM-768+X25519 key is generated.
- *                                                                           Note: Curve25519 (new format), Curve448 and PQC are not widely supported yet.
+ * @param {'rsa'|'ecc'|'curve25519'|'curve448'|'pqc'|'symmetric'} [options.type='ecc']
+ *   The key algorithm type: RSA, ECC (default for v4 keys), Curve25519 (new format, default for v6 keys), Curve448 or PQC.
+ *   When PQC is selected, an ML-DSA-65+Ed25519 & ML-KEM-768+X25519 key is generated.
+ *   Note: Curve25519 (new format), Curve448, PQC and persistent symmetric keys are not widely supported yet.
+ *   Note: Persistent symmetric keys can't have subkeys. The `options.subkeys` parameter is ignored when `type` is `'symmetric'`.
  * @param {String} [options.passphrase=(not protected)] - The passphrase used to encrypt the generated private key. If omitted or empty, the key won't be encrypted.
  * @param {Number} [options.rsaBits=4096] - Number of bits for RSA keys
- * @param {String} [options.curve='curve25519Legacy'] - Elliptic curve for ECC keys:
- *                                             curve25519Legacy (default), nistP256, nistP384, nistP521, secp256k1,
- *                                             brainpoolP256r1, brainpoolP384r1, or brainpoolP512r1
+ * @param {String} [options.curve='curve25519Legacy']
+ *   Elliptic curve for ECC keys:
+ *   curve25519Legacy (default), nistP256, nistP384, nistP521, secp256k1,
+ *   brainpoolP256r1, brainpoolP384r1, or brainpoolP512r1
  * @param {Date} [options.date=current date] - Override the creation date of the key and the key signatures
  * @param {Number} [options.keyExpirationTime=0 (never expires)] - Number of seconds from the key creation time after which the key expires
- * @param {Array<Object>} [options.subkeys=a single encryption subkey] - Options for each subkey e.g. `[{sign: true, passphrase: '123'}]`
- *                                             default to main key options, except for `sign` parameter that defaults to false, and indicates whether the subkey should sign rather than encrypt
+ * @param {Array<Object>} [options.subkeys=a single encryption subkey]
+ *   Options for each subkey e.g. `[{sign: true, passphrase: '123'}]`
+ *   default to main key options, except for `sign` parameter that defaults to false, and indicates whether the subkey should sign rather than encrypt
  * @param {'armored'|'binary'|'object'} [options.format='armored'] - format of the output keys
  * @param {Object|Object[]} [options.signatureNotations=[]] - Array of notations to add to the primary self-signature, e.g. `[{ name: 'test@example.org', value: new TextEncoder().encode('test'), humanReadable: true, critical: false }]`
  * @param {Object} [options.config] - Custom configuration settings to overwrite those in [config]{@link module:config}
- * @returns {Promise<Object>} The generated key object in the form:
- *                                     { privateKey:PrivateKey|Uint8Array|String, publicKey:PublicKey|Uint8Array|String, revocationCertificate:String }
+ * @returns {Promise<Object>}
+ *   The generated key object in the form:
+ *   { privateKey:PrivateKey|Uint8Array|String, publicKey:PublicKey|Uint8Array|String, revocationCertificate:String }
  * @async
  * @static
  */
@@ -70,8 +75,11 @@ export async function generateKey({ userIDs = [], passphrase, type, curve, rsaBi
   userIDs = toArray(userIDs); signatureNotations = toArray(signatureNotations);
   const unknownOptions = Object.keys(rest); if (unknownOptions.length > 0) throw new Error(`Unknown option: ${unknownOptions.join(', ')}`);
 
-  if (userIDs.length === 0 && !config.v6Keys) {
+  if (userIDs.length === 0 && !config.v6Keys && type !== 'symmetric') {
     throw new Error('UserIDs are required for V4 keys');
+  }
+  if (userIDs.length !== 0 && type === 'symmetric') {
+    throw new Error('Persistent symmetric keys cannot have User IDs');
   }
   if (type === 'rsa' && rsaBits < config.minRSABits) {
     throw new Error(`rsaBits should be at least ${config.minRSABits}, got: ${rsaBits}`);
@@ -85,7 +93,7 @@ export async function generateKey({ userIDs = [], passphrase, type, curve, rsaBi
 
     return {
       privateKey: formatObject(key, format, config),
-      publicKey: formatObject(key.toPublic(), format, config),
+      publicKey: type !== 'symmetric' ? formatObject(key.toPublic(), format, config) : undefined,
       revocationCertificate
     };
   } catch (err) {
@@ -118,6 +126,9 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase, keyExp
   if (userIDs.length === 0 && privateKey.keyPacket.version !== 6) {
     throw new Error('UserIDs are required for V4 keys');
   }
+  if (userIDs.length !== 0 && privateKey.keyPacket.algorithm === 0) {
+    throw new Error('Persistent symmetric keys cannot have User IDs');
+  }
   const options = { privateKey, userIDs, passphrase, keyExpirationTime, date, signatureNotations };
 
   try {
@@ -125,7 +136,7 @@ export async function reformatKey({ privateKey, userIDs = [], passphrase, keyExp
 
     return {
       privateKey: formatObject(reformattedKey, format, config),
-      publicKey: formatObject(reformattedKey.toPublic(), format, config),
+      publicKey: privateKey.keyPacket.algorithm !== 0 ? formatObject(reformattedKey.toPublic(), format, config) : undefined,
       revocationCertificate
     };
   } catch (err) {

--- a/src/packet/all_packets.js
+++ b/src/packet/all_packets.js
@@ -22,3 +22,4 @@ export { default as SecretSubkeyPacket } from './secret_subkey.js';
 export { default as SignaturePacket } from './signature.js';
 export { default as TrustPacket } from './trust.js';
 export { default as PaddingPacket } from './padding.js';
+export { default as PersistentSymmetricKeyPacket } from './persistent_symmetric_key.js';

--- a/src/packet/persistent_symmetric_key.js
+++ b/src/packet/persistent_symmetric_key.js
@@ -1,0 +1,99 @@
+/** @access public */
+// OpenPGP.js - An OpenPGP implementation in javascript
+// Copyright (C) 2026 Proton AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+import SecretKeyPacket from './secret_key.js';
+import enums from '../enums.ts';
+import defaultConfig from '../config.ts';
+
+/**
+ * The Persistent Symmetric Key Packet (Type ID 40) has identical fields
+ * to the Secret Key Packet (Type ID 5).
+ * @extends SecretKeyPacket
+ */
+class PersistentSymmetricKeyPacket extends SecretKeyPacket {
+  static get tag() {
+    return enums.packet.persistentSymmetricKey;
+  }
+
+  /**
+   * @param {Date} [date] - Creation date
+   * @param {Object} [config] - Full configuration, defaults to openpgp.config
+   */
+  constructor(date = new Date(), config = defaultConfig) {
+    super(date, config);
+
+    // Only version 6 of the packet is defined.
+    this.version = 6;
+  }
+
+  /**
+   * Internal parser for persistent symmetric key packets as specified in
+   * {@link https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-persistent-symmetric-keys-02#section-5|draft-ietf-openpgp-persistent-symmetric-keys section 5}
+   * @param {Uint8Array} bytes - Input string to read the packet from
+   * @async
+   */
+  async read(bytes, config = defaultConfig) {
+    await super.read(bytes, config);
+
+    // Only version 6 of the packet is defined. Earlier versions of the
+    // Secret Key Packet format MUST NOT be used with the Persistent
+    // Symmetric Key Packet.
+    if (this.version < 6) {
+      throw new Error('Persistent Symmetric Key packets can only be used with version 6');
+    }
+
+    // The Persistent Symmetric Key Packet MUST NOT be used with
+    // asymmetric algorithms, i.e. any of the public key algorithms
+    // defined in table 18 of [RFC9580]. It may only be used with the
+    // persistent symmetric algorithm defined below, with special
+    // algorithm ID value 0.
+    if (this.algorithm !== enums.publicKey.aead) {
+      throw new Error('Persistent Symmetric Key packets can only be used with algorithm 0');
+    }
+
+    // When storing encrypted symmetric key material in a Persistent
+    // Symmetric Key Packet, AEAD encryption (S2K usage octet 253, see
+    // section 3.7.2.1 of [RFC9580]) MUST be used, to ensure that the
+    // secret key material is bound to the fingerprint. Implementations
+    // MUST NOT decrypt symmetric key material in a Persistent Symmetric
+    // Key Packet that was encrypted using a different method.
+    if (this.s2kUsage && !this.usedModernAEAD) {
+      throw new Error('Persistent Symmetric Key packets can only be encrypted with modern AEAD');
+    }
+  }
+
+  /**
+   * Writes a persistent symmetric key packet.
+   * @returns {Uint8Array} A string of bytes containing the persistent symmetric key packet.
+   */
+  write() {
+    // Sanity checks, same as above.
+    if (this.version < 6) {
+      throw new Error('Persistent Symmetric Key packets can only be used with version 6');
+    }
+    if (this.algorithm !== enums.publicKey.aead) {
+      throw new Error('Persistent Symmetric Key packets can only be used with algorithm 0');
+    }
+    if (this.s2kUsage && !this.usedModernAEAD) {
+      throw new Error('Persistent Symmetric Key packets can only be encrypted with modern AEAD');
+    }
+    return super.write();
+  }
+}
+
+export default PersistentSymmetricKeyPacket;

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -121,6 +121,9 @@ class PublicKeyPacket {
 
       // - A one-octet number denoting the public-key algorithm of this key.
       this.algorithm = bytes[pos++];
+      if (this.algorithm === enums.publicKey.aead && this.constructor.tag !== enums.packet.persistentSymmetricKey) {
+        throw new Error('AEAD may only be used with Persistent Symmetric Key packets');
+      }
 
       if (this.version >= 5) {
         // - A four-octet scalar octet count for the following key material.
@@ -281,6 +284,8 @@ class PublicKeyPacket {
       result.bits = util.uint8ArrayBitLength(modulo);
     } else if (this.publicParams.oid) {
       result.curve = this.publicParams.oid.getName();
+    } else if (this.publicParams.symAlgo) {
+      result.cipherAlgorithm = enums.read(enums.symmetric, this.publicParams.symAlgo);
     }
     return result;
   }

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -180,11 +180,12 @@ class PublicKeyEncryptedSessionKeyPacket {
 
   /**
    * Encrypt session key packet
-   * @param {PublicKeyPacket} key - Public key
+   * @param {PublicKeyPacket|PersistentSymmetricKeyPacket} key - Public key or persistent symmetric key packet
+   * @param {Object} config
    * @throws {Error} if encryption failed
    * @async
    */
-  async encrypt(key) {
+  async encrypt(key, config) {
     const algo = enums.write(enums.publicKey, this.publicKeyAlgorithm);
     // No symmetric encryption algorithm identifier is passed to the public-key algorithm for a
     // v6 PKESK packet, as it is included in the v2 SEIPD packet.
@@ -192,12 +193,12 @@ class PublicKeyEncryptedSessionKeyPacket {
     const fingerprint = key.version === 5 ? key.getFingerprintBytes().subarray(0, 20) : key.getFingerprintBytes();
     const encoded = encodeSessionKey(this.version, algo, sessionKeyAlgorithm, this.sessionKey);
     this.encrypted = await publicKeyEncrypt(
-      algo, sessionKeyAlgorithm, key.publicParams, encoded, fingerprint);
+      algo, sessionKeyAlgorithm, key.publicParams, key.privateParams, encoded, fingerprint, config);
   }
 
   /**
    * Decrypts the session key (only for public key encrypted session key packets (tag 1)
-   * @param {SecretKeyPacket} key - decrypted private key
+   * @param {SecretKeyPacket|PersistentSymmetricKeyPacket} key - decrypted private key or persistent symmetric key packet
    * @param {Object} [randomSessionKey] - Bogus session key to use in case of sensitive decryption error, or if the decrypted session key is of a different type/size.
    *                                      This is needed for constant-time processing. Expected object of the form: { sessionKey: Uint8Array, sessionKeyAlgorithm: enums.symmetric }
    * @throws {Error} if decryption failed, unless `randomSessionKey` is given
@@ -235,6 +236,11 @@ export default PublicKeyEncryptedSessionKeyPacket;
 
 function encodeSessionKey(version, keyAlgo, cipherAlgo, sessionKeyData) {
   switch (keyAlgo) {
+    case enums.publicKey.aead:
+      return util.concatUint8Array([
+        new Uint8Array(version === 6 ? [] : [cipherAlgo]),
+        sessionKeyData
+      ]);
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.elgamal:
@@ -257,6 +263,10 @@ function encodeSessionKey(version, keyAlgo, cipherAlgo, sessionKeyData) {
 
 function decodeSessionKey(version, keyAlgo, decryptedData, randomSessionKey) {
   switch (keyAlgo) {
+    case enums.publicKey.aead:
+      return version === 6 ?
+        { sessionKeyAlgorithm: null, sessionKey: decryptedData } :
+        { sessionKeyAlgorithm: decryptedData[0], sessionKey: decryptedData.subarray(1) };
     case enums.publicKey.rsaEncrypt:
     case enums.publicKey.rsaEncryptSign:
     case enums.publicKey.elgamal:

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -391,7 +391,7 @@ class SecretKeyPacket extends PublicKeyPacket {
 
     const { blockSize } = getCipherParams(this.symmetric);
 
-    if (config.aeadProtect) {
+    if (config.aeadProtect || this.algorithm === enums.publicKey.aead) {
       this.s2kUsage = 253;
       this.aead = config.preferredAEADAlgorithm;
       const mode = cipherMode.getAEADMode(this.aead);
@@ -525,7 +525,11 @@ class SecretKeyPacket extends PublicKeyPacket {
     }
   }
 
-  async generate(bits, curve) {
+  async generate(bits, curve, config) {
+    // Sanity check
+    if (this.algorithm === enums.publicKey.aead && this.constructor.tag !== enums.packet.persistentSymmetricKey) {
+      throw new Error('AEAD may only be used with Persistent Symmetric Key packets');
+    }
     // The deprecated OIDs for Ed25519Legacy and Curve25519Legacy are used in legacy version 4 keys and signatures.
     // Implementations MUST NOT accept or generate v6 key material using the deprecated OIDs.
     if (this.version === 6 && (
@@ -537,7 +541,7 @@ class SecretKeyPacket extends PublicKeyPacket {
     if (this.version !== 6 && this.algorithm === enums.publicKey.mldsa65Ed25519) {
       throw new Error(`Cannot generate v${this.version} signing keys of type 'pqc'. Generate a v6 key instead`);
     }
-    const { privateParams, publicParams } = await generateParams(this.algorithm, bits, curve);
+    const { privateParams, publicParams } = await generateParams(this.algorithm, bits, curve, config);
     this.privateParams = privateParams;
     this.publicParams = publicParams;
     this.isEncrypted = false;

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -260,7 +260,7 @@ class SignaturePacket {
 
     this.signedHashValue = streamSlice(streamClone(hash), 0, 2);
     const signed = async () => signature.sign(
-      this.publicKeyAlgorithm, this.hashAlgorithm, key.publicParams, key.privateParams, toHash, await streamReadToEnd(hash)
+      this.publicKeyAlgorithm, this.hashAlgorithm, key.publicParams, key.privateParams, toHash, await streamReadToEnd(hash), config
     );
     if (util.isStream(hash)) {
       this.params = signed();
@@ -788,7 +788,8 @@ class SignaturePacket {
       this.params = await this.params;
 
       this[verified] = await signature.verify(
-        this.publicKeyAlgorithm, this.hashAlgorithm, this.params, key.publicParams,
+        this.publicKeyAlgorithm, this.hashAlgorithm, this.params,
+        key.publicParams, key.privateParams,
         toHash, hash
       );
 

--- a/test/crypto/crypto.js
+++ b/test/crypto/crypto.js
@@ -215,7 +215,7 @@ export default () => describe('API functional testing', async function() {
           openpgp.enums.publicKey.rsaEncryptSign, hash, RSAPublicParams, RSAPrivateParams, data, await crypto.computeDigest(hash, data)
         );
         const success = await crypto.signature.verify(
-          openpgp.enums.publicKey.rsaEncryptSign, hash, RSAsignedData, RSAPublicParams, data, await crypto.computeDigest(hash, data)
+          openpgp.enums.publicKey.rsaEncryptSign, hash, RSAsignedData, RSAPublicParams, {}, data, await crypto.computeDigest(hash, data)
         );
         expect(success).to.be.true;
       });
@@ -227,7 +227,7 @@ export default () => describe('API functional testing', async function() {
           openpgp.enums.publicKey.dsa, hash, DSAPublicParams, DSAPrivateParams, data, await crypto.computeDigest(hash, data)
         );
         const success = await crypto.signature.verify(
-          openpgp.enums.publicKey.dsa, hash, DSAsignedData, DSAPublicParams, data, await crypto.computeDigest(hash, data)
+          openpgp.enums.publicKey.dsa, hash, DSAsignedData, DSAPublicParams, {}, data, await crypto.computeDigest(hash, data)
         );
         expect(success).to.be.true;
       });
@@ -242,7 +242,7 @@ export default () => describe('API functional testing', async function() {
         openpgp.enums.publicKey.ed448, openpgp.enums.hash.sha512, { A }, { seed }, data, toSign
       );
       const success = await crypto.signature.verify(
-        openpgp.enums.publicKey.ed448, openpgp.enums.hash.sha512, signedData, { A }, data, toSign
+        openpgp.enums.publicKey.ed448, openpgp.enums.hash.sha512, signedData, { A }, {}, data, toSign
       );
 
       return expect(success).to.be.true;
@@ -274,7 +274,7 @@ export default () => describe('API functional testing', async function() {
 
     it('Asymmetric using RSA with eme_pkcs1 padding', function () {
       const symmKey = crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
-      return crypto.publicKeyEncrypt(algoRSA, openpgp.enums.symmetric.aes256, RSAPublicParams, symmKey).then(RSAEncryptedData => {
+      return crypto.publicKeyEncrypt(algoRSA, openpgp.enums.symmetric.aes256, RSAPublicParams, {}, symmKey).then(RSAEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoRSA, RSAPublicParams, RSAPrivateParams, RSAEncryptedData
         ).then(data => {
@@ -285,7 +285,7 @@ export default () => describe('API functional testing', async function() {
 
     it('Asymmetric using Elgamal with eme_pkcs1 padding', function () {
       const symmKey = crypto.generateSessionKey(openpgp.enums.symmetric.aes256);
-      return crypto.publicKeyEncrypt(algoElGamal, openpgp.enums.symmetric.aes256, elGamalPublicParams, symmKey).then(ElgamalEncryptedData => {
+      return crypto.publicKeyEncrypt(algoElGamal, openpgp.enums.symmetric.aes256, elGamalPublicParams, {}, symmKey).then(ElgamalEncryptedData => {
         return crypto.publicKeyDecrypt(
           algoElGamal, elGamalPublicParams, elGamalPrivateParams, ElgamalEncryptedData
         ).then(data => {

--- a/test/crypto/postQuantum.js
+++ b/test/crypto/postQuantum.js
@@ -682,7 +682,7 @@ export default () => describe('PQC', function () {
     const sessionKey = { data: new Uint8Array(16).fill(1), algorithm: 'aes128' };
 
     const { privateParams, publicParams } = await generateParams(openpgp.enums.publicKey.mlkem768X25519);
-    const encryptedSessionKeyParams = await publicKeyEncrypt(openpgp.enums.publicKey.mlkem768X25519, undefined, publicParams, sessionKey.data);
+    const encryptedSessionKeyParams = await publicKeyEncrypt(openpgp.enums.publicKey.mlkem768X25519, undefined, publicParams, {}, sessionKey.data);
     const decryptedSessionKey = await publicKeyDecrypt(openpgp.enums.publicKey.mlkem768X25519, publicParams, privateParams, encryptedSessionKeyParams);
     expect(decryptedSessionKey).to.deep.equal(sessionKey.data);
   });
@@ -836,7 +836,7 @@ Fy70NCeqH2b6JeETZ1xFQEiEInk6B9WE558S9Mi6yjeSXdV65yNK2km5
 
     const { privateParams, publicParams } = await generateParams(openpgp.enums.publicKey.mldsa65Ed25519);
     const signature = await sign(openpgp.enums.publicKey.mldsa65Ed25519, hashAlgo, publicParams, privateParams, null, digest);
-    const verified = await verify(openpgp.enums.publicKey.mldsa65Ed25519, hashAlgo, signature, publicParams, null, digest);
+    const verified = await verify(openpgp.enums.publicKey.mldsa65Ed25519, hashAlgo, signature, publicParams, {}, null, digest);
     expect(verified).to.be.true;
   });
 

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -2237,6 +2237,13 @@ VFBLG8uc9IiaKann/DYBAJcZNZHRSfpDoV2pUA5EAEi2MdjxkRysFQnYPRAu
 =rWL8
 -----END PGP PRIVATE KEY BLOCK-----`;
 
+const persistentSymmetricKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+6HcGaXT0TgAAAAAhCWXcoYn5e9mbCXz0RJmbldb+3noZXSWT0+OhS8RsPUMk
+/RoJAwsDCAULqTD3qZhHABNOf5G9YQymW3Qqn2N9+ilERkQJ0eGwRNOCRLfQ
+zQZHkrrLxfeeoeqyGdC5Aqcu0dbOce1n4NeiVkbaUw==
+-----END PGP PRIVATE KEY BLOCK-----`;
+
 function versionSpecificTests() {
   it('Preferences of generated key', function() {
     const testPref = function(key) {
@@ -2617,6 +2624,24 @@ function versionSpecificTests() {
     }
   });
 
+  it('Generate persistent symmetric key', async function() {
+    const opt = { type: 'symmetric', passphrase: '123', format: 'object' };
+    const { privateKey: key, publicKey, revocationCertificate } = await openpgp.generateKey(opt);
+    expect(publicKey).to.be.undefined;
+    expect(revocationCertificate).to.be.undefined;
+    expect(key instanceof openpgp.PersistentSymmetricKey).to.equal(true);
+    expect(key.getAlgorithmInfo().algorithm).to.equal('aead');
+    expect(key.getAlgorithmInfo().cipherAlgorithm).to.equal('aes256');
+    expect(key.keyPacket.version).to.equal(6);
+    expect(key.users.length).to.equal(0);
+    expect(key.subkeys.length).to.equal(0);
+  });
+
+  it('Generate persistent symmetric key - cannot add User IDs', async function() {
+    const opt = { type: 'symmetric', passphrase: '123', format: 'object', userIDs: [{ name: 'Test' }] };
+    await expect(openpgp.generateKey(opt)).to.be.rejectedWith('Persistent symmetric keys cannot have User IDs');
+  });
+
   it('Generate key - ensure keyExpirationTime works', function() {
     const expect_delta = 365 * 24 * 60 * 60;
     const userID = { name: 'test', email: 'a@b.com' };
@@ -2887,6 +2912,33 @@ function versionSpecificTests() {
       const decryptedKey = await openpgp.decryptKey({ privateKey: refKey, passphrase });
       expect(decryptedKey.isDecrypted()).to.be.true;
     });
+  });
+
+  it('Reformat and encrypt persistent symmetric key', async function() {
+    const original = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+    const privateKey = await openpgp.decryptKey({ privateKey: original, passphrase: '123' });
+
+    const passphrase = 'hello world';
+    const reformatOpt = { privateKey, passphrase, format: 'object' };
+    return openpgp.reformatKey(reformatOpt).then(async ({ privateKey: refKey, publicKey, revocationCertificate }) => {
+      expect(publicKey).to.be.undefined;
+      expect(revocationCertificate).to.be.undefined;
+      expect(refKey instanceof openpgp.PersistentSymmetricKey).to.be.true;
+      expect(refKey.users.length).to.equal(0);
+      expect(refKey.subkeys.length).to.equal(0);
+      expect(refKey.directSignatures.length).to.equal(0);
+      expect(refKey.isDecrypted()).to.be.false;
+      const decryptedKey = await openpgp.decryptKey({ privateKey: refKey, passphrase });
+      expect(decryptedKey.isDecrypted()).to.be.true;
+    });
+  });
+
+  it('Reformat persistent symmetric key - cannot add user IDs', async function() {
+    const original = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+    const privateKey = await openpgp.decryptKey({ privateKey: original, passphrase: '123' });
+
+    const reformatOpt = { privateKey, format: 'object', userIDs: [{ name: 'Test' }] };
+    await expect(openpgp.reformatKey(reformatOpt)).to.be.rejectedWith('Persistent symmetric keys cannot have User IDs');
   });
 
   it('Sign and encrypt with reformatted key', async function() {
@@ -3294,6 +3346,43 @@ ruh8m7Xo2ehSSFyWRSuTSZe5tm/KXgYG
       stubArgon2PrimaryKey.restore();
       stubArgon2Subkey.restore();
     }
+  });
+
+  it('Parsing, decrypting, encrypting and serializing persistent symmetric key', async function() {
+    const passphrase = '123';
+    const encryptedKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+
+    const decryptedKey = await openpgp.decryptKey({
+      privateKey: encryptedKey,
+      passphrase
+    });
+
+    const reecryptedKey = await openpgp.encryptKey({
+      privateKey: decryptedKey,
+      passphrase,
+      config: { aeadProtect: true }
+    });
+    expect(reecryptedKey.keyPacket.s2kUsage).to.equal(253);
+    const redecryptedKey = await openpgp.decryptKey({
+      privateKey: reecryptedKey,
+      passphrase
+    });
+    expect(redecryptedKey.write()).to.deep.equal(decryptedKey.write());
+
+    // sanity checks
+    expect(decryptedKey.isPrivate()).to.be.true;
+    await expect(decryptedKey.validate()).to.be.fulfilled;
+    const signingKey = await decryptedKey.getSigningKey();
+    expect(signingKey.keyPacket.algorithm).to.equal(openpgp.enums.publicKey.aead);
+    expect(signingKey.getAlgorithmInfo()).to.deep.equal({ algorithm: 'aead', 'cipherAlgorithm': 'aes256' });
+
+    const encryptionKey = await decryptedKey.getEncryptionKey();
+    expect(encryptionKey.keyPacket.algorithm).to.equal(openpgp.enums.publicKey.aead);
+    expect(encryptionKey.getAlgorithmInfo()).to.deep.equal({ algorithm: 'aead', 'cipherAlgorithm': 'aes256' });
+
+    await expect(decryptedKey.revoke()).to.be.rejectedWith('Persistent Symmetric Keys cannot be revoked');
+    await expect(decryptedKey.addSubkey()).to.be.rejectedWith('Persistent Symmetric Keys cannot have subkeys');
+    expect(() => decryptedKey.toPublic()).to.throw('Persistent Symmetric Keys do not have a public key');
   });
 
   it('Parsing EdDSALegacy key with unsupported OID (Curve448Legacy)', async function() {
@@ -4921,6 +5010,14 @@ I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUrk0mXubZvyl4GBg==
       const decrypted = await openpgp.decrypt({ message, decryptionKeys: newPrivateKey });
       expect(decrypted).to.exist;
       expect(decrypted.data).to.be.equal(vData);
+    });
+
+    it('cannot add persistent symmetric subkey', async function() {
+      const privateKey = await openpgp.decryptKey({
+        privateKey: await openpgp.readKey({ armoredKey: priv_key_rsa }),
+        passphrase: 'hello world'
+      });
+      await expect(privateKey.addSubkey({ type: 'symmetric' })).to.be.rejectedWith('Cannot add persistent symmetric subkey');
     });
   });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -3750,6 +3750,208 @@ XfA3pqV4mTzF
         });
       });
 
+      describe('Encrypt/decrypt, sign/verify with persistent symmetric key', function() {
+        const persistentSymmetricKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+6HcGaXT0TgAAAAAhCWXcoYn5e9mbCXz0RJmbldb+3noZXSWT0+OhS8RsPUMk
+/RoJAwsDCAULqTD3qZhHABNOf5G9YQymW3Qqn2N9+ilERkQJ0eGwRNOCRLfQ
+zQZHkrrLxfeeoeqyGdC5Aqcu0dbOce1n4NeiVkbaUw==
+-----END PGP PRIVATE KEY BLOCK-----`;
+
+        it('should encrypt and decrypt', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const encOpt = {
+            message: await openpgp.createMessage({ text: plaintext }),
+            encryptionKeys: decryptedKey
+          };
+          const decOpt = {
+            decryptionKeys: decryptedKey
+          };
+          return openpgp.encrypt(encOpt).then(async function (encrypted) {
+            decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
+            return openpgp.decrypt(decOpt);
+          }).then(function (decrypted) {
+            expect(decrypted.data).to.equal(plaintext);
+            expect(decrypted.signatures.length).to.equal(0);
+          });
+        });
+
+        it('should encrypt and decrypt (larger message)', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const largerPlaintext = new Uint8Array(100_000);
+          const encOpt = {
+            message: await openpgp.createMessage({ binary: largerPlaintext }),
+            encryptionKeys: decryptedKey
+          };
+          const decOpt = {
+            decryptionKeys: decryptedKey,
+            format: 'binary'
+          };
+          return openpgp.encrypt(encOpt).then(async function (encrypted) {
+            decOpt.message = await openpgp.readMessage({ armoredMessage: encrypted });
+            return openpgp.decrypt(decOpt);
+          }).then(function (decrypted) {
+            expect(util.equalsUint8Array(decrypted.data, largerPlaintext)).to.be.true;
+            expect(decrypted.signatures.length).to.equal(0);
+          });
+        });
+
+        it('Streaming encrypt and decrypt small message roundtrip', async function() {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const plaintext = [];
+          let i = 0;
+          const data = new globalThis.ReadableStream({
+            pull(controller) {
+              if (i++ < 4) {
+                const randomBytes = crypto.getRandomBytes(10);
+                controller.enqueue(randomBytes);
+                plaintext.push(randomBytes.slice());
+              } else {
+                controller.close();
+              }
+            }
+          });
+          const encrypted = await openpgp.encrypt({
+            message: await openpgp.createMessage({ binary: data }),
+            encryptionKeys: decryptedKey
+          });
+          expect(stream.isStream(encrypted)).to.equal('web');
+
+          const message = await openpgp.readMessage({ armoredMessage: encrypted });
+          const decrypted = await openpgp.decrypt({
+            decryptionKeys: decryptedKey,
+            message,
+            format: 'binary'
+          });
+          expect(stream.isStream(decrypted.data)).to.equal('web');
+          expect(await stream.readToEnd(decrypted.data)).to.deep.equal(util.concatUint8Array(plaintext));
+        });
+
+        it('should sign and verify', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const signOpt = {
+            message: await openpgp.createMessage({ text: plaintext }),
+            signingKeys: decryptedKey
+          };
+          const verifyOpt = {
+            verificationKeys: decryptedKey
+          };
+          return openpgp.sign(signOpt).then(async function (signed) {
+            verifyOpt.message = await openpgp.readMessage({ armoredMessage: signed });
+            return openpgp.verify(verifyOpt);
+          }).then(async function (verified) {
+            expect(verified.data).to.equal(plaintext);
+            expect(verified.signatures.length).to.equal(1);
+            expect(await verified.signatures[0].verified).to.be.true;
+          });
+        });
+
+        it('should sign and verify (larger message)', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const largerPlaintext = new Uint8Array(100_000);
+          const signOpt = {
+            message: await openpgp.createMessage({ binary: largerPlaintext }),
+            signingKeys: decryptedKey
+          };
+          const verifyOpt = {
+            verificationKeys: decryptedKey,
+            format: 'binary'
+          };
+          return openpgp.sign(signOpt).then(async function (signed) {
+            verifyOpt.message = await openpgp.readMessage({ armoredMessage: signed });
+            return openpgp.verify(verifyOpt);
+          }).then(async function (verified) {
+            expect(util.equalsUint8Array(verified.data, largerPlaintext)).to.be.true;
+            expect(verified.signatures.length).to.equal(1);
+            expect(await verified.signatures[0].verified).to.be.true;
+          });
+        });
+
+        it('Streaming sign and verify small message roundtrip', async function() {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const plaintext = [];
+          let i = 0;
+          const data = new globalThis.ReadableStream({
+            pull(controller) {
+              if (i++ < 4) {
+                const randomBytes = crypto.getRandomBytes(10);
+                controller.enqueue(randomBytes);
+                plaintext.push(randomBytes.slice());
+              } else {
+                controller.close();
+              }
+            }
+          });
+          const signed = await openpgp.sign({
+            message: await openpgp.createMessage({ binary: data }),
+            signingKeys: decryptedKey
+          });
+          expect(stream.isStream(signed)).to.equal('web');
+
+          const message = await openpgp.readMessage({ armoredMessage: signed });
+          const verified = await openpgp.verify({
+            verificationKeys: decryptedKey,
+            message,
+            format: 'binary'
+          });
+          expect(stream.isStream(verified.data)).to.equal('web');
+          expect(await stream.readToEnd(verified.data)).to.deep.equal(util.concatUint8Array(plaintext));
+          expect(verified.signatures.length).to.equal(1);
+          expect(await verified.signatures[0].verified).to.be.true;
+        });
+
+        it('should sign and verify detached', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const signOpt = {
+            message: await openpgp.createMessage({ text: plaintext }),
+            signingKeys: decryptedKey,
+            detached: true
+          };
+          const verifyOpt = {
+            message: await openpgp.createMessage({ text: plaintext }),
+            verificationKeys: decryptedKey
+          };
+          return openpgp.sign(signOpt).then(async function (signed) {
+            verifyOpt.signature = await openpgp.readSignature({ armoredSignature: signed });
+            return openpgp.verify(verifyOpt);
+          }).then(async function (verified) {
+            expect(verified.data).to.equal(plaintext);
+            expect(verified.signatures.length).to.equal(1);
+            expect(await verified.signatures[0].verified).to.be.true;
+          });
+        });
+
+        it('should sign and verify detached (larger message)', async function () {
+          const privateKey = await openpgp.readKey({ armoredKey: persistentSymmetricKey });
+          const decryptedKey = await openpgp.decryptKey({ privateKey, passphrase: '123' });
+          const largerPlaintext = new Uint8Array(100_000);
+          const signOpt = {
+            message: await openpgp.createMessage({ binary: largerPlaintext }),
+            signingKeys: decryptedKey,
+            detached: true
+          };
+          const verifyOpt = {
+            message: await openpgp.createMessage({ binary: largerPlaintext }),
+            verificationKeys: decryptedKey,
+            format: 'binary'
+          };
+          return openpgp.sign(signOpt).then(async function (signed) {
+            verifyOpt.signature = await openpgp.readSignature({ armoredSignature: signed });
+            return openpgp.verify(verifyOpt);
+          }).then(async function (verified) {
+            expect(util.equalsUint8Array(verified.data, largerPlaintext)).to.be.true;
+            expect(verified.signatures.length).to.equal(1);
+            expect(await verified.signatures[0].verified).to.be.true;
+          });
+        });
+      });
     }
 
     describe('AES / RSA encrypt, decrypt, sign, verify', function() {

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -241,7 +241,7 @@ export default () => describe('X25519 Cryptography (legacy format)', function ()
           expect(R).to.deep.eq(r);
           expect(S).to.deep.eq(s);
         }),
-        signature.verify(22, openpgp.enums.hash.sha256, { r: R, s: S }, publicParams, undefined, data).then(result => {
+        signature.verify(22, openpgp.enums.hash.sha256, { r: R, s: S }, publicParams, {}, undefined, data).then(result => {
           expect(result).to.be.true;
         })
       ]);


### PR DESCRIPTION
Implements [draft-ietf-openpgp-persistent-symmetric-keys-03](https://www.ietf.org/archive/id/draft-ietf-openpgp-persistent-symmetric-keys-03.html).

This introduces a new `PersistentSymmetricKey` class that extends `PrivateKey` and can be generated, parsed and used in place of a `PrivateKey` and (for encrypting and verifying) a `PublicKey`. Unlike a `PrivateKey`, it's not possible to add User IDs, subkeys, or derive a public key from the private key. Additionally, the private key needs to be available in decrypted form in order to use it for encrypting and verifying (unlike asymmetric keys).

To be merged after https://github.com/openpgpjs/openpgpjs/pull/2022.