### PR TITLE
Argon2: set hard limit for `config.maxArgon2MemoryExponent` to cap memory at 1 TiB

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ const config: Config = {
   },
   /**
    * Max memory exponent allowed for Argon2 memory allocation (e.g. `maxArgon2MemoryExponent: 20` corresponds
-   * to a memory limit of 2**20 = 1GiB).
+   * to a memory limit of 2**20 KiB = 1GiB).
    * This limit is applied both on encryption (if `config.s2kType` is set to `enums.s2k.argon2`)
    * and decryption.
    * If the input memory exponent exceeds this value, the library will not attempt the argon2 key derivation
@@ -181,7 +181,7 @@ const config: Config = {
    * NB: on encryption, if `s2kArgon2Params.memoryExponent` is larger than `maxArgon2MemoryExponent`,
    * the operation will fail.
    */
-  maxArgon2MemoryExponent: Infinity,
+  maxArgon2MemoryExponent: 30,
   /**
    * Allow decryption of messages without integrity protection.
    * This is an **insecure** setting:

--- a/src/type/s2k/argon2.js
+++ b/src/type/s2k/argon2.js
@@ -7,6 +7,12 @@ import { getRandomBytes } from '../../crypto/index.js';
 const ARGON2_TYPE = 0x02; // id
 const ARGON2_VERSION = 0x13;
 const ARGON2_SALT_SIZE = 16;
+/**
+ * Max exponent supported, that applies regardless of `config.maxArgon2MemoryExponent`;
+ * the argon2 lib in principle supports a larger value, but this is already unrealistically large,
+ * and it enables us to use bitwise operations.
+ */
+const ARGON2_MAX_ENCODEDM = 30;
 
 export class Argon2OutOfMemoryError extends Error {
   constructor(...params) {
@@ -104,10 +110,13 @@ class Argon2S2K {
   * @async
   */
   async produceKey(passphrase, keySize, config) {
+    if (config.maxArgon2MemoryExponent > ARGON2_MAX_ENCODEDM) {
+      throw new Argon2OutOfMemoryError(`'config.maxArgon2MemoryExponent' exceeds the max allowed value of ${ARGON2_MAX_ENCODEDM}`);
+    }
     if (this.encodedM > config.maxArgon2MemoryExponent) {
       throw new Argon2OutOfMemoryError('Argon2 required memory exceeds `config.maxArgon2MemoryExponent`');
     }
-    const decodedM = 2 << (this.encodedM - 1);
+    const decodedM = 1 << this.encodedM;
 
     try {
       // on first load, the argon2 lib is imported and the WASM module is initialized.


### PR DESCRIPTION
Follow up to #1943 : while the argon2 lib in principle supports a larger value, this new limit is still unrealistically large, and it enables the safe use of bitwise operations.

Thanks to Shirsendu Mondal (@Shirshaw64p) for the report.