### PR TITLE
Add missing clearPrivateParams() to TypeScript declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -387,6 +387,7 @@ declare abstract class BaseSecretKeyPacket extends BasePublicKeyPacket {
   public isDummy(): boolean;
   public isMissingSecretKeyMaterial(): boolean;
   public makeDummy(config?: Config): void;
+  public clearPrivateParams(): void;
 }
 
 export class SecretKeyPacket extends BaseSecretKeyPacket {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,6 +99,7 @@ export class PrivateKey extends PublicKey {
   constructor(packetlist: PacketList<AnyPacket>);
   public revoke(reason?: ReasonForRevocation, date?: Date, config?: Config): Promise<PrivateKey>;
   public isDecrypted(): boolean;
+  public clearPrivateParams(): void;
   public addSubkey(options: SubkeyOptions): Promise<PrivateKey>;
   public getDecryptionKeys(keyID?: KeyID, date?: Date | null, userID?: UserID, config?: Config): Promise<(PrivateKey | Subkey)[]>;
   public update(sourceKey: PublicKey, date?: Date, config?: Config): Promise<PrivateKey>;

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -203,6 +203,10 @@ import {
   // @ts-expect-error for incompatible packet type
   new PacketList<SecretKeyPacket>().push(new SecretSubkeyPacket());
 
+  // clearPrivateParams is available on secret key packets
+  new SecretKeyPacket().clearPrivateParams();
+  new SecretSubkeyPacket().clearPrivateParams();
+
   expect(LiteralDataPacket.tag).to.equal(enums.packet.literalData);
 
   // // Detached - sign text message (armored)

--- a/test/typescript/definitions.ts
+++ b/test/typescript/definitions.ts
@@ -62,6 +62,11 @@ import {
   // @ts-expect-error isDecrypted is not defined for public keys
   try { (await privateKey.toPublic().update(privateKey.toPublic())).isDecrypted(); } catch {}
 
+  // Clear decrypted private key material
+  privateKey.clearPrivateParams();
+  // @ts-expect-error clearPrivateParams is not defined for public keys
+  try { privateKey.toPublic().clearPrivateParams(); } catch {}
+
   // Revoke keys
   await revokeKey({ key: privateKey });
   // @ts-expect-error for missing revocation certificate


### PR DESCRIPTION
Fixes #1710. Fixes #2028 (duplicate report).

### What

`clearPrivateParams()` exists at runtime and is [documented](https://docs.openpgpjs.org/PrivateKey.html#clearPrivateParams), but was missing from the TypeScript declarations in `src/index.d.ts` on both classes flagged in #1710:

- `PrivateKey` (`src/key/private_key.js`)
- `SecretKeyPacket` (`src/packet/secret_key.js`)

TS callers using it to zero decrypted key material got:

```
Property 'clearPrivateParams' does not exist on type 'PrivateKey'. (2339)
```

### Change

- Declare `public clearPrivateParams(): void;` on the `PrivateKey` class.
- Declare it on `BaseSecretKeyPacket`, shared by `SecretKeyPacket` and `SecretSubkeyPacket` (matches the runtime, where both packet types expose it).
- Add coverage in `test/typescript/definitions.ts`: a positive `PrivateKey` call plus a `@ts-expect-error` asserting it is not on `PublicKey`, and positive calls on both secret key packet types.

### Verification

`npm run build-types && tsc --project test/typescript/tsconfig.test.json` passes clean. Runtime matches the declared signature:

```js
const key = await decryptKey({ privateKey: await readPrivateKey({ armoredKey }), passphrase })
key.isDecrypted()        // true
key.clearPrivateParams() // returns void
key.isDecrypted()        // false
```
