### PR TITLE
TS: fix AnyPacket declaration to also include `BasePacket<true>` subclasses

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
           path: main
       - uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version-file: main/package.json
 
       - name: Run pull request time benchmark
         run: cd pr && npm install && npm run --silent benchmark-time > benchmarks.txt && cat benchmarks.txt

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -542,7 +542,7 @@ export class UnparseablePacket {
   write: () => Uint8Array;
 }
 
-export type AnyPacket = BasePacket | UnparseablePacket;
+export type AnyPacket = BasePacket<boolean> | UnparseablePacket;
 export type AnySecretKeyPacket = SecretKeyPacket | SecretSubkeyPacket;
 export type AnyKeyPacket = BasePublicKeyPacket;
 

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -15,7 +15,7 @@ import {
   readMessage, createMessage, Message, createCleartextMessage,
   encrypt, decrypt, sign, verify, config, enums,
   generateSessionKey, encryptSessionKey, decryptSessionKeys,
-  LiteralDataPacket, PacketList, CompressedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket, CleartextMessage,
+  LiteralDataPacket, PacketList, CompressedDataPacket, SymEncryptedIntegrityProtectedDataPacket, PublicKeyPacket, PublicSubkeyPacket, SecretKeyPacket, SecretSubkeyPacket, CleartextMessage,
   type WebStream, type NodeWebStream
 } from 'openpgp';
 
@@ -104,6 +104,8 @@ import {
   expect(encryptedBinaryObject).to.be.instanceOf(Message);
   const encryptedTextObject: Message<string> = await encrypt({ encryptionKeys: publicKeys, message: textMessage, format: 'object' });
   expect(encryptedTextObject).to.be.instanceOf(Message);
+  const seipdPacket = encryptedTextObject.packets.findPacket(enums.packet.symEncryptedIntegrityProtectedData) as SymEncryptedIntegrityProtectedDataPacket;
+  expect(seipdPacket).to.be.instanceOf(SymEncryptedIntegrityProtectedDataPacket);
 
   // Session key functions
   // Get session keys from encrypted message


### PR DESCRIPTION
Issue introduced in https://github.com/openpgpjs/openpgpjs/commit/48d1cfd15f3cfe37c2bcf0666060c0ec460b57a6 due to `BasePacket` defaulting to `BasePacket<false>`