### PR TITLE
[v7] CurveWithOID: stricter WebCrypto checks

### DIFF
--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -98,6 +98,9 @@ async function genPublicEphemeralKey(curve, Q) {
         try {
           return await webPublicEphemeralKey(curve, Q);
         } catch (err) {
+          if (err.name !== 'NotSupportedError') {
+            throw err;
+          }
           util.printDebugError(err);
           return jsPublicEphemeralKey(curve, Q);
         }
@@ -162,6 +165,9 @@ async function genPrivateEphemeralKey(curve, V, Q, d) {
         try {
           return await webPrivateEphemeralKey(curve, V, Q, d);
         } catch (err) {
+          if (err.name !== 'NotSupportedError') {
+            throw err;
+          }
           util.printDebugError(err);
           return jsPrivateEphemeralKey(curve, V, d);
         }

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -110,7 +110,6 @@ async function genPublicEphemeralKey(curve, Q) {
       return nodePublicEphemeralKey(curve, Q);
     default:
       return jsPublicEphemeralKey(curve, Q);
-
   }
 }
 
@@ -131,6 +130,10 @@ export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
   const curve = new CurveWithOID(oid);
   checkPublicPointEnconding(curve, Q);
   const { publicKey, sharedKey } = await genPublicEphemeralKey(curve, Q);
+  if (sharedKey.length !== curve.payloadSize) {
+    // sanity check to avoid generating undecryptable data, in case the shared secret is not padded
+    throw new Error('Unexpected shared secret size')
+  }
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, kdfParams, fingerprint);
   const { keySize } = getCipherParams(kdfParams.cipher);
   const Z = await kdf(kdfParams.hash, sharedKey, keySize, param);
@@ -348,7 +351,8 @@ function nodePrivateEphemeralKey(curve, V, d) {
   const recipient = nodeCrypto.createECDH(curve.node);
   recipient.setPrivateKey(d);
   const sharedKey = new Uint8Array(recipient.computeSecret(V));
-  const secretKey = new Uint8Array(recipient.getPrivateKey());
+  // If `d` was padded, `setPrivateKey` drops the zeros, hence we need to re-pad
+  const secretKey = util.leftPad(new Uint8Array(recipient.getPrivateKey()), curve.payloadSize);
   return { secretKey, sharedKey };
 }
 
@@ -364,6 +368,7 @@ function nodePublicEphemeralKey(curve, Q) {
   const nodeCrypto = util.getNodeCrypto();
   const sender = nodeCrypto.createECDH(curve.node);
   sender.generateKeys();
+  // `computeSecret()` always pads to size, unlike `getPrivateKey()`
   const sharedKey = new Uint8Array(sender.computeSecret(Q));
   const publicKey = new Uint8Array(sender.getPublicKey());
   return { publicKey, sharedKey };

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -152,11 +152,6 @@ export async function encrypt(oid, kdfParams, data, Q, fingerprint) {
  * @async
  */
 async function genPrivateEphemeralKey(curve, V, Q, d) {
-  if (d.length !== curve.payloadSize) {
-    const privateKey = new Uint8Array(curve.payloadSize);
-    privateKey.set(d, curve.payloadSize - d.length);
-    d = privateKey;
-  }
   switch (curve.type) {
     case 'curve25519Legacy': {
       const secretKey = d.slice().reverse();

--- a/src/crypto/public_key/elliptic/ecdsa.js
+++ b/src/crypto/public_key/elliptic/ecdsa.js
@@ -56,8 +56,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
           // Need to await to make sure browser succeeds
           return await webSign(curve, hashAlgo, message, keyPair);
         } catch (err) {
-          // We do not fallback if the error is related to key integrity
-          if (err.name === 'DataError' || err.name === 'OperationError') {
+          if (err.name !== 'NotSupportedError') {
             throw err;
           }
           util.printDebugError('Browser did not support signing: ' + err.message);
@@ -112,8 +111,7 @@ export async function verify(oid, hashAlgo, signature, message, publicKey, hashe
           const verified = await webVerify(curve, hashAlgo, signature, message, publicKey);
           return verified || tryFallbackVerificationForOldBug();
         } catch (err) {
-          // We do not fallback if the error is related to key integrity
-          if (err.name === 'DataError' || err.name === 'OperationError') {
+          if (err.name !== 'NotSupportedError') {
             throw err;
           }
           util.printDebugError('Browser did not support verifying: ' + err.message);

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -176,6 +176,9 @@ class CurveWithOID {
         try {
           return await webGenKeyPair(this.name, this.wireFormatLeadingByte, this.payloadSize);
         } catch (err) {
+          if (err.name !== 'NotSupportedError') {
+            throw err;
+          }
           util.printDebugError('Browser did not support generating ec key ' + err.message);
           return jsGenKeyPair(this.name);
         }

--- a/src/crypto/public_key/elliptic/oid_curves.js
+++ b/src/crypto/public_key/elliptic/oid_curves.js
@@ -174,7 +174,7 @@ class CurveWithOID {
     switch (this.type) {
       case 'web':
         try {
-          return await webGenKeyPair(this.name, this.wireFormatLeadingByte, this.payloadSize);
+          return await webGenKeyPair(this.name, this.wireFormatLeadingByte);
         } catch (err) {
           if (err.name !== 'NotSupportedError') {
             throw err;
@@ -306,19 +306,16 @@ async function jsGenKeyPair(name) {
   return { publicKey, privateKey };
 }
 
-async function webGenKeyPair(name, wireFormatLeadingByte, expectedPayloadSize) {
+async function webGenKeyPair(name, wireFormatLeadingByte) {
   // Note: keys generated with ECDSA and ECDH are structurally equivalent
   const webCryptoKey = await webCrypto.generateKey({ name: 'ECDSA', namedCurve: webCurves[name] }, true, ['sign', 'verify']);
 
   const privateKey = await webCrypto.exportKey('jwk', webCryptoKey.privateKey);
   const publicKey = await webCrypto.exportKey('jwk', webCryptoKey.publicKey);
 
-  const rawPublicKey = jwkToRawPublic(publicKey, wireFormatLeadingByte);
-  const rawPrivateKey = b64ToUint8Array(privateKey.d, true);
-
   return {
-    publicKey: rawPublicKey,
-    privateKey: util.leftPad(rawPrivateKey, expectedPayloadSize)
+    publicKey: jwkToRawPublic(publicKey, wireFormatLeadingByte),
+    privateKey: b64ToUint8Array(privateKey.d, true)
   };
 }
 

--- a/test/browserChecks.ts
+++ b/test/browserChecks.ts
@@ -1,0 +1,3 @@
+export const isSafari15or16 = () => typeof window !== 'undefined' && window.navigator.userAgent.match(/Version\/1(5|6)\.\d(\.\d)* (Mobile\/\w+ )?Safari/);
+
+export const isSafariOrHeadlessWebKit = () => typeof window !== 'undefined' && window.navigator.userAgent.match(/WebKit/) && !window.navigator.userAgent.match(/Chrome/);

--- a/test/crypto/ecdh.js
+++ b/test/crypto/ecdh.js
@@ -11,6 +11,7 @@ import * as elliptic_curves from '../../src/crypto/public_key/elliptic/index.js'
 import util from '../../src/util.js';
 import elliptic_data from './elliptic_data.js';
 import * as random from '../../src/crypto/random.js';
+import { isSafari15or16 } from '../browserChecks.ts';
 
 const key_data = elliptic_data.key_data;
 /* eslint-disable no-invalid-this */
@@ -273,6 +274,7 @@ export default () => describe('ECDH key exchange @lightweight', function () {
     }
   });
 
+  const expectNativeWebCurveWithOID = new Set(['nistP256', 'nistP384', 'nistP521', !isSafari15or16() && 'curve25519Legacy'].filter(Boolean));
   const allCurves = ['secp256k1', 'nistP256', 'nistP384', 'nistP521', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'];
   allCurves.forEach(curveName => {
     it(`${curveName} - Successful exchange`, async function () {
@@ -376,8 +378,6 @@ export default () => describe('ECDH key exchange @lightweight', function () {
 
     allCurves.forEach(curveName => {
       it(`${curveName}`, async function () {
-        const expectNativeWeb = new Set(['nistP256', 'nistP384', 'nistP521']);
-
         const curve = new elliptic_curves.CurveWithOID(curveName);
         const oid = new OID(curve.oid);
         const kdfParams = new KDFParams({ hash: curve.hash, cipher: curve.cipher });
@@ -387,7 +387,7 @@ export default () => describe('ECDH key exchange @lightweight', function () {
         await testRountripWithAndWithoutNative(
           data => ecdh.encrypt(oid, kdfParams, data, Q, fingerprint1),
           encryptResult => ecdh.decrypt(oid, kdfParams, encryptResult.publicKey, encryptResult.wrappedKey, Q, d, fingerprint1),
-          expectNativeWeb.has(curveName)
+          expectNativeWebCurveWithOID.has(curveName)
         );
       });
     });
@@ -400,7 +400,7 @@ export default () => describe('ECDH key exchange @lightweight', function () {
       await testRountripWithAndWithoutNative(
         data => ecdh.encrypt(oid, kdfParams, data, Q1, fingerprint1),
         encryptResult => ecdh.decrypt(oid, kdfParams, encryptResult.publicKey, encryptResult.wrappedKey, Q1, d1, fingerprint1),
-        false // all major browsers implement x25519, but webkit linux falls back due to bugs
+        expectNativeWebCurveWithOID.has(openpgp.enums.curve.curve25519Legacy)
       );
     });
   });

--- a/test/crypto/ecdsa_eddsa.js
+++ b/test/crypto/ecdsa_eddsa.js
@@ -12,6 +12,7 @@ import util from '../../src/util.js';
 import elliptic_data from './elliptic_data.js';
 import OID from '../../src/type/oid.js';
 import { getRandomBytes } from '../../src/crypto/random.js';
+import { isSafari15or16 } from '../browserChecks.ts';
 
 /**
  * Test that the result of `signFunction` can be verified by `verifyFunction`
@@ -56,6 +57,7 @@ const testRountripWithAndWithoutNative = async (
 };
 
 const key_data = elliptic_data.key_data;
+const expectNativeWebCurveWithOID = new Set(['nistP256', 'nistP384', 'nistP521', !isSafari15or16() && 'ed25519Legacy'].filter(Boolean));
 export default () => describe('ECC signatures', function () {
   const signature_data = {
     priv: new Uint8Array([
@@ -101,29 +103,62 @@ export default () => describe('ECC signatures', function () {
     }
   };
   describe('Basic Operations', function () {
-    it('Creating curve from name or oid', function (done) {
+    let sinonSandbox;
+    let getWebCryptoStub;
+    let getNodeCryptoStub;
+
+    beforeEach(function () {
+      sinonSandbox = sinon.createSandbox();
+    });
+
+    afterEach(function () {
+      sinonSandbox.restore();
+    });
+
+    const disableNative = () => {
+      enableNative();
+      // stubbed functions return undefined
+      getWebCryptoStub = sinonSandbox.stub(util, 'getWebCrypto').returns({
+        generateKey: () => { const e = new Error('getWebCrypto is mocked'); e.name = 'NotSupportedError'; throw e; },
+        importKey: () => { const e = new Error('getWebCrypto is mocked'); e.name = 'NotSupportedError'; throw e; }
+      });
+      getNodeCryptoStub = sinonSandbox.stub(util, 'getNodeCrypto');
+    };
+    const enableNative = () => {
+      getWebCryptoStub && getWebCryptoStub.restore();
+      getNodeCryptoStub && getNodeCryptoStub.restore();
+    };
+
+    it('Creating curve from name or oid', function () {
       Object.keys(openpgp.enums.curve).forEach(function(name_or_oid) {
         expect(new elliptic_curves.CurveWithOID(name_or_oid)).to.exist;
       });
       Object.values(openpgp.enums.curve).forEach(function(name_or_oid) {
         expect(new elliptic_curves.CurveWithOID(name_or_oid)).to.exist;
       });
-      done();
     });
-    it('Creating KeyPair', function () {
-      if (!config.useEllipticFallback && !util.getNodeCrypto()) {
-        // eslint-disable-next-line no-invalid-this
-        this.skip();
+    const curves = ['nistP256', 'nistP384', 'nistP521', 'secp256k1', 'ed25519Legacy', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'];
+    curves.forEach(curveName => it(`${curveName} - Creating key pair via genKeyPair`, async function () {
+      const nodeCrypto = util.getNodeCrypto();
+      const webCrypto = util.getWebCrypto();
+
+      const curve = new elliptic_curves.CurveWithOID(curveName);
+
+      const nativeSpyGenerate = webCrypto ? sinonSandbox.spy(webCrypto, 'exportKey') : sinonSandbox.spy(nodeCrypto, 'createECDH');
+      const nativeKey = await curve.genKeyPair();
+      expect(nativeKey.privateKey.length).to.equal(curve.payloadSize);
+      const expectedNativeCallCount = nativeSpyGenerate.callCount;
+
+      sinonSandbox.restore(); // reset spies
+      disableNative();
+      const nonNativeKey = await curve.genKeyPair();
+      expect(nonNativeKey.privateKey.length).to.equal(curve.payloadSize);
+      expect(nativeSpyGenerate.callCount).to.equal(expectedNativeCallCount); // assert that fallback implementation was called
+      if (expectNativeWebCurveWithOID.has(curveName)) {
+        expect(nativeSpyGenerate.callCount).to.equal(2); // export privateKey and publicKey
       }
-      const names = config.useEllipticFallback ? ['nistP256', 'nistP384', 'nistP521', 'secp256k1', 'curve25519Legacy', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'] :
-        ['nistP256', 'nistP384', 'nistP521', 'curve25519Legacy'];
-      return Promise.all(names.map(function (name) {
-        const curve = new elliptic_curves.CurveWithOID(name);
-        return curve.genKeyPair().then(keyPair => {
-          expect(keyPair).to.exist;
-        });
-      }));
-    });
+    }));
+
     it('Signature verification', async function () {
       const curve = new elliptic_curves.CurveWithOID('nistP256');
       await expect(
@@ -285,20 +320,19 @@ export default () => describe('ECC signatures', function () {
         () => expect(verify_signature('nistP384', 8, p384_r, p384_s, p384_message, key_data.nistP384.pub)).to.eventually.be.true
       );
     });
-    const curves = ['secp256k1' , 'nistP256', 'nistP384', 'nistP521', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'];
-    curves.forEach(curveName => it(`${curveName} - Sign and verify message with generated key`, async function () {
+    const ecdsaCurves = ['secp256k1' , 'nistP256', 'nistP384', 'nistP521', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1'];
+    ecdsaCurves.forEach(curveName => it(`${curveName} - Sign and verify message with generated key`, async function () {
       const sinonState = { sinonSandbox, enableNative, disableNative };
 
       const curve = new elliptic_curves.CurveWithOID(curveName);
       const oid = new OID(curve.oid);
-      const expectNativeWeb = new Set(['nistP256', 'nistP384', 'nistP521']);
 
       const nativeKey = await elliptic_curves.generate(curveName);
       await testRountripWithAndWithoutNative(
         sinonState,
         (data, dataDigest) => elliptic_curves.ecdsa.sign(oid, openpgp.enums.hash.sha512, data, nativeKey.Q, nativeKey.secret, dataDigest),
         (signature, data, dataDigest) => elliptic_curves.ecdsa.verify(oid, openpgp.enums.hash.sha512, signature, data, nativeKey.Q, dataDigest),
-        expectNativeWeb.has(curveName)
+        expectNativeWebCurveWithOID.has(curveName)
       );
 
       sinonSandbox.restore(); // reset spies
@@ -309,7 +343,7 @@ export default () => describe('ECC signatures', function () {
         sinonState,
         (data, dataDigest) => elliptic_curves.ecdsa.sign(oid, openpgp.enums.hash.sha512, data, nonNativeKey.Q, nonNativeKey.secret, dataDigest),
         (signature, data, dataDigest) => elliptic_curves.ecdsa.verify(oid, openpgp.enums.hash.sha512, signature, data, nonNativeKey.Q, dataDigest),
-        expectNativeWeb.has(curveName)
+        expectNativeWebCurveWithOID.has(curveName)
       );
     }));
   });
@@ -345,12 +379,14 @@ export default () => describe('ECC signatures', function () {
       const sinonState = { sinonSandbox, enableNative, disableNative };
       const curve = new elliptic_curves.CurveWithOID(openpgp.enums.curve.ed25519Legacy);
       const oid = new OID(curve.oid);
+      const expectNative = expectNativeWebCurveWithOID.has(openpgp.enums.curve.ed25519Legacy)
 
       const nativeKey = await elliptic_curves.generate(openpgp.enums.curve.ed25519Legacy);
       await testRountripWithAndWithoutNative(
         sinonState,
         (data, dataDigest) => elliptic_curves.eddsaLegacy.sign(oid, openpgp.enums.hash.sha512, data, nativeKey.Q, nativeKey.secret, dataDigest),
-        (signature, data, dataDigest) => elliptic_curves.eddsaLegacy.verify(oid, openpgp.enums.hash.sha512, signature, data, nativeKey.Q, dataDigest)
+        (signature, data, dataDigest) => elliptic_curves.eddsaLegacy.verify(oid, openpgp.enums.hash.sha512, signature, data, nativeKey.Q, dataDigest),
+        expectNative
       );
 
       sinonSandbox.restore(); // reset spies
@@ -360,18 +396,21 @@ export default () => describe('ECC signatures', function () {
       await testRountripWithAndWithoutNative(
         sinonState,
         (data, dataDigest) => elliptic_curves.eddsaLegacy.sign(oid, openpgp.enums.hash.sha512, data, nonNativeKey.Q, nonNativeKey.secret, dataDigest),
-        (signature, data, dataDigest) => elliptic_curves.eddsaLegacy.verify(oid, openpgp.enums.hash.sha512, signature, data, nonNativeKey.Q, dataDigest)
+        (signature, data, dataDigest) => elliptic_curves.eddsaLegacy.verify(oid, openpgp.enums.hash.sha512, signature, data, nonNativeKey.Q, dataDigest),
+        expectNative
       );
     });
 
     ['ed25519', 'ed448'].forEach(algoName => it(`${algoName} - Sign and verify message with native generated key`, async function () {
       const sinonState = { sinonSandbox, enableNative, disableNative };
       const algo = openpgp.enums.publicKey[algoName];
+      const expectNative = algoName === 'ed25519' && !isSafari15or16();
       const nativeKey = await elliptic_curves.eddsa.generate(algo);
       await testRountripWithAndWithoutNative(
         sinonState,
         (data, dataDigest) => elliptic_curves.eddsa.sign(algo, openpgp.enums.hash.sha512, data, nativeKey.A, nativeKey.seed, dataDigest),
-        (signature, data, dataDigest) => elliptic_curves.eddsa.verify(algo, openpgp.enums.hash.sha512, signature, data, nativeKey.A, dataDigest)
+        (signature, data, dataDigest) => elliptic_curves.eddsa.verify(algo, openpgp.enums.hash.sha512, signature, data, nativeKey.A, dataDigest),
+        expectNative
       );
 
       sinonSandbox.restore(); // reset spies
@@ -381,7 +420,8 @@ export default () => describe('ECC signatures', function () {
       await testRountripWithAndWithoutNative(
         sinonState,
         (data, dataDigest) => elliptic_curves.eddsa.sign(algo, openpgp.enums.hash.sha512, data, nonNativeKey.A, nonNativeKey.seed, dataDigest),
-        (signature, data, dataDigest) => elliptic_curves.eddsa.verify(algo, openpgp.enums.hash.sha512, signature, data, nonNativeKey.A, dataDigest)
+        (signature, data, dataDigest) => elliptic_curves.eddsa.verify(algo, openpgp.enums.hash.sha512, signature, data, nonNativeKey.A, dataDigest),
+        expectNative
       );
     }));
   });

--- a/test/general/x25519.js
+++ b/test/general/x25519.js
@@ -11,8 +11,7 @@ import OID from '../../src/type/oid.js';
 import util from '../../src/util.js';
 
 import * as input from './testInputs.js';
-
-const isSafariOrHeadlessWebKit = () => typeof window !== 'undefined' && window.navigator.userAgent.match(/WebKit/) && !window.navigator.userAgent.match(/Chrome/);
+import { isSafariOrHeadlessWebKit } from '../browserChecks.ts';
 
 export default () => describe('X25519 Cryptography (legacy format)', function () {
   const data = {

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -1,4 +1,5 @@
 import openpgp from './initOpenpgp.js';
+import { isSafari15or16 } from './browserChecks.ts';
 
 (typeof window !== 'undefined' ? window : global).globalThis = (typeof window !== 'undefined' ? window : global);
 
@@ -35,7 +36,7 @@ describe('Unit Tests', function () {
   if (typeof window !== 'undefined') {
     // Safari 15.* and 16.* seem to have issues handling rejections when their native TransformStream implementation is involved,
     // so for now we ignore unhandled rejections for those browser versions.
-    if (!window.navigator.userAgent.match(/Version\/1(5|6)\.\d(\.\d)* (Mobile\/\w+ )?Safari/)) {
+    if (!isSafari15or16()) {
       window.addEventListener('unhandledrejection', function (event) {
         throw event.reason;
       });


### PR DESCRIPTION
The NIST curves are implemented by all major browsers, so we can be stricter about the expected WebCrypto behaviors, in alignment with what we already do with other crypto operations.

See commits for more details.