### PR TITLE
Fix non-zero IV usages for AES-CFB

### DIFF
--- a/src/crypto/cipherMode/cfb.js
+++ b/src/crypto/cipherMode/cfb.js
@@ -149,7 +149,8 @@ class WebCryptoEncryptor {
   constructor(algo, key, iv) {
     const { blockSize } = getCipherParams(algo);
     this.key = key;
-    this.prevBlock = iv;
+    this.iv = iv;
+    this.prevBlock = iv.slice();
     this.nextBlock = new Uint8Array(blockSize);
     this.i = 0; // pointer inside next block
     this.blockSize = blockSize;


### PR DESCRIPTION
(This issue was introduced in OpenPGP.js v6; previous versions are not impacted).

AES-CFB initialization vectors (IVs) were always set to be all zeros, even in cases where a random value was expected.
This did not affect message body encryption or password-encrypted session keys (SKESK), where a zero IV is intentional per spec
(see https://www.rfc-editor.org/rfc/rfc9580.html#section-5.13.1-4 and https://www.rfc-editor.org/rfc/rfc9580.html#section-5.3.1-5).

It did affect password-encrypted keys, for which a random IV should be sampled.
However, there was **no security impact**.

This is because, while IV reuse is potentially problematic when paired with AES key reuse, that is not the case in this context (i.e. OpenPGP password-based encryption), since a reused password does not automatically produce the same AES input key, since non-legacy S2K ("string-to-key") modes also sample a random salt, meaning the derived key would change even on password reuse. (The random salt generation was performed properly.)